### PR TITLE
Adding top level registry in config

### DIFF
--- a/slideflow/cli/commands/build.py
+++ b/slideflow/cli/commands/build.py
@@ -32,6 +32,7 @@ Example:
 import time
 import typer
 import threading
+import yaml
 import pandas as pd
 from pathlib import Path
 from typing import Optional, List, Tuple, Any
@@ -210,6 +211,20 @@ def build_command(
     try:
         print_build_progress(1, 6, "Loading configuration...")
         time.sleep(0.5)
+
+        raw_config = yaml.safe_load(config_file.read_text())
+        config_registry = raw_config.get("registry")
+
+        if not registry_files and config_registry:
+            if isinstance(config_registry, str):
+                registry_files = [Path(config_registry)]
+            elif isinstance(config_registry, list):
+                registry_files = [Path(p) for p in config_registry]
+            else:
+                raise TypeError(f"Unsupported type for 'registry': {type(config_registry)}")
+
+        if not registry_files:
+            registry_files = [Path("registry.py")]
         
         if dry_run:
             print_build_progress(6, 6, "Dry run complete - configuration is valid!")

--- a/slideflow/cli/commands/build.py
+++ b/slideflow/cli/commands/build.py
@@ -130,7 +130,7 @@ def build_single_presentation(
 def build_command(
     config_file: Path = typer.Argument(..., help = "Path to YAML configuration file"),
     registry_files: Optional[List[Path]] = typer.Option(
-        ["registry.py"], "--registry", "-r", 
+        None, "--registry", "-r", 
         help="Path to Python registry files (can be used multiple times)"
     ),
     params_path: Optional[Path] = typer.Option(

--- a/slideflow/presentations/config.py
+++ b/slideflow/presentations/config.py
@@ -451,6 +451,9 @@ class PresentationConfig(BaseModel):
         template_paths: Optional list of custom directories to search for
             chart templates, in priority order. If not specified, only
             built-in templates will be available.
+        registry: Optional list of paths to Python files containing
+            `function_registry` dictionaries. These registries are used to
+            extend Slideflow with custom functions.
             
     Example:
         Complete presentation configuration:
@@ -484,7 +487,8 @@ class PresentationConfig(BaseModel):
         ...     template_paths=[
         ...         "/custom/chart_templates",
         ...         "/shared/templates"
-        ...     ]
+        ...     ],
+        ...     registry=["custom_functions.py", "shared_registry.py"]
         ... )
         
         Minimal configuration:
@@ -519,7 +523,8 @@ class PresentationConfig(BaseModel):
     """
     
     model_config = ConfigDict(extra = "forbid")
-    
+
     presentation: Annotated[PresentationSpec, Field(..., description = "Presentation specification")]
     provider: Annotated[ProviderConfig, Field(..., description = "Presentation provider configuration")]
     template_paths: Annotated[Optional[List[str]], Field(None, description = "Custom template search paths (in priority order)")]
+    registry: Annotated[Optional[List[str]], Field(None, description = "Paths to custom function registry files")]


### PR DESCRIPTION
Adds the option to define the registry path in the config file directly instead of needing it in the command line. Prioritises command line, then config file and defaults to registry.py if neither are provided