### PR TITLE
Remove duplicate code

### DIFF
--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -445,8 +445,6 @@ class Presentation(BaseModel):
                     try:
                         if chart.data_source:
                             df = chart.data_source.fetch_data()
-                            if chart.data_transforms:
-                                df = apply_data_transforms(chart.data_transforms, df)
 
                         image_data = chart.generate_chart_image(df)
 


### PR DESCRIPTION
**Fix: Prevent double application of data transformations for charts**


-   This pull request resolves an issue where data transformations for charts were being executed twice, leading to incorrect data in the final visualization and
unnecessary processing.

  **Problem:**


-   The Presentation.render() method in slideflow/presentations/base.py was applying data transformations to a chart's DataFrame. It would then pass the already 
transformed DataFrame to the chart.generate_chart_image() method, which would apply the same transformations a second time.

-   This double application could lead to incorrect results, especially for transformations that are not idempotent (i.e., functions that produce a different
result when applied to already transformed data).

  **Solution:**

- The redundant call to apply_data_transforms() has been removed from the Presentation.render() method in slideflow/presentations/base.py.


-   The responsibility for applying data transformations now lies solely with the generate_chart_image() method of each chart type. This ensures that transformations are applied exactly once, in a consistent and predictable manner.

  **Impact:**


   - **Correctness:** Fixes the bug where transformations were applied twice, ensuring the data integrity of the charts.
   - **Performance:** Improves performance by eliminating redundant data processing.
   - **Consistency:** Enforces the design principle that generate_chart_image() is the single source of truth for chart rendering, including data transformation.