### PR TITLE
Phase 2: harden config/template loading and raise coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             --cov=slideflow \
             --cov-report=term \
             --cov-report=xml \
-            --cov-fail-under=40
+            --cov-fail-under=45
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           python -m pytest -q \
             --cov=slideflow \
             --cov-report=term \
-            --cov-fail-under=40
+            --cov-fail-under=45
 
       - name: Build distribution artifacts
         run: |

--- a/slideflow/builtins/template_engine.py
+++ b/slideflow/builtins/template_engine.py
@@ -396,7 +396,7 @@ class TemplateEngine:
             # Find where the template section starts
             template_start = None
             for i, line in enumerate(lines):
-                if line.strip() == 'template:':
+                if line.lstrip() == line and line.strip().startswith('template:'):
                     template_start = i
                     break
             

--- a/slideflow/utilities/config.py
+++ b/slideflow/utilities/config.py
@@ -54,6 +54,7 @@ Example:
 import re
 import sys
 import yaml
+import importlib
 import pkgutil
 import importlib.util
 from pathlib import Path
@@ -184,12 +185,34 @@ def load_registry_from_path(registry_path: Path) -> dict[str, Callable]:
     module_name = path.stem
     package = path.parent.name
     full_name = f"{package}.{module_name}"
-    sys.path.insert(0, str(path.parent.parent))
+    parent_path = str(path.parent.parent)
+    inserted_path = False
 
-    spec = importlib.util.spec_from_file_location(full_name, path)
-    module = importlib.util.module_from_spec(spec)
-    module.__package__ = package
-    spec.loader.exec_module(module)  # type: ignore
+    if parent_path not in sys.path:
+        sys.path.insert(0, parent_path)
+        inserted_path = True
+
+    try:
+        spec = importlib.util.spec_from_file_location(full_name, path)
+        if spec is None or spec.loader is None:
+            raise ConfigurationError(f"Unable to load module specification from {path}")
+
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = package
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    except ConfigurationError:
+        raise
+    except Exception as e:
+        raise ConfigurationError(f"Failed to load registry module from {path}: {e}") from e
+    finally:
+        if inserted_path:
+            try:
+                if sys.path and sys.path[0] == parent_path:
+                    sys.path.pop(0)
+                else:
+                    sys.path.remove(parent_path)
+            except ValueError:
+                pass
 
     registry = getattr(module, "function_registry", None)
     if not isinstance(registry, dict):

--- a/tests/test_config_utilities.py
+++ b/tests/test_config_utilities.py
@@ -1,0 +1,44 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from slideflow.utilities.config import load_registry_from_path
+from slideflow.utilities.exceptions import ConfigurationError
+
+
+def test_load_registry_from_path_returns_registry_and_does_not_leak_sys_path(tmp_path):
+    registry_file = tmp_path / "registry.py"
+    registry_file.write_text(
+        "def fmt(value):\n"
+        "    return f'v={value}'\n"
+        "\n"
+        "function_registry = {'fmt': fmt}\n"
+    )
+
+    before = list(sys.path)
+    registry = load_registry_from_path(registry_file)
+    after = list(sys.path)
+
+    assert "fmt" in registry
+    assert callable(registry["fmt"])
+    assert registry["fmt"]("x") == "v=x"
+    assert before == after
+
+
+def test_load_registry_from_path_fails_when_file_missing(tmp_path):
+    missing = tmp_path / "missing_registry.py"
+
+    with pytest.raises(ConfigurationError, match="Registry file not found"):
+        load_registry_from_path(missing)
+
+
+def test_load_registry_from_path_fails_when_module_spec_is_unavailable(tmp_path, monkeypatch):
+    registry_file = tmp_path / "registry.py"
+    registry_file.write_text("function_registry = {}\n")
+
+    monkeypatch.setattr(importlib.util, "spec_from_file_location", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(ConfigurationError, match="Unable to load module specification"):
+        load_registry_from_path(registry_file)

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import pytest
+
+from slideflow.builtins.template_engine import TemplateEngine
+from slideflow.utilities.exceptions import ChartGenerationError
+
+
+def test_render_template_supports_block_scalar_template_section(tmp_path):
+    template_file = tmp_path / "block_style.yml"
+    template_file.write_text(
+        "name: Block Template\n"
+        "description: Supports template block scalars\n"
+        "parameters:\n"
+        "  - name: label\n"
+        "    type: string\n"
+        "    required: true\n"
+        "template: |\n"
+        "  traces:\n"
+        "    - type: \"bar\"\n"
+        "      name: \"{{ label }}\"\n"
+    )
+
+    engine = TemplateEngine([tmp_path])
+    rendered = engine.render_template("block_style", {"label": "Revenue"})
+
+    assert rendered["traces"][0]["type"] == "bar"
+    assert rendered["traces"][0]["name"] == "Revenue"
+
+
+def test_render_template_requires_required_parameters(tmp_path):
+    template_file = tmp_path / "required_params.yml"
+    template_file.write_text(
+        "name: Required Params\n"
+        "description: Enforces required config\n"
+        "parameters:\n"
+        "  - name: metric\n"
+        "    type: string\n"
+        "    required: true\n"
+        "template:\n"
+        "  value: \"{{ metric }}\"\n"
+    )
+
+    engine = TemplateEngine([tmp_path])
+
+    with pytest.raises(ChartGenerationError, match="Required parameter 'metric' missing"):
+        engine.render_template("required_params", {})
+
+
+def test_list_templates_returns_sorted_template_names(tmp_path):
+    (tmp_path / "zeta.yml").write_text(
+        "name: Zeta\n"
+        "description: z\n"
+        "parameters: []\n"
+        "template:\n"
+        "  v: 1\n"
+    )
+    (tmp_path / "alpha.yml").write_text(
+        "name: Alpha\n"
+        "description: a\n"
+        "parameters: []\n"
+        "template:\n"
+        "  v: 1\n"
+    )
+
+    engine = TemplateEngine([tmp_path])
+
+    assert engine.list_templates() == ["alpha", "zeta"]


### PR DESCRIPTION
## Summary
Phase 2 hardening pass focused on config/template reliability and stronger test gates.

### Code hardening
- `load_registry_from_path` now avoids leaking temporary path mutations into global `sys.path`.
- Added defensive checks for missing module spec/loader during registry loading.
- Improved registry load errors with explicit `ConfigurationError` context.
- Template parsing now supports top-level `template:` lines with scalar indicators (for example `template: |`).

### Test expansion
- Added `tests/test_config_utilities.py`:
  - registry load success path
  - missing registry file error
  - unavailable module spec error
- Added `tests/test_template_engine.py`:
  - block-scalar template rendering path
  - required parameter validation
  - template listing behavior

### CI quality gate ratchet
- Raised coverage thresholds from `40` to `45` in:
  - `.github/workflows/ci.yml`
  - `.github/workflows/release.yml`

## Validation
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m pytest -q --cov=slideflow --cov-report=term --cov-fail-under=45`

Both pass locally (25 tests, coverage 48.27%).
