### PR TITLE
Phase 3 PR1: expand unit coverage and raise CI gate to 55%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             --cov=slideflow \
             --cov-report=term \
             --cov-report=xml \
-            --cov-fail-under=45
+            --cov-fail-under=55
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           python -m pytest -q \
             --cov=slideflow \
             --cov-report=term \
-            --cov-fail-under=45
+            --cov-fail-under=55
 
       - name: Build distribution artifacts
         run: |

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -31,7 +31,7 @@ mkdocs build --strict
 
 ## Coverage policy
 
-- CI enforces a minimum coverage floor (`--cov-fail-under=45`)
+- CI enforces a minimum coverage floor (`--cov-fail-under=55`)
 - Raise this threshold over time; do not lower it without explicit approval
 
 ## Branching policy

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,7 +36,7 @@ pytest -q -m e2e
 
 - CI enforces version consistency checks.
 - CI enforces dependency consistency via `pip check`.
-- CI enforces coverage floor (`--cov-fail-under=45`).
+- CI enforces coverage floor (`--cov-fail-under=55`).
 - Distribution artifacts are built for every CI run.
 
 ## Contribution expectations

--- a/slideflow/cli/theme.py
+++ b/slideflow/cli/theme.py
@@ -39,7 +39,7 @@ from typing import Optional, Any
 console = Console(force_terminal = True, color_system = "truecolor")
 
 def print_slideflow_banner() -> None:
-    """Display the Slideflow ASCII art banner with brand colors.
+    r"""Display the Slideflow ASCII art banner with brand colors.
     
     Prints a stylized ASCII art logo with the Slideflow branding and tagline.
     Uses Rich markup for color styling with blue primary color and magenta

--- a/tests/test_cli_output_and_main.py
+++ b/tests/test_cli_output_and_main.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import slideflow.cli.main as cli_main_module
+import slideflow.cli.theme as theme_module
+import slideflow.cli.utils as cli_utils_module
+
+
+def _sample_presentation_config():
+    slide = SimpleNamespace(
+        replacements=[
+            SimpleNamespace(config={"data_source": {"type": "csv"}}),
+            SimpleNamespace(config={}),
+        ],
+        charts=[
+            SimpleNamespace(config={"data_source": {"type": "json"}}),
+        ],
+    )
+    return SimpleNamespace(
+        presentation=SimpleNamespace(name="Demo Deck", slides=[slide]),
+        data_sources={"warehouse": SimpleNamespace(type="databricks")},
+    )
+
+
+def test_theme_output_helpers_emit_expected_messages(monkeypatch):
+    calls = []
+    monkeypatch.setattr(theme_module.console, "print", lambda *a, **k: calls.append((a, k)))
+
+    theme_module.print_slideflow_banner()
+    theme_module.print_validation_header("config.yml")
+    theme_module.print_success()
+    theme_module.print_config_summary(_sample_presentation_config())
+    theme_module.print_error("line1\nline2")
+    theme_module.print_build_header("config.yml")
+    theme_module.print_build_progress(2, 4, "Processing")
+    theme_module.print_build_success("https://slides.example/test")
+    theme_module.print_build_error("boom\ndetails")
+    theme_module.print_help_footer()
+
+    rendered = [str(args[0]) for args, _ in calls if args]
+    assert any("Validation Complete" in entry for entry in rendered)
+    assert any("Build Complete" in entry for entry in rendered)
+    assert any("line1" in entry for entry in rendered)
+    assert all("line2" not in entry for entry in rendered if "line1" in entry and "red" in entry)
+
+
+def test_theme_build_error_verbose_includes_full_message(monkeypatch):
+    calls = []
+    monkeypatch.setattr(theme_module.console, "print", lambda *a, **k: calls.append((a, k)))
+
+    theme_module.print_build_error("line1\nline2", verbose=True)
+    rendered = [str(args[0]) for args, _ in calls if args]
+
+    assert any("line1\nline2" in entry for entry in rendered)
+
+
+def test_theme_validation_error_verbose_includes_full_message(monkeypatch):
+    calls = []
+    monkeypatch.setattr(theme_module.console, "print", lambda *a, **k: calls.append((a, k)))
+
+    theme_module.print_error("line1\nline2", verbose=True)
+    rendered = [str(args[0]) for args, _ in calls if args]
+
+    assert any("line1\nline2" in entry for entry in rendered)
+
+
+def test_cli_utils_helpers_emit_summary_and_error(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli_utils_module.console, "print", lambda *a, **k: calls.append((a, k)))
+
+    cli_utils_module.print_validation_header(Path("config.yml"))
+    cli_utils_module.print_config_summary(_sample_presentation_config())
+    cli_utils_module.handle_validation_error(RuntimeError("simple error"))
+    cli_utils_module.handle_validation_error(RuntimeError("line1\nline2"), verbose=True)
+
+    rendered = [str(args[0]) for args, _ in calls if args]
+    assert calls
+    assert any("Summary" in entry for entry in rendered)
+    assert any("Presentation: Demo Deck" in entry for entry in rendered)
+    assert any("simple error" in entry for entry in rendered)
+    assert any("line1\nline2" in entry for entry in rendered)
+
+
+def test_main_sets_log_level_and_prints_banner_only_without_subcommand(monkeypatch):
+    setup_calls = []
+    banner_calls = []
+    footer_calls = []
+
+    monkeypatch.setattr(
+        cli_main_module,
+        "setup_logging",
+        lambda level, enable_debug: setup_calls.append((level, enable_debug)),
+    )
+    monkeypatch.setattr(cli_main_module, "print_slideflow_banner", lambda: banner_calls.append(True))
+    monkeypatch.setattr(cli_main_module, "print_help_footer", lambda: footer_calls.append(True))
+
+    ctx = SimpleNamespace(invoked_subcommand=None)
+    cli_main_module.main(ctx, verbose=True, debug=False, quiet=False)
+    assert setup_calls[-1] == ("INFO", False)
+    assert banner_calls and footer_calls
+
+    ctx.invoked_subcommand = "build"
+    cli_main_module.main(ctx, verbose=False, debug=True, quiet=False)
+    assert setup_calls[-1] == ("DEBUG", True)
+
+    cli_main_module.main(ctx, verbose=True, debug=True, quiet=True)
+    assert setup_calls[-1] == ("ERROR", True)

