### PR TITLE
Fixing registry path in build.py

### DIFF
--- a/slideflow/cli/commands/build.py
+++ b/slideflow/cli/commands/build.py
@@ -217,8 +217,6 @@ def build_command(
 
         if isinstance(config_registry, (str, Path, list)):
             config_registry = [Path(p) for p in ([config_registry] if isinstance(config_registry, (str, Path)) else config_registry)]
-        else:
-            pass
 
         registry_files = registry_files or config_registry or [Path("registry.py")]
         


### PR DESCRIPTION
Instead of raising a TypeError it should skip if the registry is not readable from the config.yml.

The purpose of this workflow is that if the registry is passed in the cli it should use that, if not it should check the config file and failing that should just default to registry.py. By raising a type error it would never prioritise the cli or fall back on the default