### PR TITLE
Phase 3 PR2: expand builtins/registry tests and raise coverage gate to 65%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             --cov=slideflow \
             --cov-report=term \
             --cov-report=xml \
-            --cov-fail-under=55
+            --cov-fail-under=65
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           python -m pytest -q \
             --cov=slideflow \
             --cov-report=term \
-            --cov-fail-under=55
+            --cov-fail-under=65
 
       - name: Build distribution artifacts
         run: |

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -31,7 +31,7 @@ mkdocs build --strict
 
 ## Coverage policy
 
-- CI enforces a minimum coverage floor (`--cov-fail-under=55`)
+- CI enforces a minimum coverage floor (`--cov-fail-under=65`)
 - Raise this threshold over time; do not lower it without explicit approval
 
 ## Branching policy

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,7 +36,7 @@ pytest -q -m e2e
 
 - CI enforces version consistency checks.
 - CI enforces dependency consistency via `pip check`.
-- CI enforces coverage floor (`--cov-fail-under=55`).
+- CI enforces coverage floor (`--cov-fail-under=65`).
 - Distribution artifacts are built for every CI run.
 
 ## Contribution expectations

--- a/tests/test_builtins_utilities.py
+++ b/tests/test_builtins_utilities.py
@@ -1,0 +1,198 @@
+import decimal
+
+import pandas as pd
+import pytest
+
+import slideflow.builtins.registry as builtins_registry_module
+import slideflow.builtins.formatting.format as format_module
+from slideflow.builtins.column_utils import (
+    abbreviate_currency_columns,
+    abbreviate_number_columns,
+    format_percentages,
+    round_numbers,
+)
+from slideflow.builtins.formatting.color import function_registry as color_registry
+from slideflow.builtins.formatting.color import green_or_red
+from slideflow.builtins.table_utils import (
+    create_dynamic_colors,
+    create_growth_colors,
+    create_performance_colors,
+    create_traffic_light_colors,
+    growth_color_function,
+    performance_color_function,
+)
+from slideflow.utilities.exceptions import DataTransformError
+
+
+def _install_pandas_stub_compat(monkeypatch):
+    """Add minimal methods expected by transformation helpers."""
+    df_type = type(pd.DataFrame({}))
+    series_type = type(pd.DataFrame({"x": [1]})["x"])
+
+    if not hasattr(df_type, "copy"):
+        monkeypatch.setattr(df_type, "copy", lambda self: df_type(self), raising=False)
+
+    if not hasattr(series_type, "round"):
+        def _series_round(self, decimal_places=0):
+            return series_type(
+                round(float(value), decimal_places) if isinstance(value, (int, float)) else value
+                for value in self
+            )
+
+        monkeypatch.setattr(series_type, "round", _series_round, raising=False)
+
+    if not hasattr(series_type, "tolist"):
+        monkeypatch.setattr(series_type, "tolist", lambda self: list(self), raising=False)
+
+
+def test_formatting_functions_cover_numeric_and_edge_cases(monkeypatch):
+    assert format_module.abbreviate(1234) == "1.2K"
+    assert format_module.abbreviate(decimal.Decimal("42.5")) == "42.50"
+    assert format_module.abbreviate("N/A") == "N/A"
+
+    assert format_module.percentage(0.1234, ndigits=1) == "12.3%"
+    assert format_module.percentage(25.5, from_ratio=False) == "25.50%"
+    assert format_module.percentage(float("nan")) == "NaN%"
+    assert format_module.percentage(None) == "None"
+
+    assert format_module.round_value(3.14159, ndigits=3) == 3.142
+    assert format_module.round_value("skip", ndigits=3) == "skip"
+
+    assert format_module.format_currency(1234.5, currency_symbol="$") == "$1,234.50"
+    assert (
+        format_module.format_currency(
+            -1234.5,
+            currency_symbol="$",
+            negative_parens=True,
+            thousands_sep=".",
+            decimal_sep=",",
+        )
+        == "($1.234,50)"
+    )
+    assert format_module.format_currency("not-a-number") == "not-a-number"
+
+    assert format_module.abbreviate_currency(1_250_000, currency_symbol="$") == "$1.2M"
+    assert (
+        format_module.abbreviate_currency(-900, currency_symbol="$", negative_parens=True)
+        == "($900.00)"
+    )
+    assert format_module.abbreviate_currency("n/a") == "n/a"
+
+    assert set(format_module.function_registry) >= {
+        "abbreviate",
+        "percentage",
+        "round_value",
+        "format_currency",
+        "abbreviate_currency",
+    }
+
+    # Force the hard-failure path in format_currency (unexpected conversion error).
+    class BadFloat:
+        def __float__(self):
+            raise RuntimeError("boom")
+
+    with pytest.raises(DataTransformError, match="Critical currency formatting error"):
+        format_module.format_currency(BadFloat())
+
+    # Force hard-failure path for percentage.
+    monkeypatch.setattr(format_module.math, "isnan", lambda _v: (_ for _ in ()).throw(RuntimeError("err")))
+    with pytest.raises(DataTransformError, match="Critical percentage formatting error"):
+        format_module.percentage(1.23)
+
+
+def test_color_and_table_helpers_generate_expected_color_maps(monkeypatch):
+    _install_pandas_stub_compat(monkeypatch)
+
+    assert green_or_red(10) == "green"
+    assert green_or_red(-1) == "red"
+    assert green_or_red(decimal.Decimal("0")) == "green"
+    assert green_or_red("x") == "black"
+    assert color_registry["green_or_red"] is green_or_red
+
+    assert growth_color_function(0) == "#28a745"
+    assert growth_color_function(-0.1) == "#dc3545"
+    assert growth_color_function("bad") == "black"
+
+    assert performance_color_function(100, threshold=80) == "#28a745"
+    assert performance_color_function(79.9, threshold=80) == "#dc3545"
+    assert performance_color_function(None, threshold=80) == "black"
+
+    assert create_traffic_light_colors(90, good_threshold=80, warning_threshold=60) == "#28a745"
+    assert create_traffic_light_colors(70, good_threshold=80, warning_threshold=60) == "#ffc107"
+    assert create_traffic_light_colors(50, good_threshold=80, warning_threshold=60) == "#dc3545"
+    assert create_traffic_light_colors("x", good_threshold=80, warning_threshold=60) == "black"
+
+    df = pd.DataFrame({"name": ["A", "B"], "growth": [0.2, -0.1], "score": [82, 75]})
+    colored = create_dynamic_colors(
+        df,
+        column_order=["name", "growth", "score", "missing_col"],
+        color_func=growth_color_function,
+        target_columns=["growth", "missing_col"],
+    )
+
+    assert colored["_color_col_0"].tolist() == ["black", "black"]
+    assert colored["_color_col_1"].tolist() == ["#28a745", "#dc3545"]
+    assert colored["_color_col_2"].tolist() == ["black", "black"]
+    assert colored["_color_col_3"].tolist() == ["black", "black"]
+
+    growth_wrapped = create_growth_colors(df, ["name", "growth"], ["growth"])
+    assert growth_wrapped["_color_col_1"].tolist() == ["#28a745", "#dc3545"]
+
+    perf_wrapped = create_performance_colors(df, ["name", "score"], ["score"], threshold=80)
+    assert perf_wrapped["_color_col_1"].tolist() == ["#28a745", "#dc3545"]
+
+
+def test_column_transforms_apply_only_to_target_columns(monkeypatch):
+    _install_pandas_stub_compat(monkeypatch)
+
+    original = pd.DataFrame(
+        {
+            "revenue": [1_250_000, 900],
+            "cost": [400_000, 200],
+            "ratio": [0.1234, -0.5],
+            "value": [10.126, 20.555],
+            "text": ["A", "B"],
+        }
+    )
+
+    abbreviated = abbreviate_number_columns(original, ["revenue", "missing"])
+    assert abbreviated["revenue"].tolist() == ["1.2M", "900.00"]
+    assert original["revenue"].tolist() == [1_250_000, 900]  # original unchanged
+
+    currency = abbreviate_currency_columns(
+        original,
+        ["cost"],
+        currency_symbol="€",
+        symbol_position="suffix",
+        decimals=1,
+    )
+    assert currency["cost"].tolist() == ["400.0K €", "200.0 €"]
+
+    percentages = format_percentages(original, ["ratio", "text"], decimal_places=1, from_ratio=True)
+    assert percentages["ratio"].tolist() == ["12.3%", "-50.0%"]
+    assert percentages["text"].tolist() == ["A", "B"]
+
+    rounded = round_numbers(original, ["value", "missing"], decimal_places=2)
+    assert rounded["value"].tolist() == [10.13, 20.55]
+
+
+def test_builtins_registry_supports_custom_registration():
+    known = builtins_registry_module.list_builtin_functions()
+    assert "create_growth_colors" in known
+    assert callable(builtins_registry_module.get_builtin_function("round_numbers"))
+
+    custom_name = "__phase3_temp_builtin_fn__"
+
+    def custom_fn(x):
+        return f"custom:{x}"
+
+    builtins_registry_module.register_builtin_function(custom_name, custom_fn)
+    try:
+        fetched = builtins_registry_module.get_builtin_function(custom_name)
+        assert fetched("ok") == "custom:ok"
+        assert custom_name in builtins_registry_module.list_builtin_functions()
+
+        with pytest.raises(ValueError, match="already registered"):
+            builtins_registry_module.register_builtin_function(custom_name, custom_fn)
+    finally:
+        builtins_registry_module.builtin_function_registry.remove(custom_name)

