### PR TITLE
Fix replacement request method name

### DIFF
--- a/slideflow/presentation/presentation.py
+++ b/slideflow/presentation/presentation.py
@@ -183,7 +183,7 @@ class Presentation(BaseModel):
             charts.extend(chart_requests.get('requests', []))
             file_ids.extend(chart_requests.get('ids', []))
 
-            replacement_requests = slide.ger_replacement_requests(data_manager)
+            replacement_requests = slide.get_replacement_requests(data_manager)
             replacements.extend(replacement_requests)
 
         slides_service.presentations().batchUpdate(

--- a/slideflow/presentation/slide.py
+++ b/slideflow/presentation/slide.py
@@ -91,7 +91,7 @@ class Slide(BaseModel):
 
         return {'requests': requests, 'ids': ids}
 
-    def ger_replacement_requests(self, data_manager: DataManager) -> None:
+    def get_replacement_requests(self, data_manager: DataManager) -> None:
         """
         Generates replacement requests for text and table placeholders.
 


### PR DESCRIPTION
## Summary
- fix typo in Slide.get_replacement_requests and usage in Presentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851529dd2288328ac147d18698058b3