--- a/tests/test_connectors_and_providers_unit.py
+++ b/tests/test_connectors_and_providers_unit.py
@@ -1,0 +1,323 @@
+from types import SimpleNamespace
+from typing import ClassVar, Literal
+
+import pandas as pd
+import pytest
+
+import slideflow.data.connectors.base as base_connectors_module
+import slideflow.data.connectors.databricks as databricks_module
+import slideflow.presentations.providers.factory as provider_factory_module
+import slideflow.presentations.providers.google_slides as google_provider_module
+from slideflow.presentations.config import ProviderConfig
+from slideflow.presentations.providers.base import (
+    PresentationProvider,
+    PresentationProviderConfig,
+    ProviderPresentationResult,
+    ProviderSlideResult,
+)
+from slideflow.utilities.exceptions import ConfigurationError
+
+
+class DummyConnector(base_connectors_module.DataConnector):
+    def __init__(self, token: str):
+        self.token = token
+        self.connected = False
+        self.disconnected = False
+
+    def connect(self):
+        self.connected = True
+        return "connected"
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+    def fetch_data(self) -> pd.DataFrame:
+        return pd.DataFrame({"token": [self.token]})
+
+
+class DummySourceConfig(base_connectors_module.BaseSourceConfig):
+    type: Literal["dummy"] = "dummy"
+    token: str
+    connector_class: ClassVar = DummyConnector
+
+
+class DummyProviderConfig(PresentationProviderConfig):
+    provider_type: Literal["dummy_provider"] = "dummy_provider"
+    token: str
+
+
+class DummyProvider(PresentationProvider):
+    def create_presentation(self, name: str, template_id=None) -> str:
+        return f"{name}:{template_id or 'none'}"
+
+    def upload_chart_image(self, presentation_id: str, image_data: bytes, filename: str):
+        return ("https://example/image.png", "file-id")
+
+    def insert_chart_to_slide(
+        self,
+        presentation_id: str,
+        slide_id: str,
+        image_url: str,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+    ) -> None:
+        return None
+
+    def replace_text_in_slide(self, presentation_id: str, slide_id: str, placeholder: str, replacement: str) -> int:
+        return 1
+
+    def share_presentation(self, presentation_id: str, emails, role="writer") -> None:
+        return None
+
+    def get_presentation_url(self, presentation_id: str) -> str:
+        return f"https://example/{presentation_id}"
+
+    def delete_chart_image(self, file_id: str) -> None:
+        return None
+
+
+def test_data_connector_context_manager_and_base_source_cache(monkeypatch):
+    connector = DummyConnector("abc")
+    with connector as active:
+        assert active is connector
+        assert connector.connected is True
+    assert connector.disconnected is True
+
+    class FakeCache:
+        def __init__(self):
+            self.store = {}
+            self.set_calls = 0
+
+        def _key(self, source_type, kwargs):
+            return (source_type, tuple(sorted(kwargs.items())))
+
+        def get(self, source_type, **kwargs):
+            return self.store.get(self._key(source_type, kwargs))
+
+        def set(self, data, source_type, **kwargs):
+            self.set_calls += 1
+            self.store[self._key(source_type, kwargs)] = data
+
+    fake_cache = FakeCache()
+    monkeypatch.setattr(base_connectors_module, "get_data_cache", lambda: fake_cache)
+
+    config = DummySourceConfig(name="demo", type="dummy", token="secret")
+    first = config.fetch_data()
+    second = config.fetch_data()
+
+    assert first.to_dict(orient="records")[0]["token"] == "secret"
+    assert second is first
+    assert fake_cache.set_calls == 1
+
+
+def test_databricks_connector_connect_disconnect_and_fetch(monkeypatch):
+    connect_calls = []
+
+    class FakeArrow:
+        def to_pandas(self):
+            return pd.DataFrame({"value": [1, 2]})
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query):
+            self.query = query
+
+        def fetchall_arrow(self):
+            return FakeArrow()
+
+    class FakeConnection:
+        def __init__(self):
+            self.closed = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+        def close(self):
+            self.closed = True
+
+    fake_conn = FakeConnection()
+
+    def fake_connect(**kwargs):
+        connect_calls.append(kwargs)
+        return fake_conn
+
+    monkeypatch.setattr(databricks_module.sql, "connect", fake_connect)
+    monkeypatch.setenv("DATABRICKS_HOST", "host")
+    monkeypatch.setenv("DATABRICKS_HTTP_PATH", "http-path")
+    monkeypatch.setenv("DATABRICKS_ACCESS_TOKEN", "token")
+
+    api_logs = []
+    data_logs = []
+    monkeypatch.setattr(databricks_module, "log_api_operation", lambda *a, **k: api_logs.append((a, k)))
+    monkeypatch.setattr(databricks_module, "log_data_operation", lambda *a, **k: data_logs.append((a, k)))
+
+    connector = databricks_module.DatabricksConnector("SELECT 1")
+    assert connector.connect() is fake_conn
+    assert connector.connect() is fake_conn  # cached connection reuse
+    assert len(connect_calls) == 1
+
+    result = connector.fetch_data()
+    assert len(result) == 2
+    assert api_logs and api_logs[-1][0][2] is True
+    assert data_logs
+
+    connector.disconnect()
+    assert fake_conn.closed is True
+    assert connector._connection is None
+
+
+def test_databricks_connector_fetch_logs_failure(monkeypatch):
+    class FailingCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, _query):
+            raise RuntimeError("boom")
+
+    class FailingConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FailingCursor()
+
+    logs = []
+    monkeypatch.setattr(databricks_module, "log_api_operation", lambda *a, **k: logs.append((a, k)))
+
+    connector = databricks_module.DatabricksConnector("SELECT fail")
+    monkeypatch.setattr(connector, "connect", lambda: FailingConnection())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        connector.fetch_data()
+
+    assert logs and logs[-1][0][2] is False
+
+
+def test_provider_result_models_and_factory_registration():
+    result = ProviderPresentationResult(
+        presentation_id="p1",
+        presentation_url="https://example/p1",
+        slide_results=[
+            ProviderSlideResult(slide_id="s1", chart_urls=[("u1", "p1")], replacements_made=2),
+            ProviderSlideResult(slide_id="s2", chart_urls=[("u2", "p2"), ("u3", "p3")], replacements_made=1),
+        ],
+    )
+    assert result.total_charts_generated == 3
+    assert result.total_replacements_made == 3
+
+    provider_factory_module.ProviderFactory.register_provider(
+        "dummy_provider",
+        DummyProvider,
+        DummyProviderConfig,
+    )
+    config = ProviderConfig(type="dummy_provider", config={"token": "abc"})
+    provider = provider_factory_module.ProviderFactory.create_provider(config)
+
+    assert isinstance(provider, DummyProvider)
+    assert provider.config.token == "abc"
+    assert "dummy_provider" in provider_factory_module.ProviderFactory.get_available_providers()
+    assert provider_factory_module.ProviderFactory.get_provider_class("dummy_provider") is DummyProvider
+    assert provider_factory_module.ProviderFactory.get_config_class("dummy_provider") is DummyProviderConfig
+
+
+def test_provider_factory_rejects_unsupported_provider():
+    with pytest.raises(ConfigurationError, match="Unsupported provider type"):
+        provider_factory_module.ProviderFactory.create_provider(
+            ProviderConfig(type="missing_provider", config={})
+        )
+
+
+def test_google_provider_helper_methods(monkeypatch):
+    provider = object.__new__(google_provider_module.GoogleSlidesProvider)
+    provider.config = SimpleNamespace(template_id="template-1")
+
+    copy_calls = []
+    create_calls = []
+    monkeypatch.setattr(provider, "_copy_template", lambda t, n: copy_calls.append((t, n)) or "copied")
+    monkeypatch.setattr(provider, "_create_presentation", lambda n: create_calls.append(n) or "created")
+    monkeypatch.setattr(provider, "_upload_image_to_drive", lambda data, name: ("https://img", "file-1"))
+
+    assert provider.create_presentation("Deck") == "copied"
+    assert copy_calls == [("template-1", "Deck")]
+
+    assert provider.create_presentation("Deck2", template_id="template-2") == "copied"
+    assert copy_calls[-1] == ("template-2", "Deck2")
+
+    provider.config = SimpleNamespace(template_id=None)
+    assert provider.create_presentation("Plain Deck") == "created"
+    assert create_calls == ["Plain Deck"]
+
+    assert provider.upload_chart_image("p1", b"bytes", "x.png") == ("https://img", "file-1")
+
+    batch_calls = []
+    monkeypatch.setattr(provider, "_batch_update", lambda pres_id, reqs: batch_calls.append((pres_id, reqs)) or {})
+    provider.insert_chart_to_slide("p1", "s1", "https://img", 1, 2, 3, 4)
+    assert batch_calls and batch_calls[0][0] == "p1"
+    assert batch_calls[0][1][0]["createImage"]["url"] == "https://img"
+
+    monkeypatch.setattr(
+        provider,
+        "_batch_update",
+        lambda _pres_id, _reqs: {"replies": [{"replaceAllText": {"occurrencesChanged": 7}}]},
+    )
+    assert provider.replace_text_in_slide("p1", "s1", "{{X}}", "Y") == 7
+
+    monkeypatch.setattr(provider, "_batch_update", lambda _pres_id, _reqs: {})
+    assert provider.replace_text_in_slide("p1", "s1", "{{X}}", "Y") == 0
+    assert provider.get_presentation_url("abc123").endswith("/abc123")
+
+
+def test_google_provider_execute_request_and_batch_update(monkeypatch):
+    provider = object.__new__(google_provider_module.GoogleSlidesProvider)
+    wait_calls = []
+    provider.rate_limiter = SimpleNamespace(wait=lambda: wait_calls.append(True))
+
+    class FakeRequest:
+        def execute(self, num_retries):
+            return {"num_retries": num_retries}
+
+    assert provider._execute_request(FakeRequest()) == {"num_retries": 3}
+    assert wait_calls == [True]
+
+    assert provider._batch_update("p1", []) == {}
+
+    presentations = SimpleNamespace(
+        batchUpdate=lambda presentationId, body: ("request", presentationId, body)
+    )
+    provider.slides_service = SimpleNamespace(presentations=lambda: presentations)
+    monkeypatch.setattr(provider, "_execute_request", lambda request: {"request": request})
+    logs = []
+    monkeypatch.setattr(google_provider_module, "log_api_operation", lambda *a, **k: logs.append((a, k)))
+
+    response = provider._batch_update("p1", [{"replaceAllText": {}}])
+    assert response["request"][1] == "p1"
+    assert logs and logs[-1][0][2] is True
+
+
+def test_google_rate_limiter_singleton_update(monkeypatch):
+    monkeypatch.setattr(google_provider_module, "_api_rate_limiter", None)
+    rl1 = google_provider_module._get_rate_limiter(1.0)
+    rl2 = google_provider_module._get_rate_limiter(5.0)
+    rl3 = google_provider_module._get_rate_limiter(5.0, force_update=True)
+
+    assert rl1 is rl2 is rl3
+    assert rl3.rate == 5.0

