### PR TITLE
Phase 3 PR3: replacements+AI test expansion and coverage gate to 70%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             --cov=slideflow \
             --cov-report=term \
             --cov-report=xml \
-            --cov-fail-under=65
+            --cov-fail-under=70
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           python -m pytest -q \
             --cov=slideflow \
             --cov-report=term \
-            --cov-fail-under=65
+            --cov-fail-under=70
 
       - name: Build distribution artifacts
         run: |

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -31,7 +31,7 @@ mkdocs build --strict
 
 ## Coverage policy
 
-- CI enforces a minimum coverage floor (`--cov-fail-under=65`)
+- CI enforces a minimum coverage floor (`--cov-fail-under=70`)
 - Raise this threshold over time; do not lower it without explicit approval
 
 ## Branching policy

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,7 +36,7 @@ pytest -q -m e2e
 
 - CI enforces version consistency checks.
 - CI enforces dependency consistency via `pip check`.
-- CI enforces coverage floor (`--cov-fail-under=65`).
+- CI enforces coverage floor (`--cov-fail-under=70`).
 - Distribution artifacts are built for every CI run.
 
 ## Contribution expectations

--- a/slideflow/ai/providers.py
+++ b/slideflow/ai/providers.py
@@ -290,6 +290,8 @@ class GeminiProvider:
 
         except ImportError as e:
             raise APIError(f"Missing Gemini dependencies: {e}") from e
+        except (APIAuthenticationError, APIRateLimitError, APIError):
+            raise
         except Exception as e:
             error_msg = str(e).lower()
             if 'authentication' in error_msg or 'credential' in error_msg or 'unauthorized' in error_msg:

--- a/tests/test_ai_providers.py
+++ b/tests/test_ai_providers.py
@@ -4,7 +4,7 @@ import types
 import pytest
 
 import slideflow.ai.providers as providers_module
-from slideflow.utilities.exceptions import APIRateLimitError
+from slideflow.utilities.exceptions import APIAuthenticationError, APIError, APIRateLimitError
 
 
 def test_openai_rate_limit_error_maps_to_api_rate_limit_error(monkeypatch):
@@ -95,3 +95,174 @@ def test_gemini_non_vertex_uses_google_genai_client_api(monkeypatch):
     assert captured["config_kwargs"]["max_output_tokens"] == 128
     assert captured["config_kwargs"]["temperature"] == 0.25
     assert captured["config_kwargs"]["top_p"] == 0.7
