### PR TITLE
Phase 3: add integration/e2e workflow tests and CI marker split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,19 @@ jobs:
       - name: Run unit tests with coverage
         run: |
           python -m pytest -q \
+            -m "not integration and not e2e" \
             --cov=slideflow \
             --cov-report=term \
             --cov-report=xml \
             --cov-fail-under=70
+
+      - name: Run integration tests
+        run: |
+          python -m pytest -q -m integration
+
+      - name: Run e2e tests
+        run: |
+          python -m pytest -q -m e2e
 
       - name: Upload coverage report
         if: always()

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -5,7 +5,9 @@
 - `CI` (`.github/workflows/ci.yml`)
   - installs project + dev deps
   - runs `pip check`
-  - runs unit tests with coverage gate
+  - runs unit tests with coverage gate (`-m "not integration and not e2e"`)
+  - runs integration marker tests (`-m integration`)
+  - runs e2e marker tests (`-m e2e`)
   - builds distribution artifacts
 - `Docs` (`.github/workflows/docs.yml`)
   - runs `mkdocs build --strict`
@@ -26,6 +28,9 @@
 ```bash
 source .venv/bin/activate
 pytest -q
+pytest -q -m "not integration and not e2e" --cov=slideflow --cov-report=term --cov-fail-under=70
+pytest -q -m integration
+pytest -q -m e2e
 mkdocs build --strict
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,11 +32,20 @@ pytest -q -m integration
 pytest -q -m e2e
 ```
 
+Mirror CI marker split locally:
+
+```bash
+pytest -q -m "not integration and not e2e" --cov=slideflow --cov-report=term --cov-report=xml --cov-fail-under=70
+pytest -q -m integration
+pytest -q -m e2e
+```
+
 ## CI quality gates
 
 - CI enforces version consistency checks.
 - CI enforces dependency consistency via `pip check`.
-- CI enforces coverage floor (`--cov-fail-under=70`).
+- CI enforces coverage floor (`--cov-fail-under=70`) on unit tests (`not integration and not e2e`).
+- CI runs dedicated integration and e2e marker suites in separate steps.
 - Distribution artifacts are built for every CI run.
 
 ## Contribution expectations

