### PR TITLE
Add doctor preflight and machine-readable CLI/workflow outputs

### DIFF
--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -42,6 +42,16 @@ on:
         required: false
         default: true
         type: boolean
+      run-doctor:
+        description: "Run slideflow doctor preflight checks before validate/build"
+        required: false
+        default: true
+        type: boolean
+      strict-doctor:
+        description: "Fail fast when doctor detects error-severity issues"
+        required: false
+        default: false
+        type: boolean
       run-validate:
         description: "Run slideflow validate before build"
         required: false
@@ -74,8 +84,17 @@ on:
         type: string
     outputs:
       presentation-urls:
-        description: "Comma-separated presentation URLs discovered in build logs"
+        description: "Comma-separated presentation URLs extracted from build JSON output"
         value: ${{ jobs.build.outputs.presentation_urls }}
+      doctor-result-json:
+        description: "JSON output emitted by slideflow doctor"
+        value: ${{ jobs.build.outputs.doctor_result_json }}
+      validate-result-json:
+        description: "JSON output emitted by slideflow validate"
+        value: ${{ jobs.build.outputs.validate_result_json }}
+      build-result-json:
+        description: "JSON output emitted by slideflow build"
+        value: ${{ jobs.build.outputs.build_result_json }}
 
 permissions:
   contents: read
@@ -85,6 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       presentation_urls: ${{ steps.extract_urls.outputs.presentation_urls }}
+      doctor_result_json: ${{ steps.extract_json.outputs.doctor_result_json }}
+      validate_result_json: ${{ steps.extract_json.outputs.validate_result_json }}
+      build_result_json: ${{ steps.extract_json.outputs.build_result_json }}
     defaults:
       run:
         shell: bash
@@ -124,10 +146,16 @@ jobs:
         env:
           LOG_FILE: ${{ runner.temp }}/slideflow-build.log
           URL_FILE: ${{ runner.temp }}/slideflow-presentation-urls.txt
+          DOCTOR_JSON_FILE: ${{ runner.temp }}/slideflow-doctor-result.json
+          VALIDATE_JSON_FILE: ${{ runner.temp }}/slideflow-validate-result.json
+          BUILD_JSON_FILE: ${{ runner.temp }}/slideflow-build-result.json
         run: |
           set -euo pipefail
           : > "$LOG_FILE"
           : > "$URL_FILE"
+          printf '{}\n' > "$DOCTOR_JSON_FILE"
+          printf '{}\n' > "$VALIDATE_JSON_FILE"
+          printf '{}\n' > "$BUILD_JSON_FILE"
 
           registry_args=()
           if [[ -n "${{ inputs.registry-files }}" ]]; then
@@ -139,8 +167,22 @@ jobs:
             done < <(printf '%s\n' "${{ inputs.registry-files }}" | tr ',' '\n')
           fi
 