+
+
+def test_openai_authentication_error_maps_to_api_authentication_error(monkeypatch):
+    fake_openai = types.ModuleType("openai")
+
+    class APIError(Exception):
+        pass
+
+    class RateLimitError(APIError):
+        pass
+
+    class AuthenticationError(APIError):
+        pass
+
+    class _Completions:
+        def create(self, *args, **kwargs):
+            raise AuthenticationError("bad key")
+
+    class _Chat:
+        completions = _Completions()
+
+    class OpenAI:
+        def __init__(self, *args, **kwargs):
+            self.chat = _Chat()
+
+    fake_openai.APIError = APIError
+    fake_openai.RateLimitError = RateLimitError
+    fake_openai.AuthenticationError = AuthenticationError
+    fake_openai.OpenAI = OpenAI
+
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+    provider = providers_module.OpenAIProvider(model="gpt-test")
+    with pytest.raises(APIAuthenticationError):
+        provider.generate_text("hello")
+
+
+def test_openai_success_trims_response_content(monkeypatch):
+    fake_openai = types.ModuleType("openai")
+    captured = {}
+
+    class APIError(Exception):
+        pass
+
+    class RateLimitError(APIError):
+        pass
+
+    class AuthenticationError(APIError):
+        pass
+
+    class _Message:
+        content = "  response text  "
+
+    class _Choice:
+        message = _Message()
+
+    class _Completions:
+        def create(self, *args, **kwargs):
+            captured["kwargs"] = kwargs
+            return types.SimpleNamespace(choices=[_Choice()])
+
+    class _Chat:
+        completions = _Completions()
+
+    class OpenAI:
+        def __init__(self, *args, **kwargs):
+            self.chat = _Chat()
+
+    fake_openai.APIError = APIError
+    fake_openai.RateLimitError = RateLimitError
+    fake_openai.AuthenticationError = AuthenticationError
+    fake_openai.OpenAI = OpenAI
+
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+    provider = providers_module.OpenAIProvider(model="gpt-test", temperature=0.1)
+    text = provider.generate_text("hello", top_p=0.8)
+    assert text == "response text"
+    assert captured["kwargs"]["model"] == "gpt-test"
+    assert captured["kwargs"]["temperature"] == 0.1
+    assert captured["kwargs"]["top_p"] == 0.8
+
+
+def test_gemini_non_vertex_missing_api_key_raises_auth_error(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    provider = providers_module.GeminiProvider(model="gemini-test")
+    with pytest.raises(APIAuthenticationError):
+        provider.generate_text("hello")
+
+
+def test_gemini_vertex_requires_project_and_location(monkeypatch):
+    provider = providers_module.GeminiProvider(
+        model="gemini-test",
+        vertex=True,
+        project=None,
+        location="us-central1",
+        credentials="{}",
+    )
+
+    with pytest.raises(APIAuthenticationError):
+        provider.generate_text("hello")
+
+
+def test_gemini_non_vertex_rate_limit_error_is_mapped(monkeypatch):
+    google_mod = sys.modules.get("google")
+    if google_mod is None:
+        google_mod = types.ModuleType("google")
+        google_mod.__path__ = []
+        sys.modules["google"] = google_mod
+
+    genai_mod = types.ModuleType("google.genai")
+    genai_types_mod = types.ModuleType("google.genai.types")
+
+    class GenerateContentConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class Client:
+        def __init__(self, api_key=None, **kwargs):
+            self.models = self
+
+        def generate_content(self, *args, **kwargs):
+            raise RuntimeError("rate limit exceeded")
+
+    genai_types_mod.GenerateContentConfig = GenerateContentConfig
+    genai_mod.Client = Client
+    genai_mod.types = genai_types_mod
+
+    monkeypatch.setitem(sys.modules, "google.genai", genai_mod)
+    monkeypatch.setitem(sys.modules, "google.genai.types", genai_types_mod)
+    setattr(google_mod, "genai", genai_mod)
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "abc123")
+    provider = providers_module.GeminiProvider(model="gemini-test")
+
+    with pytest.raises(APIRateLimitError):
+        provider.generate_text("hello")
+
+
+def test_gemini_import_error_maps_to_api_error(monkeypatch):
+    google_mod = sys.modules.get("google")
+    if google_mod is None:
+        google_mod = types.ModuleType("google")
+        google_mod.__path__ = []
+        sys.modules["google"] = google_mod
+
+    genai_mod = types.ModuleType("google.genai")
+    genai_types_mod = types.ModuleType("google.genai.types")
+
+    class GenerateContentConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class Client:
+        def __init__(self, *args, **kwargs):
+            raise ImportError("missing dependency")
+
+    genai_types_mod.GenerateContentConfig = GenerateContentConfig
+    genai_mod.Client = Client
+    genai_mod.types = genai_types_mod
+
+    monkeypatch.setitem(sys.modules, "google.genai", genai_mod)
+    monkeypatch.setitem(sys.modules, "google.genai.types", genai_types_mod)
+    setattr(google_mod, "genai", genai_mod)
+    monkeypatch.setenv("GOOGLE_API_KEY", "abc123")
+
+    provider = providers_module.GeminiProvider(model="gemini-test")
+    with pytest.raises(APIError, match="Missing Gemini dependencies"):
+        provider.generate_text("hello")

--- a/tests/test_ai_registry_additional.py
+++ b/tests/test_ai_registry_additional.py
@@ -1,0 +1,34 @@
+import pytest
+
+import slideflow.ai.registry as ai_registry_module
+from slideflow.utilities.exceptions import ProviderError
+
+
+def test_ai_registry_custom_registration_and_factory_flow():
+    class CustomProvider:
+        def __init__(self, prefix=""):
+            self.prefix = prefix
+
+        def generate_text(self, prompt: str, **_kwargs) -> str:
+            return f"{self.prefix}{prompt}"
+
+    temp_name = "__phase3_custom_ai_provider__"
+
+    ai_registry_module.register_provider(temp_name, CustomProvider)
+    try:
+        assert "openai" in ai_registry_module.list_available_providers()
+        assert "gemini" in ai_registry_module.list_available_providers()
+        assert ai_registry_module.get_provider_class(temp_name) is CustomProvider
+
+        instance = ai_registry_module.create_provider(temp_name, prefix=">")
+        assert instance.generate_text("ok") == ">ok"
+    finally:
+        ai_registry_module.ai_provider_registry.remove(temp_name)
+
+
+def test_ai_registry_missing_provider_errors():
+    with pytest.raises(ProviderError, match="Unknown provider"):
+        ai_registry_module.get_provider_class("__missing_provider__")
+
+    with pytest.raises(ProviderError, match="Failed to create provider"):
+        ai_registry_module.create_provider("__missing_provider__")