--- a/tests/test_positioning_and_registries.py
+++ b/tests/test_positioning_and_registries.py
@@ -1,0 +1,179 @@
+import types
+
+import pytest
+
+from slideflow.core.registry import (
+    ClassRegistry,
+    FunctionRegistry,
+    ProviderRegistry,
+    create_class_registry,
+    create_function_registry,
+    create_provider_registry,
+)
+from slideflow.presentations.positioning import (
+    apply_alignment,
+    compute_chart_dimensions,
+    convert_dimensions,
+    safe_eval_expression,
+)
+from slideflow.utilities.exceptions import ChartGenerationError, ProviderError
+
+
+def test_safe_eval_expression_accepts_arithmetic_and_rejects_unsafe_nodes():
+    assert safe_eval_expression("10") == 10
+    assert safe_eval_expression("10.5") == 10.5
+    assert safe_eval_expression("(10 + 5) * 2") == 30
+    assert safe_eval_expression("20 / 4") == 5.0
+
+    with pytest.raises(ChartGenerationError, match="Expression cannot be empty"):
+        safe_eval_expression("")
+    with pytest.raises(ChartGenerationError, match="Invalid expression syntax"):
+        safe_eval_expression("1 +")
+    with pytest.raises(ChartGenerationError, match="Division by zero"):
+        safe_eval_expression("1 / 0")
+    with pytest.raises(ChartGenerationError, match="Unsupported AST node type"):
+        safe_eval_expression("__import__('os')")
+    with pytest.raises(ChartGenerationError, match="Result too large"):
+        safe_eval_expression("9999999999 * 2")
+
+
+def test_convert_dimensions_supports_pt_emu_relative_and_errors():
+    assert convert_dimensions("50 + 25", "100", "400", "300", "pt") == (75, 100, 400, 300)
+    assert convert_dimensions(635000, 1270000, 5080000, 3810000, "emu") == (50, 100, 400, 300)
+    assert convert_dimensions("5 * 10", "4 * 10", "20 * 10", "15 * 10", "expression") == (50, 40, 200, 150)
+
+    slides_app = {
+        "pageSize": {
+            "width": {"magnitude": 9144000, "unit": "EMU"},   # 720 pt
+            "height": {"magnitude": 6858000, "unit": "EMU"},  # 540 pt
+        }
+    }
+    assert convert_dimensions(0.1, 0.2, 0.5, 0.4, "relative", slides_app) == (72, 108, 360, 216)
+
+    with pytest.raises(ChartGenerationError, match="slides_app must be provided"):
+        convert_dimensions(0.1, 0.2, 0.5, 0.4, "relative", None)
+    with pytest.raises(ChartGenerationError, match="Unsupported dimensions_format"):
+        convert_dimensions(1, 2, 3, 4, "pixels")
+
+
+def test_alignment_and_dimension_computation_validation_paths():
+    assert apply_alignment(10, 20, 300, 100, "center-top", 720, 540) == (220, 20)
+    assert apply_alignment(50, 30, 200, 150, "right-bottom", 720, 540) == (470, 360)
+    assert apply_alignment(5, 7, 100, 100, "left-center", 720, 540) == (5, 227)
+
+    with pytest.raises(ChartGenerationError, match="Invalid alignment format"):
+        apply_alignment(0, 0, 100, 100, "center", 720, 540)
+    with pytest.raises(ChartGenerationError, match="Invalid horizontal alignment"):
+        apply_alignment(0, 0, 100, 100, "middle-top", 720, 540)
+    with pytest.raises(ChartGenerationError, match="Invalid vertical alignment"):
+        apply_alignment(0, 0, 100, 100, "left-middle", 720, 540)
+
+    assert compute_chart_dimensions(
+        x="50 + 10",
+        y="20",
+        width=300,
+        height=200,
+        dimensions_format="pt",
+        alignment_format="center-top",
+        page_width_pt=720,
+        page_height_pt=540,
+    ) == (270, 20, 300, 200)
+
+    with pytest.raises(ChartGenerationError, match="must be positive"):
+        compute_chart_dimensions(0, 0, 0, 100)
+    with pytest.raises(ChartGenerationError, match="too large"):
+        compute_chart_dimensions(0, 0, 2000, 100)
+    with pytest.raises(ChartGenerationError, match="too far from slide"):
+        compute_chart_dimensions(3000, 0, 100, 100, page_width_pt=720, page_height_pt=540)
+
+
+def test_function_registry_supports_registration_call_module_loading_and_errors():
+    registry = create_function_registry("unit_funcs")
+    registry.register_function("add", lambda x, y: x + y)
+    assert registry.call("add", 2, 3) == 5
+    assert registry.get_optional("missing", default="x") == "x"
+    assert registry.has("add") is True
+    assert "add" in registry
+    assert len(registry) == 1
+    assert registry.size() == 1
+    assert "unit_funcs" in repr(registry)
+
+    with pytest.raises(TypeError, match="must be callable"):
+        registry.register_function("bad", 123)
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register_function("add", lambda x, y: x - y)
+
+    mod = types.ModuleType("temp_mod")
+
+    def public_fn():
+        return "ok"
+
+    def _private_fn():
+        return "hidden"
+
+    mod.public_fn = public_fn
+    mod._private_fn = _private_fn
+    registry.register_module_functions(mod, prefix="m_")
+    assert registry.call("m_public_fn") == "ok"
+    with pytest.raises(KeyError):
+        registry.get("m__private_fn")
+
+    # Trigger call error path.
+    registry.register_function("explode", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    with pytest.raises(RuntimeError, match="boom"):
+        registry.call("explode")
+
+    removed = registry.remove("add")
+    assert callable(removed)
+    with pytest.raises(KeyError):
+        registry.remove("add")
+
+    registry.clear()
+    assert registry.list_available() == []
+    assert registry.items() == {}
+
+
+def test_class_and_provider_registry_behavior_and_factory_helpers():
+    class Base:
+        def __init__(self, value=0):
+            self.value = value
+
+    class Impl(Base):
+        pass
+
+    class NotBase:
+        pass
+
+    class_registry = create_class_registry("classes", Base)
+    class_registry.register_class("impl", Impl)
+    assert isinstance(class_registry.get_class("impl"), type)
+    assert class_registry.create_instance("impl", value=7).value == 7
+
+    with pytest.raises(TypeError, match="must be a class"):
+        class_registry.register_class("not-class", 123)
+    with pytest.raises(TypeError, match="must inherit"):
+        class_registry.register_class("notbase", NotBase)
+
+    provider_registry = create_provider_registry("providers", Base)
+    provider_registry.register_class("impl", Impl)
+    instance = provider_registry.create_provider("impl", value=3)
+    assert isinstance(instance, Impl)
+    assert instance.value == 3
+
+    with pytest.raises(ProviderError, match="Unknown provider"):
+        provider_registry.get_provider_class("missing")
+    with pytest.raises(ProviderError, match="Failed to create provider"):
+        provider_registry.create_provider("missing")
+
+    class Exploding(Impl):
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("ctor failed")
+
+    provider_registry.register_class("exploding", Exploding)
+    with pytest.raises(ProviderError, match="Failed to create provider"):
+        provider_registry.create_provider("exploding")
+
+    # Direct constructors should remain available and typed.
+    assert isinstance(FunctionRegistry("f"), FunctionRegistry)
+    assert isinstance(ClassRegistry("c"), ClassRegistry)
+    assert isinstance(ProviderRegistry("p"), ProviderRegistry)


### PR DESCRIPTION
## Summary
- add focused unit tests for builtins formatting/color/table/column utilities
- add focused unit tests for positioning math/conversion/alignment validation paths
- add deep unit coverage for core registry abstractions (function/class/provider registries)
- add builtins registry registration/get/list behavior tests
- raise enforced coverage floor from 55% to 65% in CI and release workflows
- update testing and CI quality docs to reflect the new coverage floor

## Validation
- source .venv/bin/activate && pytest -q
- source .venv/bin/activate && pytest -q --cov=slideflow --cov-report=term --cov-fail-under=65
- source .venv/bin/activate && mkdocs build --strict

## Coverage
- total coverage now: 70.44% (58 tests passing)
- notable improvements:
  - slideflow/core/registry.py -> 100%
  - slideflow/presentations/positioning.py -> 97%
  - slideflow/builtins/registry.py -> 100%
  - slideflow/builtins/table_utils.py -> 100%
  - slideflow/builtins/column_utils.py -> 100%