--- a/slideflow/presentations/config.py
+++ b/slideflow/presentations/config.py
@@ -59,7 +59,8 @@ Validation:
     - Cross-field validation where applicable
 """
 
-from pydantic import BaseModel, Field, ConfigDict
+from pathlib import Path
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 from typing import List, Optional, Dict, Any, Annotated, Callable
 
 class ReplacementSpec(BaseModel):
@@ -527,3 +528,15 @@ class PresentationConfig(BaseModel):
     provider: Annotated[ProviderConfig, Field(..., description = "Presentation provider configuration")]
     template_paths: Annotated[Optional[List[str]], Field(None, description = "Custom template search paths (in priority order)")]
     registry: Annotated[Optional[List[str]], Field(None, description = "Paths to custom function registry files")]
+
+    @field_validator("registry", mode = "before")
+    @classmethod
+    def _normalize_registry(cls, value: Any) -> Optional[List[str]]:
+        """Allow both string and list forms for backward-compatible registry config."""
+        if value is None:
+            return None
+        if isinstance(value, (str, Path)):
+            return [str(value)]
+        if isinstance(value, list):
+            return [str(path) for path in value]
+        return value

--- a/tests/test_config_utilities.py
+++ b/tests/test_config_utilities.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from slideflow.presentations.config import PresentationConfig
 from slideflow.utilities.config import load_registry_from_path, render_params
 from slideflow.utilities.exceptions import ConfigurationError
 
@@ -127,3 +128,15 @@ def test_render_params_tolerates_invalid_format_syntax():
     rendered = render_params(payload, {"quarter": "Q1"})
 
     assert rendered == payload
+
+
+def test_presentation_config_accepts_registry_as_string():
+    config = PresentationConfig.model_validate(
+        {
+            "registry": "registry.py",
+            "provider": {"type": "google_slides", "config": {}},
+            "presentation": {"name": "Demo", "slides": []},
+        }
+    )
+
+    assert config.registry == ["registry.py"]

--- a/tests/test_integration_cli_workflows.py
+++ b/tests/test_integration_cli_workflows.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+
+import pytest
+
+import slideflow.cli.commands.build as build_command_module
+import slideflow.cli.commands.validate as validate_command_module
+
+
+def _stub_cli_output(monkeypatch):
+    monkeypatch.setattr(build_command_module, "print_build_header", lambda *a, **k: None)
+    monkeypatch.setattr(build_command_module, "print_build_progress", lambda *a, **k: None)
+    monkeypatch.setattr(build_command_module, "print_build_success", lambda *a, **k: None)
+    monkeypatch.setattr(build_command_module, "print_build_error", lambda *a, **k: None)
+    monkeypatch.setattr(build_command_module.time, "sleep", lambda *_: None)
+
+    monkeypatch.setattr(validate_command_module, "print_validation_header", lambda *a, **k: None)
+    monkeypatch.setattr(validate_command_module, "print_success", lambda *a, **k: None)
+    monkeypatch.setattr(validate_command_module, "print_config_summary", lambda *a, **k: None)
+    monkeypatch.setattr(validate_command_module, "print_error", lambda *a, **k: None)
+
+
+def _write_registry(registry_path: Path) -> None:
+    registry_path.write_text(
+        "def build_region_label(region='unknown'):\n"
+        "    return f'Region: {region}'\n"
+        "\n"
+        "function_registry = {\n"
+        "    'build_region_label': build_region_label,\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_config(config_path: Path) -> None:
+    config_path.write_text(
+        "registry: registry.py\n"
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: 'Regional Deck {region}'\n"
+        "  slides:\n"
+        "    - id: slide_1\n"
+        "      title: Overview\n"
+        "      replacements:\n"
+        "        - type: text\n"
+        "          config:\n"
+        "            placeholder: '{{REGION_LABEL}}'\n"
+        "            value_fn: build_region_label\n"
+        "            value_fn_args:\n"
+        "              region: '{region}'\n"
+        "      charts: []\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.integration
+def test_validate_command_with_real_loader_and_registry(tmp_path, monkeypatch):
+    _stub_cli_output(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    registry_path = tmp_path / "registry.py"
+    config_path = tmp_path / "config.yml"
+    _write_registry(registry_path)
+    _write_config(config_path)
+
+    validate_command_module.validate_command(config_file=config_path, registry_paths=None)
+
+
+@pytest.mark.integration
+def test_validate_fails_when_registry_function_is_missing(tmp_path, monkeypatch):
+    _stub_cli_output(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    config_path = tmp_path / "broken.yml"
+    config_path.write_text(
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: 'Broken Deck'\n"
+        "  slides:\n"
+        "    - id: slide_1\n"
+        "      replacements:\n"
+        "        - type: text\n"
+        "          config:\n"
+        "            placeholder: '{{X}}'\n"
+        "            value_fn: missing_function\n"
+        "      charts: []\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(validate_command_module.typer.Exit) as exc_info:
+        validate_command_module.validate_command(config_file=config_path, registry_paths=None)
+
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.e2e
+def test_e2e_validate_then_build_dry_run_with_param_csv(tmp_path, monkeypatch):
+    _stub_cli_output(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    registry_path = tmp_path / "registry.py"
+    config_path = tmp_path / "config.yml"
+    params_path = tmp_path / "params.csv"
+
+    _write_registry(registry_path)
+    _write_config(config_path)
+    params_path.write_text(
+        "region\nus\neu\n",
+        encoding="utf-8",
+    )
+
+    validate_command_module.validate_command(config_file=config_path, registry_paths=None)
+
+    result = build_command_module.build_command(
+        config_file=config_path,
+        registry_files=None,
+        params_path=params_path,
+        dry_run=True,
+    )
+    assert result == []


### PR DESCRIPTION
## Summary
- add real workflow tests for `slideflow validate` and `slideflow build --dry-run` paths using temp config/registry fixtures
- add regression coverage for `PresentationConfig` accepting `registry` as string and normalizing to list
- split CI test execution into:
  - unit tests with coverage (`not integration and not e2e`)
  - integration marker tests
  - e2e marker tests
- align testing docs with CI marker split commands

## Validation
- `source .venv/bin/activate && pytest -q`
- `source .venv/bin/activate && pytest -q -m "not integration and not e2e" --cov=slideflow --cov-report=term --cov-report=xml --cov-fail-under=70`
- `source .venv/bin/activate && pytest -q -m integration`
- `source .venv/bin/activate && pytest -q -m e2e`
- `source .venv/bin/activate && mkdocs build --strict`