--- a/tests/test_replacements_and_transforms.py
+++ b/tests/test_replacements_and_transforms.py
@@ -1,0 +1,228 @@
+import pandas as pd
+import pytest
+
+import slideflow.replacements.ai_text as ai_text_module
+from slideflow.replacements.ai_text import AITextReplacement
+from slideflow.replacements.table import TableColumnFormatter, TableFormattingOptions, TableReplacement
+from slideflow.replacements.text import TextReplacement
+from slideflow.utilities.data_transforms import apply_data_transforms
+from slideflow.utilities.exceptions import DataTransformError, ReplacementError
+
+
+def _install_pandas_stub_compat(monkeypatch):
+    """Provide minimal pandas methods/properties used by transform/replacement code."""
+    df_type = type(pd.DataFrame({}))
+    series_type = type(pd.DataFrame({"x": [1]})["x"])
+
+    if not hasattr(df_type, "copy"):
+        monkeypatch.setattr(df_type, "copy", lambda self: df_type(self), raising=False)
+    if not hasattr(df_type, "empty"):
+        monkeypatch.setattr(df_type, "empty", property(lambda self: len(self) == 0), raising=False)
+    if not hasattr(df_type, "shape"):
+        monkeypatch.setattr(df_type, "shape", property(lambda self: (len(self), len(self.columns))), raising=False)
+    if not hasattr(series_type, "tolist"):
+        monkeypatch.setattr(series_type, "tolist", lambda self: list(self), raising=False)
+
+
+def test_apply_data_transforms_noop_success_and_failure_paths(monkeypatch):
+    _install_pandas_stub_compat(monkeypatch)
+
+    df = pd.DataFrame({"a": [1, 2]})
+
+    assert apply_data_transforms(None, df) is df
+    assert apply_data_transforms([], df) is df
+
+    empty_df = pd.DataFrame({})
+    assert apply_data_transforms([{"transform_fn": lambda x: x}], empty_df) is empty_df
+
+    def add_scaled_column(frame, multiplier=2):
+        frame["b"] = [value * multiplier for value in frame["a"]]
+        return frame
+
+    transformed = apply_data_transforms(
+        [{"transform_fn": add_scaled_column, "transform_args": {"multiplier": 3}}],
+        df,
+    )
+    assert transformed["b"].tolist() == [3, 6]
+    assert "b" not in df.columns  # original should be untouched
+
+    def explode(_frame, column):
+        raise KeyError(column)
+
+    with pytest.raises(DataTransformError, match="Transform function 'explode' failed"):
+        apply_data_transforms(
+            [{"transform_fn": explode, "transform_args": {"column": "missing"}}],
+            df,
+        )
+
+
+def test_text_replacement_static_and_value_function_modes(monkeypatch):
+    _install_pandas_stub_compat(monkeypatch)
+
+    static = TextReplacement(type="text", placeholder="{{STATIC}}", replacement=123)
+    assert static.replacement == "123"
+    assert static.get_replacement() == "123"
+
+    empty = TextReplacement(type="text", placeholder="{{EMPTY}}")
+    assert empty.get_replacement() == ""
+
+    direct_fn = TextReplacement(
+        type="text",
+        placeholder="{{FN}}",
+        value_fn=lambda greeting="hi": f"{greeting} there",
+        value_fn_args={"greeting": "hello"},
+    )
+    assert direct_fn.get_replacement() == "hello there"
+
+    class DummySource:
+        def fetch_data(self):
+            return pd.DataFrame({"v": [10, 20]})
+
+    def add_column(frame):
+        frame["w"] = [value + 1 for value in frame["v"]]
+        return frame
+
+    from_data = TextReplacement.model_construct(
+        type="text",
+        placeholder="{{DATA}}",
+        replacement=None,
+        data_source=DummySource(),
+        value_fn=lambda frame, suffix="": f"{len(frame.columns)}{suffix}",
+        value_fn_args={"suffix": "c"},
+        data_transforms=[{"transform_fn": add_column}],
+    )
+    assert from_data.get_replacement() == "2c"
+
+
+def test_table_replacement_dynamic_mode_applies_transforms_and_formatters(monkeypatch):
+    _install_pandas_stub_compat(monkeypatch)
+
+    class DummySource:
+        def fetch_data(self):
+            return pd.DataFrame({"product": ["Widget"], "sales": [1000]})
+
+    def double_sales(frame):
+        frame["sales"] = [value * 2 for value in frame["sales"]]
+        return frame
+
+    formatting = TableFormattingOptions(
+        custom_formatters={
+            "sales": TableColumnFormatter(
+                format_fn=lambda value, symbol="$": f"{symbol}{value}",
+                format_fn_args={"symbol": "EUR "},
+            )
+        }
+    )
+
+    replacement = TableReplacement.model_construct(
+        type="table",
+        prefix="T_",
+        data_source=DummySource(),
+        formatting=formatting,
+        replacements=None,
+        data_transforms=[{"transform_fn": double_sales}],
+    )
+
+    output = replacement.get_replacement()
+    assert output == {
+        "{{T_1,1}}": "Widget",
+        "{{T_1,2}}": "EUR 2000",
+    }
+
+
+def test_ai_text_replacement_provider_resolution_and_prompt_context(monkeypatch):
+    _install_pandas_stub_compat(monkeypatch)
+
+    class DummyProvider:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+
+        def generate_text(self, prompt, temperature=0.0):
+            return f"{self.api_key}:{temperature}:{prompt}"
+
+    monkeypatch.setattr(ai_text_module, "get_provider_class", lambda _name: DummyProvider)
+
+    string_provider = AITextReplacement(
+        type="ai_text",
+        placeholder="{{AI}}",
+        prompt="Prompt",
+        provider="dummy",
+        provider_args={"api_key": "k", "temperature": 0.4},
+    )
+    fn, call_args = string_provider._prepare_provider()
+    assert call_args == {"temperature": 0.4}
+    assert fn("hello", **call_args).startswith("k:0.4:hello")
+
+    instance_provider = AITextReplacement(
+        type="ai_text",
+        placeholder="{{AI2}}",
+        prompt="Prompt",
+        provider=DummyProvider(api_key="instance"),
+        provider_args={"temperature": 0.2},
+    )
+    fn2, call_args2 = instance_provider._prepare_provider()
+    assert fn2("hello", **call_args2).startswith("instance:0.2:hello")
+
+    callable_provider = AITextReplacement(
+        type="ai_text",
+        placeholder="{{AI3}}",
+        prompt="Prompt",
+        provider=lambda prompt, suffix="": f"{prompt}{suffix}",
+        provider_args={"suffix": "!"},
+    )
+    fn3, call_args3 = callable_provider._prepare_provider()
+    assert fn3("hello", **call_args3) == "hello!"
+
+    invalid_provider = AITextReplacement.model_construct(
+        type="ai_text",
+        placeholder="{{BAD}}",
+        prompt="Prompt",
+        provider=123,
+        provider_args={},
+        data_source=None,
+        data_transforms=None,
+    )
+    with pytest.raises(ReplacementError, match="Invalid AI provider"):
+        invalid_provider._prepare_provider()
+
+
+def test_ai_text_replacement_data_context_and_transform_failure_fallback(monkeypatch):
+    _install_pandas_stub_compat(monkeypatch)
+
+    class DummySource:
+        def __init__(self, name):
+            self.name = name
+
+        def fetch_data(self):
+            return pd.DataFrame({"metric": [42]})
+
+    ok = AITextReplacement.model_construct(
+        type="ai_text",
+        placeholder="{{AI_OK}}",
+        prompt="Summarize",
+        provider=lambda prompt, suffix="": f"{prompt}{suffix}",
+        provider_args={"suffix": "!"},
+        data_source=[DummySource("sales")],
+        data_transforms=[{"transform_fn": lambda frame: frame}],
+    )
+    rendered = ok.get_replacement()
+    assert "Summarize" in rendered
+    assert "Data from sales" in rendered
+    assert rendered.endswith("!")
+
+    def fail_transform(_frame):
+        raise RuntimeError("boom")
+
+    failing = AITextReplacement.model_construct(
+        type="ai_text",
+        placeholder="{{AI_FAIL}}",
+        prompt="Summarize",
+        provider=lambda prompt, **_kwargs: prompt,
+        provider_args={},
+        data_source=[DummySource("sales")],
+        data_transforms=[{"transform_fn": fail_transform}],
+    )
+    assert (
+        failing.get_replacement()
+        == 'Summary unable to be generated as data source "sales" was not available'
+    )


