### PR TITLE
Image deletion and folder generation

### DIFF
--- a/slideflow/presentations/providers/base.py
+++ b/slideflow/presentations/providers/base.py
@@ -394,13 +394,8 @@ class PresentationProvider(ABC):
         """
         pass
     
-    @abstractmethod
     def get_presentation_url(self, presentation_id: str) -> str:
         """Get the public URL for accessing a presentation.
-        
-        Returns a URL that can be used to view or edit the presentation in the
-        platform's web interface. The URL should be publicly accessible to users
-        who have been granted appropriate permissions.
         
         Args:
             presentation_id: Unique identifier of the presentation.
@@ -418,5 +413,14 @@ class PresentationProvider(ABC):
             >>> url = provider.get_presentation_url("presentation_123")
             >>> print(f"View presentation at: {url}")
             >>> # Example output: "https://docs.google.com/presentation/d/presentation_123"
+        """
+        pass
+
+    @abstractmethod
+    def delete_chart_image(self, file_id: str) -> None:
+        """Delete a chart image from the platform's storage.
+        
+        Args:
+            file_id: The unique identifier of the file to delete.
         """
         pass


### PR DESCRIPTION

Changes

   * Image Deletion:
       * The GoogleSlidesProvider now tracks the file_id of each uploaded chart image.
       * After presentation.render() completes, a new cleanup step iterates through all tracked file_ids and calls delete_chart_image to remove them from Google Drive.
       * The drive_folder_id configuration option has been removed from GoogleSlidesProviderConfig as it is now redundant.

  * Folder creation
      * Adds two new accepted arguements to the provider config section, new_folder_name and new_folder_name_fn.
      * If new_folder_name is present a new folder is created within the provided parent folder, new_folder_name_fn enables dynamic folder name generation such as week number
      * Uses thread locking to ensure that in bulk created presentations, only one distinct folder is generated