### PR TITLE
Release hardening: wheel smoke tests and TestPyPI dry-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,14 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build
 
+      - name: Smoke test installed wheel (validate + dry-run build)
+        run: |
+          python -m venv .venv-smoke
+          . .venv-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          bash scripts/ci/run_quickstart_smoke.sh
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,14 @@ jobs:
         run: |
           python -m build
 
+      - name: Smoke test built wheel
+        run: |
+          python -m venv .venv-smoke
+          . .venv-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          bash scripts/ci/run_quickstart_smoke.sh
+
       - name: Create and push release tag
         env:
           VERSION: ${{ steps.branch.outputs.version }}

--- a/.github/workflows/testpypi-dry-run.yml
+++ b/.github/workflows/testpypi-dry-run.yml
@@ -1,0 +1,53 @@
+name: TestPyPI Dry Run
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "release/v*.*.*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-testpypi:
+    runs-on: ubuntu-latest
+    environment: testpypi
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Validate version consistency
+        run: |
+          if [[ "${GITHUB_REF_NAME}" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            python scripts/ci/check_version_consistency.py "${GITHUB_REF_NAME}"
+          else
+            python scripts/ci/check_version_consistency.py
+          fi
+
+      - name: Build distribution artifacts
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Smoke test built wheel
+        run: |
+          python -m venv .venv-smoke
+          . .venv-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          bash scripts/ci/run_quickstart_smoke.sh
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -8,7 +8,8 @@
   - runs unit tests with coverage gate (`-m "not integration and not e2e"`)
   - runs integration marker tests (`-m integration`)
   - runs e2e marker tests (`-m e2e`)
-  - builds distribution artifacts
+  - builds wheel/sdist artifacts
+  - installs built wheel and runs quickstart smoke validation (`validate` + `build --dry-run`)
 - `Docs` (`.github/workflows/docs.yml`)
   - runs `mkdocs build --strict`
   - deploys to GitHub Pages on `master`/`main`
@@ -18,6 +19,10 @@
   - runs tests + build
   - creates tag + GitHub release
   - publishes to PyPI
+- `TestPyPI Dry Run` (`.github/workflows/testpypi-dry-run.yml`)
+  - runs on `release/vX.Y.Z` pushes and manual dispatch
+  - builds artifacts + smoke tests installed wheel
+  - publishes to TestPyPI using OIDC (`skip-existing`)
 - `Audit` (`.github/workflows/audit.yml`)
   - runs `pip-audit`
   - runs `bandit`
@@ -32,6 +37,12 @@ pytest -q -m "not integration and not e2e" --cov=slideflow --cov-report=term --c
 pytest -q -m integration
 pytest -q -m e2e
 mkdocs build --strict
+```
+
+To run the same smoke validation CI uses:
+
+```bash
+bash scripts/ci/run_quickstart_smoke.sh
 ```
 
 ## Coverage policy

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,16 @@ slideflow build config.yml
 
 Validation should be treated as mandatory in CI and release workflows.
 
+## Quick smoke check (recommended after install)
+
+Run the checked-in smoke sample with no external credentials:
+
+```bash
+cd docs/quickstart/smoke
+slideflow validate config.yml
+slideflow build config.yml --params-path params.csv --dry-run
+```
+
 ## Next steps
 
 - Run the sample pipeline in [Quickstart](quickstart.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,26 +1,36 @@
 # Quickstart
 
-This guide runs the checked-in sample in `docs/quickstart/` end-to-end.
+This guide gives you a copy-paste runnable sample first, then shows how to switch to real Google Slides deployment.
 
-## 1. Prepare sample config
+## 1. Run the smoke sample (no credentials required)
 
-Open `docs/quickstart/config.yml` and set:
+The smoke sample lives in `docs/quickstart/smoke/` and is designed for `--dry-run` validation.
+
+```bash
+cd docs/quickstart/smoke
+slideflow validate config.yml
+slideflow build config.yml --params-path params.csv --dry-run
+```
+
+What this verifies:
+
+- YAML schema validity
+- registry function resolution (`registry.py`)
+- parameter fan-out from CSV (`params.csv`)
+- chart/replacement wiring for a local CSV data source
+
+## 2. Switch to a real Google Slides build
+
+Use `docs/quickstart/config.yml` for a real build and set:
 
 - `provider.config.template_id`
 - `provider.config.credentials` (or set `GOOGLE_SLIDEFLOW_CREDENTIALS`)
 - slide IDs under `presentation.slides[*].id`
 
-## 2. Validate configuration
+Then run:
 
 ```bash
 slideflow validate docs/quickstart/config.yml --registry docs/quickstart/registry.py
-```
-
-Validation checks YAML structure, provider config, chart/replacement wiring, and registry resolution.
-
-## 3. Build a presentation
-
-```bash
 slideflow build docs/quickstart/config.yml --registry docs/quickstart/registry.py
 ```
 
@@ -30,7 +40,7 @@ Expected outcome:
 - Slide 1 gets `{{MONTH}}` replacement and a bar chart from `docs/quickstart/data.csv`
 - Slide 2 gets a template chart from `docs/quickstart/bar_chart.yml`
 
-## 4. Batch mode (multi-deck)
+## 3. Batch mode (multi-deck)
 
 Create `variants.csv`:
 
@@ -54,7 +64,7 @@ Rules:
 - Empty CSV rows are rejected at runtime
 - Use `--dry-run` to validate all variants without building
 
-## 5. Control concurrency and rate limits
+## 4. Control concurrency and rate limits
 
 ```bash
 slideflow build docs/quickstart/config.yml \
@@ -65,7 +75,7 @@ slideflow build docs/quickstart/config.yml \
 
 Use conservative `--threads` and `--rps` when Google API quotas are tight.
 
-## 6. Troubleshoot fast
+## 5. Troubleshoot fast
 
 If anything fails:
 

--- a/docs/quickstart/smoke/config.yml
+++ b/docs/quickstart/smoke/config.yml
@@ -1,0 +1,37 @@
+registry: registry.py
+
+provider:
+  type: google_slides
+  config: {}
+
+presentation:
+  name: "SlideFlow Smoke Deck ({region})"
+  slides:
+    - id: smoke_slide_1
+      title: Smoke Slide
+      replacements:
+        - type: text
+          config:
+            placeholder: "{{REGION_LABEL}}"
+            value_fn: region_label
+            value_fn_args:
+              region: "{region}"
+      charts:
+        - type: plotly_go
+          config:
+            title: Revenue Trend
+            data_source:
+              type: csv
+              name: smoke_metrics
+              file_path: data.csv
+            traces:
+              - type: scatter
+                x: "$month"
+                y: "$revenue"
+                mode: "lines+markers"
+                name: Revenue
+            layout_config:
+              xaxis:
+                title: Month
+              yaxis:
+                title: Revenue

--- a/docs/quickstart/smoke/data.csv
+++ b/docs/quickstart/smoke/data.csv
@@ -1,0 +1,5 @@
+month,revenue
+Jan,10000
+Feb,12000
+Mar,15000
+Apr,14000

--- a/docs/quickstart/smoke/params.csv
+++ b/docs/quickstart/smoke/params.csv
@@ -1,0 +1,3 @@
+region
+NA
+EMEA

--- a/docs/quickstart/smoke/registry.py
+++ b/docs/quickstart/smoke/registry.py
@@ -1,0 +1,7 @@
+def region_label(region: str = "unknown") -> str:
+    return f"Region: {region}"
+
+
+function_registry = {
+    "region_label": region_label,
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -18,9 +18,12 @@ On push to a `release/vX.Y.Z` branch, the `Release` workflow:
 2. validates project version consistency
 3. runs release test suite + coverage gate
 4. builds wheel and source distributions
-5. creates and pushes Git tag `vX.Y.Z`
-6. creates GitHub release with artifacts
-7. publishes package to PyPI (OIDC trusted publishing)
+5. installs built wheel and runs quickstart smoke validation (`validate` + `build --dry-run`)
+6. creates and pushes Git tag `vX.Y.Z`
+7. creates GitHub release with artifacts
+8. publishes package to PyPI (OIDC trusted publishing)
+
+In parallel, `TestPyPI Dry Run` can publish the same artifacts to TestPyPI (with `skip-existing`) for pre-production validation.
 
 ## Version consistency contract
 
@@ -51,6 +54,13 @@ mkdocs build --strict
 2. Add trusted publisher for this GitHub repo/workflow.
 3. Configure GitHub environment `pypi` with any required reviewers.
 4. Keep `id-token: write` enabled in release workflow permissions.
+
+## TestPyPI setup (recommended)
+
+1. Create a TestPyPI project matching your package name.
+2. Add a trusted publisher for `.github/workflows/testpypi-dry-run.yml`.
+3. Configure GitHub environment `testpypi` with any required reviewers.
+4. Trigger the workflow manually first to verify OIDC publishing works.
 
 ## Rollback guidance
 

--- a/scripts/ci/run_quickstart_smoke.sh
+++ b/scripts/ci/run_quickstart_smoke.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SMOKE_DIR="${1:-docs/quickstart/smoke}"
+
+if [[ ! -d "${SMOKE_DIR}" ]]; then
+  echo "Smoke sample directory not found: ${SMOKE_DIR}" >&2
+  exit 1
+fi
+
+pushd "${SMOKE_DIR}" >/dev/null
+slideflow validate config.yml
+slideflow build config.yml --params-path params.csv --dry-run
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add a deterministic, copy-paste runnable quickstart smoke sample in `docs/quickstart/smoke/`
  - `config.yml`, `registry.py`, `data.csv`, `params.csv`
  - sample is designed for `validate` + `build --dry-run` with no external credentials
- add reusable smoke runner script: `scripts/ci/run_quickstart_smoke.sh`
- harden CI artifact validation:
  - in `ci.yml`, after building dist artifacts, install built wheel and run smoke script
- harden release pipeline:
  - in `release.yml`, smoke test built wheel before tag/release/publish
- add new TestPyPI dry-run workflow (`.github/workflows/testpypi-dry-run.yml`)
  - triggers on `release/v*.*.*` pushes + manual dispatch
  - builds dist, smoke tests installed wheel, publishes to TestPyPI with `skip-existing`
- update docs (`quickstart`, `getting-started`, `ci-quality`, `release-process`) to reflect new smoke and TestPyPI flows

## Validation
- `source .venv/bin/activate && bash scripts/ci/run_quickstart_smoke.sh`
- `source .venv/bin/activate && pytest -q`
- `source .venv/bin/activate && mkdocs build --strict`

## Notes
- Full local wheel-install smoke in an isolated temp venv could not be fully executed in this environment due restricted package index access for installing `build`; CI runs this path with network.