--- a/tests/test_runtime_utilities.py
+++ b/tests/test_runtime_utilities.py
@@ -1,0 +1,99 @@
+import json
+
+import pytest
+import slideflow.utilities.rate_limiter as rate_limiter_module
+from slideflow.constants import Environment
+from slideflow.data.cache import DataSourceCache, get_data_cache
+from slideflow.utilities.auth import handle_google_credentials
+from slideflow.utilities.exceptions import AuthenticationError
+from slideflow.utilities.rate_limiter import RateLimiter
+
+import pandas as pd
+
+
+def test_data_source_cache_lifecycle_and_singleton_behavior():
+    cache = get_data_cache()
+    cache.enable()
+    cache.clear()
+
+    df = pd.DataFrame({"value": [1]})
+    cache.set(df, source_type="csv", file_path="data.csv")
+
+    assert cache.get("csv", file_path="data.csv") is df
+    assert cache.size == 1
+    assert cache.is_enabled is True
+    assert get_data_cache() is cache
+
+    info = cache.get_cache_info()
+    assert info["enabled"] is True
+    assert info["size"] == 1
+    assert info["cached_sources"]
+
+    cache.disable()
+    assert cache.is_enabled is False
+    assert cache.size == 0
+    assert cache.get("csv", file_path="data.csv") is None
+
+    cache.enable()
+    assert cache.is_enabled is True
+    cache.clear()
+
+
+def test_data_source_cache_key_generation_is_order_stable():
+    cache = DataSourceCache()
+    key_a = cache._generate_key("databricks", query="select 1", target="prod")
+    key_b = cache._generate_key("databricks", target="prod", query="select 1")
+    assert key_a == key_b
+
+
+def test_handle_google_credentials_from_file_and_env(tmp_path, monkeypatch):
+    payload = {"client_email": "svc@example.com", "private_key": "abc"}
+    creds_path = tmp_path / "creds.json"
+    creds_path.write_text(json.dumps(payload))
+
+    assert handle_google_credentials(str(creds_path)) == payload
+
+    monkeypatch.setenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS, json.dumps(payload))
+    assert handle_google_credentials("null") == payload
+    assert handle_google_credentials(None) == payload
+
+
+def test_handle_google_credentials_validation_errors(tmp_path, monkeypatch):
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_text("{not json}")
+
+    with pytest.raises(AuthenticationError, match="not a valid JSON"):
+        handle_google_credentials(str(bad_path))
+
+    with pytest.raises(AuthenticationError, match="not valid"):
+        handle_google_credentials("{broken")
+
+    monkeypatch.delenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS, raising=False)
+    with pytest.raises(AuthenticationError, match="Credentials not provided"):
+        handle_google_credentials(None)
+
+
+def test_rate_limiter_validates_rates():
+    with pytest.raises(ValueError, match="must be > 0"):
+        RateLimiter(0)
+    with pytest.raises(ValueError, match="must be > 0"):
+        RateLimiter(-1)
+
+    limiter = RateLimiter(2.0)
+    with pytest.raises(ValueError, match="must be > 0"):
+        limiter.set_rate(0)
+
+
+def test_rate_limiter_wait_sleeps_only_when_needed(monkeypatch):
+    monotonic_values = iter([0.0, 0.6, 2.0])
+    sleep_calls = []
+
+    monkeypatch.setattr(rate_limiter_module.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(rate_limiter_module.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+    limiter = RateLimiter(2.0)  # 0.5 seconds/request
+    limiter.wait()  # sleeps 0.5
+    limiter.wait()  # sleeps 0.4
+    limiter.wait()  # no sleep
+
+    assert sleep_calls == [0.5, 0.4]


### PR DESCRIPTION
## Summary
- add focused unit tests for CLI output/main behavior, runtime utilities, data connector/provider internals, and Google Slides provider helpers
- raise enforced test coverage floor from 45% to 55% in CI and release workflows
- update testing/CI docs to match the new 55% gate
- fix an escaped ASCII-art docstring warning in CLI theme output

## Validation
- source .venv/bin/activate && pytest -q
- source .venv/bin/activate && pytest -q --cov=slideflow --cov-report=term --cov-fail-under=55
- source .venv/bin/activate && mkdocs build --strict

## Coverage
- current total coverage: 60.36% (49 tests passing)