### PR DESCRIPTION
## Summary
- add deep tests for replacement + transform paths:
  - `utilities.data_transforms` pipeline success/failure behavior
  - `TextReplacement` static/value_fn/data-source behavior
  - `TableReplacement` dynamic mode with transforms + formatters
  - `AITextReplacement` provider resolution, prompt-context building, and fallback behavior
- expand AI provider tests (OpenAI + Gemini) across success and error mapping scenarios
- add AI registry tests for register/list/get/create paths and missing-provider errors
- fix Gemini provider error handling to preserve explicit `APIAuthenticationError` / `APIRateLimitError` / `APIError` instead of downgrading to generic APIError
- raise coverage gate from `65` to `70` in CI and release workflows, and update docs accordingly

## Validation
- `source .venv/bin/activate && pytest -q`
- `source .venv/bin/activate && pytest -q --cov=slideflow --cov-report=term --cov-fail-under=70`
- `source .venv/bin/activate && mkdocs build --strict`

## Coverage
- total coverage now: `74.05%` (71 tests passing)
- notable gains:
  - `slideflow/utilities/data_transforms.py` -> `100%`
  - `slideflow/replacements/text.py` -> `100%`
  - `slideflow/replacements/table.py` -> `100%`
  - `slideflow/replacements/ai_text.py` -> `96%`
  - `slideflow/ai/registry.py` -> `100%`
  - `slideflow/ai/providers.py` -> `77%`