+          if [[ "${{ inputs.run-doctor }}" == "true" ]]; then
+            doctor_cmd=(slideflow doctor --config-file "${{ inputs.config-file }}" --output-json "$DOCTOR_JSON_FILE")
+            if [[ ${#registry_args[@]} -gt 0 ]]; then
+              doctor_cmd+=("${registry_args[@]}")
+            fi
+            if [[ "${{ inputs.strict-doctor }}" == "true" ]]; then
+              doctor_cmd+=("--strict")
+            fi
+            {
+              echo "Running: ${doctor_cmd[*]}"
+              "${doctor_cmd[@]}"
+            } 2>&1 | tee -a "$LOG_FILE"
+          fi
+
           if [[ "${{ inputs.run-validate }}" == "true" ]]; then
-            validate_cmd=(slideflow validate "${{ inputs.config-file }}")
+            validate_cmd=(slideflow validate "${{ inputs.config-file }}" --output-json "$VALIDATE_JSON_FILE")
             if [[ ${#registry_args[@]} -gt 0 ]]; then
               validate_cmd+=("${registry_args[@]}")
             fi
@@ -150,7 +192,7 @@ jobs:
             } 2>&1 | tee -a "$LOG_FILE"
           fi
 
-          build_cmd=(slideflow build "${{ inputs.config-file }}")
+          build_cmd=(slideflow build "${{ inputs.config-file }}" --output-json "$BUILD_JSON_FILE")
           if [[ ${#registry_args[@]} -gt 0 ]]; then
             build_cmd+=("${registry_args[@]}")
           fi
@@ -172,10 +214,36 @@ jobs:
             "${build_cmd[@]}"
           } 2>&1 | tee -a "$LOG_FILE"
 
-          grep -Eo 'https://docs.google.com/presentation/d/[A-Za-z0-9_-]+' "$LOG_FILE" | sort -u > "$URL_FILE" || true
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          build_json = Path(os.environ["BUILD_JSON_FILE"])
+          url_file = Path(os.environ["URL_FILE"])
+
+          urls = []
+          if build_json.exists():
+              try:
+                  payload = json.loads(build_json.read_text(encoding="utf-8"))
+              except Exception:
+                  payload = {}
+              for row in payload.get("results", []):
+                  if isinstance(row, dict):
+                      url = row.get("url")
+                      if isinstance(url, str) and url:
+                          urls.append(url)
+
+          unique_urls = sorted(set(urls))
+          text = "\n".join(unique_urls)
+          if text:
+              text += "\n"
+          url_file.write_text(text, encoding="utf-8")
+          PY
 
       - name: Extract URL output
         id: extract_urls
+        if: ${{ always() }}
         env:
           URL_FILE: ${{ runner.temp }}/slideflow-presentation-urls.txt
         run: |
@@ -187,12 +255,41 @@ jobs:
           fi
           echo "presentation_urls=$presentation_urls" >> "$GITHUB_OUTPUT"
 
+      - name: Extract JSON outputs
+        id: extract_json
+        if: ${{ always() }}
+        env:
+          DOCTOR_JSON_FILE: ${{ runner.temp }}/slideflow-doctor-result.json
+          VALIDATE_JSON_FILE: ${{ runner.temp }}/slideflow-validate-result.json
+          BUILD_JSON_FILE: ${{ runner.temp }}/slideflow-build-result.json
+        run: |
+          set -euo pipefail
+
+          emit_json_output() {
+            local key="$1"
+            local file="$2"
+            echo "${key}<<EOF" >> "$GITHUB_OUTPUT"
+            if [[ -s "$file" ]]; then
+              cat "$file" >> "$GITHUB_OUTPUT"
+            else
+              echo "{}" >> "$GITHUB_OUTPUT"
+            fi
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          }
+
+          emit_json_output "doctor_result_json" "$DOCTOR_JSON_FILE"
+          emit_json_output "validate_result_json" "$VALIDATE_JSON_FILE"
+          emit_json_output "build_result_json" "$BUILD_JSON_FILE"
+
       - name: Upload build logs
-        if: ${{ inputs.upload-log-artifact }}
+        if: ${{ always() && inputs.upload-log-artifact }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
           path: |
             ${{ runner.temp }}/slideflow-build.log
             ${{ runner.temp }}/slideflow-presentation-urls.txt
+            ${{ runner.temp }}/slideflow-doctor-result.json
+            ${{ runner.temp }}/slideflow-validate-result.json
+            ${{ runner.temp }}/slideflow-build-result.json
           if-no-files-found: ignore

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,6 +10,7 @@ Commands:
 
 - `build`: validate + generate one or many presentations
 - `validate`: validate configuration and registries without rendering
+- `doctor`: run preflight diagnostics for runtime dependencies
 - `templates`: inspect available chart templates and contracts
 
 ## Global options
@@ -31,6 +32,7 @@ Options:
 | Option | Description |
 | --- | --- |
 | `-r`, `--registry` | One or more Python registry files |
+| `--output-json` | Write machine-readable validation summary JSON |
 
 Registry resolution order:
 
@@ -45,6 +47,7 @@ Examples:
 slideflow validate config.yml
 slideflow validate config.yml --registry registry.py
 slideflow validate config.yml -r base_registry.py -r team_registry.py
+slideflow validate config.yml --output-json validate-result.json
 ```
 
 ## `slideflow build`
@@ -62,6 +65,7 @@ Options:
 | `--dry-run` | Validate all variants without rendering |
 | `-t`, `--threads` | Number of concurrent presentation workers |
 | `--rps` | Override provider requests/second |
+| `--output-json` | Write machine-readable build summary JSON |
 
 Registry resolution order:
 
@@ -90,6 +94,33 @@ slideflow build config.yml \
 slideflow build config.yml \
   --threads 3 \
   --rps 0.8
+
+slideflow build config.yml \
+  --params-path variants.csv \
+  --output-json build-result.json
+```
+
+## `slideflow doctor`
+
+```bash
+slideflow doctor [OPTIONS]
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `-c`, `--config-file` | Optional config file for provider-level checks |
+| `-r`, `--registry` | Optional registry paths used with `--config-file` |
+| `--strict` | Exit non-zero when error-severity checks fail |
+| `--output-json` | Write machine-readable doctor summary JSON |
+
+Examples:
+
+```bash
+slideflow doctor
+slideflow doctor --config-file config.yml --registry registry.py
+slideflow doctor --config-file config.yml --strict --output-json doctor-result.json
 ```
 
 ## `slideflow templates list`
@@ -127,4 +158,6 @@ slideflow templates info bar_basic
 ## Exit behavior
 
 - Returns non-zero exit status on validation/build failures
+- `doctor --strict` returns non-zero when error checks fail
+- CLI failures include stable error codes in stderr output for automation parsing
 - CI should treat any non-zero status as a failed job

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -42,6 +42,8 @@ jobs:
       config-file: config/weekly_exec_report.yml
       registry-files: registries/base_registry.py
       params-path: config/weekly_variants.csv
+      run-doctor: true
+      strict-doctor: false
       run-validate: true
       threads: "2"
       requests-per-second: "1.0"
@@ -53,9 +55,14 @@ Security notes:
 - Treat `secrets: inherit` as privileged; only call trusted workflows.
 - Keep secrets out of YAML files.
 
-### Passing deck URLs to downstream jobs
+### Passing machine-readable outputs to downstream jobs
 
-The reusable workflow exposes `presentation-urls` output.
+The reusable workflow exposes:
+
+- `presentation-urls`: comma-separated Google Slides URLs
+- `build-result-json`: JSON summary from `slideflow build --output-json`
+- `validate-result-json`: JSON summary from `slideflow validate --output-json`
+- `doctor-result-json`: JSON summary from `slideflow doctor --output-json`
 
 ```yaml
 jobs:
@@ -70,9 +77,17 @@ jobs:
     needs: build
     steps:
       - run: echo "URLs: ${{ needs.build.outputs['presentation-urls'] }}"
+      - run: echo '${{ needs.build.outputs["build-result-json"] }}' > build-result.json
+      - run: |
+          python - <<'PY'
+          import json
+          data = json.load(open("build-result.json", "r", encoding="utf-8"))
+          urls = [row["url"] for row in data.get("results", []) if row.get("url")]
+          print("Structured URLs:", urls)
+          PY
 ```
 
-You can pass this output into email/Slack/Teams actions.
+You can pass these outputs into email/Slack/Teams actions or any parser-based automation.
 
 ## Databricks Workflows
 
@@ -83,8 +98,9 @@ Typical pattern:
 3. Run:
 
 ```bash
-slideflow validate config.yml --registry registry.py
-slideflow build config.yml --registry registry.py --threads 2 --rps 0.8
+slideflow doctor --config-file config.yml --registry registry.py
+slideflow validate config.yml --registry registry.py --output-json validate-result.json
+slideflow build config.yml --registry registry.py --threads 2 --rps 0.8 --output-json build-result.json
 ```
 
 If using Databricks connectors, set:
@@ -106,8 +122,9 @@ Use a container image that includes:
 Recommended command sequence:
 
 ```bash
-slideflow validate /app/config.yml --registry /app/registry.py
-slideflow build /app/config.yml --registry /app/registry.py --threads 2 --rps 0.8
+slideflow doctor --config-file /app/config.yml --registry /app/registry.py
+slideflow validate /app/config.yml --registry /app/registry.py --output-json /tmp/validate-result.json
+slideflow build /app/config.yml --registry /app/registry.py --threads 2 --rps 0.8 --output-json /tmp/build-result.json
 ```
 
 Operational notes:
@@ -119,7 +136,8 @@ Operational notes:
 ## Production Rollout Checklist
 
 - `slideflow validate` enforced before `slideflow build`
+- `slideflow doctor` runs before long render jobs (strict mode in CI if desired)
 - Secrets managed by platform secret manager (not committed)
 - API quotas/rate limits measured and tuned (`--rps`, `--threads`)
 - Failure notifications wired to orchestration platform
-- Build logs/artifacts retained for debugging
+- Build logs and JSON summaries retained for debugging/notifications

--- a/slideflow/cli/commands/__init__.py
+++ b/slideflow/cli/commands/__init__.py
@@ -29,6 +29,7 @@ Usage:
 """
 
 from slideflow.cli.commands.build import build_command
+from slideflow.cli.commands.doctor import doctor_command
 from slideflow.cli.commands.templates import (
     templates_app,
     templates_info_command,
@@ -39,6 +40,7 @@ from slideflow.cli.commands.validate import validate_command
 __all__ = [
     "validate_command",
     "build_command",
+    "doctor_command",
     "templates_app",
     "templates_list_command",
     "templates_info_command",

--- a/slideflow/cli/commands/build.py
+++ b/slideflow/cli/commands/build.py
@@ -40,6 +40,8 @@ import typer
 import yaml  # type: ignore[import-untyped]
 
 from slideflow.cli.commands._registry import resolve_registry_paths
+from slideflow.cli.error_codes import CliErrorCode, resolve_cli_error_code
+from slideflow.cli.json_output import now_iso8601_utc, write_output_json
 from slideflow.cli.theme import (
     print_build_error,
     print_build_header,
@@ -173,6 +175,11 @@ def build_command(
     requests_per_second: Optional[float] = typer.Option(
         None, "--rps", help="Override the API rate limit (requests per second)"
     ),
+    output_json: Optional[Path] = typer.Option(
+        None,
+        "--output-json",
+        help="Optional path to write a machine-readable build summary JSON file",
+    ),
 ) -> List[dict]:
     """Generate presentations from YAML configuration.
 
@@ -245,6 +252,7 @@ def build_command(
     """
 
     print_build_header(str(config_file))
+    run_started_at = now_iso8601_utc()
 
     try:
         print_build_progress(1, 6, "Loading configuration...")
@@ -287,6 +295,20 @@ def build_command(
                     PresentationBuilder._build_slide(slide_spec)
             print_build_progress(6, 6, "Dry run complete - configuration is valid!")
             print_build_success()
+            write_output_json(
+                output_json,
+                {
+                    "command": "build",
+                    "status": "success",
+                    "dry_run": True,
+                    "started_at": run_started_at,
+                    "completed_at": now_iso8601_utc(),
+                    "config_file": str(config_file),
+                    "registry_files": [str(path) for path in registry_files],
+                    "total_presentations": total_presentations,
+                    "results": [],
+                },
+            )
             return []
 
         print_build_progress(2, 6, "Initializing presentation builder...")
@@ -369,9 +391,37 @@ def build_command(
             print(f"  • {res['presentation_name']}: {res['url']}")
 
         print_build_success()
+        write_output_json(
+            output_json,
+            {
+                "command": "build",
+                "status": "success",
+                "dry_run": False,
+                "started_at": run_started_at,
+                "completed_at": now_iso8601_utc(),
+                "config_file": str(config_file),
+                "registry_files": [str(path) for path in registry_files],
+                "total_presentations": total_presentations,
+                "generated_presentations": len(results),
+                "results": results,
+            },
+        )
 
         return results
 
     except Exception as e:
-        print_build_error(str(e))
+        error_code = resolve_cli_error_code(e, CliErrorCode.BUILD_FAILED)
+        write_output_json(
+            output_json,
+            {
+                "command": "build",
+                "status": "error",
+                "dry_run": bool(dry_run),
+                "started_at": run_started_at,
+                "completed_at": now_iso8601_utc(),
+                "config_file": str(config_file),
+                "error": {"code": error_code, "message": str(e).split("\n")[0]},
+            },
+        )
+        print_build_error(str(e), error_code=error_code)
         raise typer.Exit(1)

--- a/slideflow/cli/commands/doctor.py
+++ b/slideflow/cli/commands/doctor.py
@@ -1,0 +1,237 @@
+"""Doctor command for local/runtime preflight diagnostics."""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional
+
+import typer
+import yaml  # type: ignore[import-untyped]
+
+from slideflow.cli.commands._registry import resolve_registry_paths
+from slideflow.cli.error_codes import CliErrorCode, resolve_cli_error_code
+from slideflow.cli.json_output import now_iso8601_utc, write_output_json
+from slideflow.constants import Environment
+from slideflow.presentations.config import PresentationConfig
+from slideflow.presentations.providers.factory import ProviderFactory
+from slideflow.utilities import ConfigLoader
+
+CheckSeverity = Literal["error", "warning", "info"]
+
+
+def _check(
+    name: str, ok: bool, detail: str, severity: CheckSeverity = "error"
+) -> Dict[str, Any]:
+    return {"name": name, "ok": ok, "detail": detail, "severity": severity}
+
+
+def _detect_chrome_binary() -> Optional[str]:
+    candidates = [
+        os.getenv("CHROME_PATH"),
+        os.getenv("GOOGLE_CHROME_BIN"),
+        shutil.which("google-chrome"),
+        shutil.which("chromium"),
+        shutil.which("chromium-browser"),
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    ]
+
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return candidate
+    return None
+
+
+def _local_environment_checks() -> List[Dict[str, Any]]:
+    checks: List[Dict[str, Any]] = []
+
+    py_ok = sys.version_info >= (3, 12)
+    checks.append(
+        _check(
+            "python_version",
+            py_ok,
+            f"Detected Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        )
+    )
+
+    try:
+        import kaleido  # type: ignore[import-untyped]  # noqa: F401
+
+        checks.append(
+            _check("kaleido_import", True, "kaleido import succeeded", "error")
+        )
+    except Exception as error:
+        checks.append(_check("kaleido_import", False, str(error), "error"))
+
+    try:
+        import plotly  # type: ignore[import-untyped]  # noqa: F401
+
+        checks.append(_check("plotly_import", True, "plotly import succeeded", "error"))
+    except Exception as error:
+        checks.append(_check("plotly_import", False, str(error), "error"))
+
+    chrome_binary = _detect_chrome_binary()
+    checks.append(
+        _check(
+            "chrome_binary",
+            chrome_binary is not None,
+            (
+                f"Found browser binary at {chrome_binary}"
+                if chrome_binary
+                else "No Chrome/Chromium binary found in common locations"
+            ),
+            "error",
+        )
+    )
+
+    databricks_env = [
+        Environment.DATABRICKS_HOST,
+        Environment.DATABRICKS_HTTP_PATH,
+        Environment.DATABRICKS_ACCESS_TOKEN,
+    ]
+    missing = [env for env in databricks_env if not os.getenv(env)]
+    checks.append(
+        _check(
+            "databricks_env",
+            len(missing) == 0,
+            (
+                "All Databricks environment variables are set"
+                if not missing
+                else f"Missing Databricks env vars: {', '.join(missing)}"
+            ),
+            "warning",
+        )
+    )
+
+    return checks
+
+
+def _provider_checks(
+    config_file: Path,
+    registry_paths: Optional[List[Path]],
+) -> List[Dict[str, Any]]:
+    checks: List[Dict[str, Any]] = []
+
+    raw_config = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
+    config_registry = raw_config.get("registry")
+    resolved_registry_paths = resolve_registry_paths(
+        config_file=config_file,
+        cli_registry_paths=registry_paths,
+        config_registry=config_registry,
+    )
+
+    loader = ConfigLoader(yaml_path=config_file, registry_paths=resolved_registry_paths)
+    presentation_config = PresentationConfig(**loader.config)
+    provider_config_type = ProviderFactory.get_config_class(
+        presentation_config.provider.type
+    )
+    provider_config_type(**presentation_config.provider.config)
+
+    provider = ProviderFactory.create_provider(presentation_config.provider)
+    checks.append(
+        _check(
+            "provider_init",
+            True,
+            f"Initialized provider '{presentation_config.provider.type}'",
+            "error",
+        )
+    )
+    for check_name, ok, detail in provider.run_preflight_checks():
+        checks.append(_check(f"provider:{check_name}", ok, detail, "error"))
+
+    return checks
+
+
+def doctor_command(
+    config_file: Optional[Path] = typer.Option(
+        None,
+        "--config-file",
+        "-c",
+        help="Optional config file to run provider-level diagnostics",
+    ),
+    registry_paths: Optional[List[Path]] = typer.Option(
+        None,
+        "--registry",
+        "-r",
+        help="Path to Python registry files (can be used multiple times)",
+    ),
+    output_json: Optional[Path] = typer.Option(
+        None,
+        "--output-json",
+        help="Optional path to write a machine-readable doctor summary JSON file",
+    ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help="Exit non-zero when any error-severity checks fail",
+    ),
+) -> Dict[str, Any]:
+    """Run preflight diagnostics for local and provider/runtime dependencies."""
+    started_at = now_iso8601_utc()
+    checks: List[Dict[str, Any]] = []
+
+    try:
+        checks.extend(_local_environment_checks())
+        if config_file is not None:
+            checks.extend(_provider_checks(config_file, registry_paths))
+
+        error_failures = [
+            check
+            for check in checks
+            if not check["ok"] and check["severity"] == "error"
+        ]
+        warning_failures = [
+            check
+            for check in checks
+            if not check["ok"] and check["severity"] == "warning"
+        ]
+
+        status = "success"
+        if error_failures:
+            status = "error"
+        elif warning_failures:
+            status = "warning"
+
+        summary = {
+            "command": "doctor",
+            "status": status,
+            "started_at": started_at,
+            "completed_at": now_iso8601_utc(),
+            "strict": strict,
+            "config_file": str(config_file) if config_file else None,
+            "checks": checks,
+            "summary": {
+                "total": len(checks),
+                "passed": sum(1 for check in checks if check["ok"]),
+                "failed_errors": len(error_failures),
+                "failed_warnings": len(warning_failures),
+            },
+        }
+
+        write_output_json(output_json, summary)
+
+        for check in checks:
+            icon = "✅" if check["ok"] else "❌"
+            severity = check["severity"].upper()
+            typer.echo(f"{icon} [{severity}] {check['name']}: {check['detail']}")
+
+        if strict and error_failures:
+            raise typer.Exit(1)
+
+        return summary
+
+    except typer.Exit:
+        raise
+    except Exception as error:
+        error_code = resolve_cli_error_code(error, CliErrorCode.DOCTOR_FAILED)
+        payload = {
+            "command": "doctor",
+            "status": "error",
+            "started_at": started_at,
+            "completed_at": now_iso8601_utc(),
+            "error": {"code": error_code, "message": str(error).split("\n")[0]},
+            "checks": checks,
+        }
+        write_output_json(output_json, payload)
+        typer.echo(f"❌ [ERROR] doctor: {error_code} {str(error).splitlines()[0]}")
+        raise typer.Exit(1)

--- a/slideflow/cli/commands/validate.py
+++ b/slideflow/cli/commands/validate.py
@@ -40,6 +40,8 @@ import typer
 import yaml  # type: ignore[import-untyped]
 
 from slideflow.cli.commands._registry import resolve_registry_paths
+from slideflow.cli.error_codes import CliErrorCode, resolve_cli_error_code
+from slideflow.cli.json_output import now_iso8601_utc, write_output_json
 from slideflow.cli.theme import (
     print_config_summary,
     print_error,
@@ -58,6 +60,11 @@ def validate_command(
         "--registry",
         "-r",
         help="Path to Python registry files (can be used multiple times)",
+    ),
+    output_json: Optional[Path] = typer.Option(
+        None,
+        "--output-json",
+        help="Optional path to write a machine-readable validation summary JSON file",
     ),
 ) -> None:
     """Validate YAML configuration and registry files.
@@ -126,6 +133,7 @@ def validate_command(
     """
 
     print_validation_header(str(config_file))
+    run_started_at = now_iso8601_utc()
 
     try:
         raw_config = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
@@ -158,6 +166,54 @@ def validate_command(
 
         print_config_summary(presentation_config)
 
+        slide_specs = list(getattr(presentation_config.presentation, "slides", []))
+
+        def _safe_len(value: object) -> int:
+            try:
+                return len(value)  # type: ignore[arg-type]
+            except TypeError:
+                return 0
+
+        total_slides = len(slide_specs)
+        total_replacements = sum(
+            _safe_len(getattr(slide_spec, "replacements", []))
+            for slide_spec in slide_specs
+        )
+        total_charts = sum(
+            _safe_len(getattr(slide_spec, "charts", [])) for slide_spec in slide_specs
+        )
+        presentation_name = str(getattr(presentation_config.presentation, "name", ""))
+        write_output_json(
+            output_json,
+            {
+                "command": "validate",
+                "status": "success",
+                "started_at": run_started_at,
+                "completed_at": now_iso8601_utc(),
+                "config_file": str(config_file),
+                "registry_files": [str(path) for path in resolved_registry_paths],
+                "summary": {
+                    "provider_type": presentation_config.provider.type,
+                    "presentation_name": presentation_name,
+                    "slides": total_slides,
+                    "replacements": total_replacements,
+                    "charts": total_charts,
+                },
+            },
+        )
+
     except Exception as e:
-        print_error(str(e))
+        error_code = resolve_cli_error_code(e, CliErrorCode.VALIDATE_FAILED)
+        write_output_json(
+            output_json,
+            {
+                "command": "validate",
+                "status": "error",
+                "started_at": run_started_at,
+                "completed_at": now_iso8601_utc(),
+                "config_file": str(config_file),
+                "error": {"code": error_code, "message": str(e).split("\n")[0]},
+            },
+        )
+        print_error(str(e), error_code=error_code)
         raise typer.Exit(1)

--- a/slideflow/cli/error_codes.py
+++ b/slideflow/cli/error_codes.py
@@ -1,0 +1,45 @@
+"""Standard CLI error codes for automation-friendly failures."""
+
+from typing import Dict, Type
+
+from slideflow.utilities.exceptions import (
+    AuthenticationError,
+    ChartGenerationError,
+    ConfigurationError,
+    DataSourceError,
+    RenderingError,
+    SlideFlowError,
+)
+
+
+class CliErrorCode:
+    """Stable error code strings used in command output."""
+
+    BUILD_FAILED = "SLIDEFLOW_BUILD_FAILED"
+    VALIDATE_FAILED = "SLIDEFLOW_VALIDATE_FAILED"
+    DOCTOR_FAILED = "SLIDEFLOW_DOCTOR_FAILED"
+
+    CONFIGURATION = "SLIDEFLOW_CONFIG_ERROR"
+    AUTHENTICATION = "SLIDEFLOW_AUTH_ERROR"
+    DATA_SOURCE = "SLIDEFLOW_DATA_SOURCE_ERROR"
+    RENDERING = "SLIDEFLOW_RENDER_ERROR"
+    CHART_GENERATION = "SLIDEFLOW_CHART_ERROR"
+    INTERNAL = "SLIDEFLOW_INTERNAL_ERROR"
+
+
+_ERROR_CODE_BY_TYPE: Dict[Type[BaseException], str] = {
+    ConfigurationError: CliErrorCode.CONFIGURATION,
+    AuthenticationError: CliErrorCode.AUTHENTICATION,
+    DataSourceError: CliErrorCode.DATA_SOURCE,
+    ChartGenerationError: CliErrorCode.CHART_GENERATION,
+    RenderingError: CliErrorCode.RENDERING,
+    SlideFlowError: CliErrorCode.INTERNAL,
+}
+
+
+def resolve_cli_error_code(error: Exception, default: str) -> str:
+    """Map an exception to the most specific CLI error code available."""
+    for exception_type, error_code in _ERROR_CODE_BY_TYPE.items():
+        if isinstance(error, exception_type):
+            return error_code
+    return default

--- a/slideflow/cli/json_output.py
+++ b/slideflow/cli/json_output.py
@@ -1,0 +1,23 @@
+"""Helpers for writing machine-readable command outputs."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def now_iso8601_utc() -> str:
+    """Return current timestamp in ISO 8601 UTC format."""
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def write_output_json(path: Optional[Path], payload: Dict[str, Any]) -> None:
+    """Write deterministic JSON output when a path is provided."""
+    if path is None:
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/slideflow/cli/main.py
+++ b/slideflow/cli/main.py
@@ -23,7 +23,7 @@ Example:
 
 import typer
 
-from slideflow.cli.commands import build_command, validate_command
+from slideflow.cli.commands import build_command, doctor_command, validate_command
 from slideflow.cli.commands.templates import (
     templates_app,
     templates_info,
@@ -107,6 +107,7 @@ def main(
 
 app.command("validate")(validate_command)
 app.command("build")(build_command)
+app.command("doctor")(doctor_command)
 if hasattr(app, "add_typer"):
     app.add_typer(templates_app, name="templates")
 else:

--- a/slideflow/cli/theme.py
+++ b/slideflow/cli/theme.py
@@ -210,10 +210,14 @@ def print_config_summary(presentation_config: Any) -> None:
     )
 
 
-def print_error(error_msg: Any, verbose: bool = False) -> None:
+def print_error(
+    error_msg: Any, verbose: bool = False, error_code: Optional[str] = None
+) -> None:
     console.print("[bold red]❌ Validation Faliled[/bold red]")
     console.print("[red]━━━━━━━━━━━━━━━━━━━━━━━[/red]")
     console.print("[bold yellow]🚨 Error Detected:[/bold yellow]")
+    if error_code:
+        console.print(f"[bold yellow]Error Code:[/bold yellow] [red]{error_code}[/red]")
 
     if verbose:
         console.print(f"[red]{error_msg}[/red]")
@@ -299,7 +303,9 @@ def print_build_success(presentation_url: Optional[str] = None) -> None:
     )
 
 
-def print_build_error(error_msg: Any, verbose: bool = False) -> None:
+def print_build_error(
+    error_msg: Any, verbose: bool = False, error_code: Optional[str] = None
+) -> None:
     """Display build failure error message.
 
     Shows a styled error message when build operations fail. Can display
@@ -311,6 +317,7 @@ def print_build_error(error_msg: Any, verbose: bool = False) -> None:
             or any object that converts to string.
         verbose: If True, displays the complete error message including
             stack traces. If False, shows only the first line for brevity.
+        error_code: Optional stable error code for automation and CI parsing.
 
     Example:
         >>> print_build_error("Configuration file not found")
@@ -322,6 +329,8 @@ def print_build_error(error_msg: Any, verbose: bool = False) -> None:
     console.print("[bold red]💥 Build Failed[/bold red]")
     console.print("[red]━━━━━━━━━━━━━━━━━━━━━━━[/red]")
     console.print("[bold yellow]🚨 Error Detected:[/bold yellow]")
+    if error_code:
+        console.print(f"[bold yellow]Error Code:[/bold yellow] [red]{error_code}[/red]")
 
     if verbose:
         console.print(f"[red]{error_msg}[/red]")

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -62,6 +62,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Callable, Dict, List, Optional
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from slideflow.constants import GoogleSlides
 from slideflow.presentations.positioning import compute_chart_dimensions
 from slideflow.presentations.providers.base import PresentationProvider
 from slideflow.replacements.base import BaseReplacement
@@ -221,7 +222,12 @@ class Slide(BaseModel):
         Field(default_factory=list, description="Charts to generate for this slide"),
     ]
 
-    def build_update_requests(self, chart_urls: Dict[str, str]) -> List[Dict[str, Any]]:
+    def build_update_requests(
+        self,
+        chart_urls: Dict[str, str],
+        page_width_pt: int = GoogleSlides.STANDARD_WIDTH_POINTS,
+        page_height_pt: int = GoogleSlides.STANDARD_HEIGHT_POINTS,
+    ) -> List[Dict[str, Any]]:
         """Build platform-specific API requests for updating this slide.
 
         Generates a list of API request objects that can be executed to update
@@ -291,6 +297,13 @@ class Slide(BaseModel):
                             }
                         )
 
+        slides_app = {
+            "pageSize": {
+                "width": {"magnitude": page_width_pt, "unit": "PT"},
+                "height": {"magnitude": page_height_pt, "unit": "PT"},
+            }
+        }
+
         # Build chart insertion requests
         for i, chart in enumerate(self.charts):
             chart_id = f"chart_{i}_{id(chart)}"
@@ -304,9 +317,9 @@ class Slide(BaseModel):
                     height=chart.height,
                     dimensions_format=chart.dimensions_format,
                     alignment_format=chart.alignment_format,
-                    slides_app=None,  # TODO: Get slide dimensions from template
-                    page_width_pt=720,  # Standard Google Slides width in points
-                    page_height_pt=540,  # Standard Google Slides height in points
+                    slides_app=slides_app,
+                    page_width_pt=page_width_pt,
+                    page_height_pt=page_height_pt,
                 )
 
                 # Create chart image with computed positioning and sizing
@@ -435,6 +448,43 @@ class Presentation(BaseModel):
             self.name = self.name_fn(self.name)
         return self
 
+    @staticmethod
+    def _to_slides_app_dimensions(
+        page_width_pt: int, page_height_pt: int
+    ) -> Dict[str, Any]:
+        return {
+            "pageSize": {
+                "width": {"magnitude": page_width_pt, "unit": "PT"},
+                "height": {"magnitude": page_height_pt, "unit": "PT"},
+            }
+        }
+
+    def _resolve_page_dimensions(self, presentation_id: str) -> Tuple[int, int]:
+        page_width_pt = GoogleSlides.STANDARD_WIDTH_POINTS
+        page_height_pt = GoogleSlides.STANDARD_HEIGHT_POINTS
+
+        get_page_size = getattr(self.provider, "get_presentation_page_size", None)
+        provider_dimensions = (
+            get_page_size(presentation_id) if callable(get_page_size) else None
+        )
+        if provider_dimensions:
+            page_width_pt, page_height_pt = provider_dimensions
+
+        return page_width_pt, page_height_pt
+
+    def _run_provider_preflight(self) -> None:
+        failed_checks = []
+        run_preflight = getattr(self.provider, "run_preflight_checks", None)
+        preflight_checks = run_preflight() if callable(run_preflight) else []
+        for check_name, ok, detail in preflight_checks:
+            if not ok:
+                failed_checks.append(f"{check_name}: {detail}")
+
+        if failed_checks:
+            raise RenderingError(
+                "Provider preflight checks failed: " + "; ".join(failed_checks)
+            )
+
     def render(self) -> PresentationResult:
         """Render the complete presentation with all content and styling.
 
@@ -479,7 +529,10 @@ class Presentation(BaseModel):
         """
         start_time = time.time()
 
+        self._run_provider_preflight()
         presentation_id = self.provider.create_presentation(self.name)
+        page_width_pt, page_height_pt = self._resolve_page_dimensions(presentation_id)
+        slides_app = self._to_slides_app_dimensions(page_width_pt, page_height_pt)
         total_charts = 0
         total_replacements = 0
         uploaded_file_ids = []
@@ -523,6 +576,9 @@ class Presentation(BaseModel):
                                 height=chart.height,
                                 dimensions_format=chart.dimensions_format,
                                 alignment_format=chart.alignment_format,
+                                slides_app=slides_app,
+                                page_width_pt=page_width_pt,
+                                page_height_pt=page_height_pt,
                             )
 
                             self.provider.insert_chart_to_slide(
@@ -556,6 +612,9 @@ class Presentation(BaseModel):
                                             height=chart.height,
                                             dimensions_format=chart.dimensions_format,
                                             alignment_format=chart.alignment_format,
+                                            slides_app=slides_app,
+                                            page_width_pt=page_width_pt,
+                                            page_height_pt=page_height_pt,
                                         )
                                     )
 

--- a/slideflow/presentations/providers/base.py
+++ b/slideflow/presentations/providers/base.py
@@ -191,6 +191,30 @@ class PresentationProvider(ABC):
         """
         self.config = config
 
+    def get_presentation_page_size(
+        self, presentation_id: str
+    ) -> Optional[Tuple[int, int]]:
+        """Return presentation page size in points when the provider supports it.
+
+        Implementations should return ``(width_pt, height_pt)``.
+
+        Args:
+            presentation_id: Unique identifier of the presentation.
+
+        Returns:
+            A tuple of width/height in points, or ``None`` if unavailable.
+        """
+        return None
+
+    def run_preflight_checks(self) -> List[Tuple[str, bool, str]]:
+        """Run provider-specific preflight checks.
+
+        Returns:
+            A list of check tuples in the form ``(check_name, ok, detail)``.
+            Providers may override this to add richer validation.
+        """
+        return []
+
     @abstractmethod
     def create_presentation(self, name: str, template_id: Optional[str] = None) -> str:
         """Create a new presentation on the platform.

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -66,6 +66,7 @@ Example:
 """
 
 import io
+import os
 import threading
 import time
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
@@ -76,7 +77,7 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseUpload
 from pydantic import Field
 
-from slideflow.constants import GoogleSlides
+from slideflow.constants import Environment, GoogleSlides
 from slideflow.presentations.providers.base import (
     PresentationProvider,
     PresentationProviderConfig,
@@ -255,6 +256,75 @@ class GoogleSlidesProvider(PresentationProvider):
         self.rate_limiter.wait()
         return request.execute(num_retries=3)
 
+    @staticmethod
+    def _dimension_to_points(dimension: Optional[Dict[str, Any]]) -> Optional[int]:
+        """Convert Google Slides dimension objects to points."""
+        if not isinstance(dimension, dict):
+            return None
+
+        magnitude = dimension.get("magnitude")
+        unit = str(dimension.get("unit", "PT")).upper()
+
+        if magnitude is None:
+            return None
+        try:
+            magnitude_value = float(str(magnitude))
+        except (TypeError, ValueError):
+            return None
+
+        if unit == "EMU":
+            return int(magnitude_value / 12700)
+        if unit == "PT":
+            return int(magnitude_value)
+        return None
+
+    def run_preflight_checks(self) -> List[Tuple[str, bool, str]]:
+        """Run Google provider preflight checks used by CLI doctor/build."""
+        has_credentials = bool(self.config.credentials) or bool(
+            os.getenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS)
+        )
+
+        checks: List[Tuple[str, bool, str]] = [
+            (
+                "google_credentials_present",
+                has_credentials,
+                (
+                    "Credentials found in config or GOOGLE_SLIDEFLOW_CREDENTIALS"
+                    if has_credentials
+                    else "Missing credentials in config and environment"
+                ),
+            ),
+            (
+                "slides_service_initialized",
+                self.slides_service is not None,
+                (
+                    "Google Slides API client initialized"
+                    if self.slides_service is not None
+                    else "Google Slides API client is not initialized"
+                ),
+            ),
+            (
+                "drive_service_initialized",
+                self.drive_service is not None,
+                (
+                    "Google Drive API client initialized"
+                    if self.drive_service is not None
+                    else "Google Drive API client is not initialized"
+                ),
+            ),
+            (
+                "rate_limiter_initialized",
+                self.rate_limiter is not None,
+                (
+                    f"Rate limiter configured at {self.config.requests_per_second} rps"
+                    if self.rate_limiter is not None
+                    else "Rate limiter is not initialized"
+                ),
+            ),
+        ]
+
+        return checks
+
     def create_presentation(self, name: str, template_id: Optional[str] = None) -> str:
         """Create a new Google Slides presentation.
 
@@ -405,6 +475,50 @@ class GoogleSlidesProvider(PresentationProvider):
             Public URL to access the presentation
         """
         return f"https://docs.google.com/presentation/d/{presentation_id}"
+
+    def get_presentation_page_size(
+        self, presentation_id: str
+    ) -> Optional[Tuple[int, int]]:
+        """Get presentation page size in points when available."""
+        start = time.time()
+        success = False
+
+        try:
+            response = self._execute_request(
+                self.slides_service.presentations().get(
+                    presentationId=presentation_id, fields="pageSize"
+                )
+            )
+
+            page_size = response.get("pageSize", {})
+            width_pt = self._dimension_to_points(page_size.get("width"))
+            height_pt = self._dimension_to_points(page_size.get("height"))
+
+            if width_pt is None or height_pt is None:
+                logger.warning(
+                    "Unable to determine page size for presentation '%s'; "
+                    "using fallback dimensions",
+                    presentation_id,
+                )
+                return None
+
+            success = True
+            return width_pt, height_pt
+        except Exception as error:
+            logger.warning(
+                "Failed to fetch page size for presentation '%s': %s",
+                presentation_id,
+                error,
+            )
+            return None
+        finally:
+            log_api_operation(
+                "google_slides",
+                "get_page_size",
+                success=success,
+                duration=time.time() - start,
+                presentation_id=presentation_id,
+            )
 
     def _get_or_create_destination_folder(self) -> Optional[str]:
         """Find or create a dynamic subfolder for the presentation."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,3 +1,4 @@
+import json
 import types
 from pathlib import Path
 
@@ -375,3 +376,102 @@ def test_build_dry_run_fails_when_deep_slide_validation_fails(tmp_path, monkeypa
         )
 
     assert exc_info.value.code == 1
+
+
+def test_validate_writes_output_json(tmp_path, monkeypatch):
+    _stub_cli_output(monkeypatch)
+    _stub_presentation_validation(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "config.yaml"
+    output_file = tmp_path / "validate.json"
+    config_file.write_text(
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n"
+    )
+
+    class FakeLoader:
+        def __init__(self, yaml_path: Path, registry_paths):
+            self.config = _minimal_loader_config()
+
+    monkeypatch.setattr(validate_command_module, "ConfigLoader", FakeLoader)
+
+    validate_command_module.validate_command(
+        config_file=config_file, registry_paths=None, output_json=output_file
+    )
+
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["command"] == "validate"
+    assert payload["status"] == "success"
+    assert payload["summary"]["slides"] == 0
+
+
+def test_build_dry_run_writes_output_json(tmp_path, monkeypatch):
+    _stub_cli_output(monkeypatch)
+    _stub_presentation_validation(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "config.yaml"
+    output_file = tmp_path / "build.json"
+    config_file.write_text(
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n"
+    )
+
+    class FakeLoader:
+        def __init__(self, yaml_path: Path, registry_paths, params):
+            self.config = _minimal_loader_config()
+
+    monkeypatch.setattr(build_command_module, "ConfigLoader", FakeLoader)
+
+    build_command_module.build_command(
+        config_file=config_file,
+        registry_files=None,
+        params_path=None,
+        dry_run=True,
+        output_json=output_file,
+    )
+
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["command"] == "build"
+    assert payload["status"] == "success"
+    assert payload["dry_run"] is True
+
+
+def test_build_error_writes_output_json_with_error_code(tmp_path, monkeypatch):
+    _stub_cli_output(monkeypatch)
+
+    config_file = tmp_path / "config.yaml"
+    params_path = tmp_path / "params.csv"
+    output_file = tmp_path / "build-error.json"
+    config_file.write_text(
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n"
+    )
+    params_path.write_text("region\n")
+
+    with pytest.raises(build_command_module.typer.Exit):
+        build_command_module.build_command(
+            config_file=config_file,
+            registry_files=None,
+            params_path=params_path,
+            dry_run=True,
+            output_json=output_file,
+        )
+
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["command"] == "build"
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "SLIDEFLOW_BUILD_FAILED"

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+
+import slideflow.cli.commands.doctor as doctor_module
+
+
+def test_doctor_writes_success_json(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        doctor_module,
+        "_local_environment_checks",
+        lambda: [
+            {
+                "name": "python_version",
+                "ok": True,
+                "detail": "Python ok",
+                "severity": "error",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        doctor_module,
+        "_provider_checks",
+        lambda _config_file, _registry_paths: [
+            {
+                "name": "provider_init",
+                "ok": True,
+                "detail": "Provider initialized",
+                "severity": "error",
+            }
+        ],
+    )
+
+    config_file = tmp_path / "config.yaml"
+    output_file = tmp_path / "doctor.json"
+    config_file.write_text(
+        "provider: {type: google_slides, config: {}}\n", encoding="utf-8"
+    )
+
+    result = doctor_module.doctor_command(
+        config_file=config_file,
+        registry_paths=None,
+        output_json=output_file,
+        strict=True,
+    )
+
+    assert result["status"] == "success"
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["command"] == "doctor"
+    assert payload["status"] == "success"
+
+
+def test_doctor_strict_exits_when_error_checks_fail(monkeypatch):
+    monkeypatch.setattr(
+        doctor_module,
+        "_local_environment_checks",
+        lambda: [
+            {
+                "name": "kaleido_import",
+                "ok": False,
+                "detail": "kaleido missing",
+                "severity": "error",
+            }
+        ],
+    )
+
+    with pytest.raises(doctor_module.typer.Exit) as exc_info:
+        doctor_module.doctor_command(
+            config_file=None,
+            registry_paths=None,
+            output_json=None,
+            strict=True,
+        )
+
+    assert exc_info.value.code == 1
+
+
+def test_doctor_writes_error_json_when_checks_raise(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        doctor_module,
+        "_local_environment_checks",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    output_file = tmp_path / "doctor-error.json"
+    with pytest.raises(doctor_module.typer.Exit):
+        doctor_module.doctor_command(
+            config_file=None,
+            registry_paths=None,
+            output_json=output_file,
+            strict=False,
+        )
+
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "SLIDEFLOW_DOCTOR_FAILED"

--- a/tests/test_connectors_and_providers_unit.py
+++ b/tests/test_connectors_and_providers_unit.py
@@ -367,3 +367,45 @@ def test_google_rate_limiter_singleton_update(monkeypatch):
 
     assert rl1 is rl2 is rl3
     assert rl3.rate == 5.0
+
+
+def test_google_provider_page_size_and_preflight(monkeypatch):
+    provider = object.__new__(google_provider_module.GoogleSlidesProvider)
+    provider.config = SimpleNamespace(credentials=None, requests_per_second=3.0)
+    provider.slides_service = SimpleNamespace(
+        presentations=lambda: SimpleNamespace(
+            get=lambda **_kwargs: "request",
+        )
+    )
+    provider.drive_service = object()
+    provider.rate_limiter = object()
+
+    monkeypatch.setattr(
+        provider,
+        "_execute_request",
+        lambda _request: {
+            "pageSize": {
+                "width": {"magnitude": 9144000, "unit": "EMU"},
+                "height": {"magnitude": 6858000, "unit": "EMU"},
+            }
+        },
+    )
+    monkeypatch.setenv("GOOGLE_SLIDEFLOW_CREDENTIALS", '{"type":"service_account"}')
+
+    assert provider.get_presentation_page_size("p1") == (720, 540)
+
+    checks = provider.run_preflight_checks()
+    assert checks
+    assert all(ok for _name, ok, _detail in checks)
+
+
+def test_google_provider_page_size_returns_none_on_invalid_shape(monkeypatch):
+    provider = object.__new__(google_provider_module.GoogleSlidesProvider)
+    provider.slides_service = SimpleNamespace(
+        presentations=lambda: SimpleNamespace(get=lambda **_kwargs: "request")
+    )
+    provider.rate_limiter = SimpleNamespace(wait=lambda: None)
+
+    monkeypatch.setattr(provider, "_execute_request", lambda _request: {"pageSize": {}})
+
+    assert provider.get_presentation_page_size("p1") is None

--- a/tests/test_presentation_render.py
+++ b/tests/test_presentation_render.py
@@ -35,6 +35,9 @@ class FakeProvider:
             },
         )()
         self.fail_cleanup = fail_cleanup
+        self.insert_calls = []
+        self.page_size = None
+        self.preflight_checks = []
 
     def create_presentation(self, _name):
         return "presentation-1"
@@ -42,7 +45,27 @@ class FakeProvider:
     def upload_chart_image(self, _presentation_id, _image_data, _filename):
         return "https://example.com/chart.png", "file-1"
 
-    def insert_chart_to_slide(self, *args, **kwargs):
+    def insert_chart_to_slide(
+        self,
+        presentation_id,
+        slide_id,
+        image_url,
+        x,
+        y,
+        width,
+        height,
+    ):
+        self.insert_calls.append(
+            {
+                "presentation_id": presentation_id,
+                "slide_id": slide_id,
+                "image_url": image_url,
+                "x": x,
+                "y": y,
+                "width": width,
+                "height": height,
+            }
+        )
         return None
 
     def replace_text_in_slide(self, *args, **kwargs):
@@ -57,6 +80,12 @@ class FakeProvider:
     def delete_chart_image(self, _file_id):
         if self.fail_cleanup:
             raise RuntimeError("cleanup failed")
+
+    def get_presentation_page_size(self, _presentation_id):
+        return self.page_size
+
+    def run_preflight_checks(self):
+        return self.preflight_checks
 
 
 def _build_presentation(provider):
@@ -88,4 +117,33 @@ def test_render_raises_when_strict_cleanup_enabled_and_delete_fails():
     presentation, _chart = _build_presentation(provider)
 
     with pytest.raises(RenderingError, match="Strict cleanup enabled"):
+        presentation.render()
+
+
+def test_render_uses_provider_page_dimensions_for_relative_chart():
+    provider = FakeProvider(strict_cleanup=False, fail_cleanup=False)
+    provider.page_size = (1000, 600)
+    presentation, chart = _build_presentation(provider)
+    chart.dimensions_format = "relative"
+    chart.x = 0
+    chart.y = 0
+    chart.width = 0.5
+    chart.height = 0.5
+
+    result = presentation.render()
+
+    assert result.charts_generated == 1
+    assert len(provider.insert_calls) == 1
+    assert provider.insert_calls[0]["width"] == 500
+    assert provider.insert_calls[0]["height"] == 300
+
+
+def test_render_fails_fast_when_provider_preflight_fails():
+    provider = FakeProvider(strict_cleanup=False, fail_cleanup=False)
+    provider.preflight_checks = [
+        ("google_credentials_present", False, "Missing credentials")
+    ]
+    presentation, _chart = _build_presentation(provider)
+
+    with pytest.raises(RenderingError, match="Provider preflight checks failed"):
         presentation.render()


### PR DESCRIPTION
Summary:
- add slideflow doctor preflight command with optional strict mode and JSON output
- add --output-json support to slideflow build and slideflow validate
- add stable CLI error codes for automation parsing
- use provider-derived slide dimensions in rendering (with fallback) and provider preflight hooks
- update reusable workflow to run doctor/validate/build with JSON outputs and expose workflow_call outputs
- update docs for new CLI and deployment/workflow behavior
- remove engineering audit docs from MkDocs nav

Validation:
- ./.venv/bin/python -m ruff check slideflow tests scripts
- ./.venv/bin/python -m black --check slideflow tests scripts
- ./.venv/bin/python -m mypy slideflow
- ./.venv/bin/python -m pytest -q

All checks are passing locally.