### PR TITLE
Fix reusable workflow secret-backed runtime env support

### DIFF
--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -82,6 +82,19 @@ on:
         required: false
         default: "slideflow-build-logs"
         type: string
+    secrets:
+      GOOGLE_SLIDEFLOW_CREDENTIALS:
+        description: "Optional Google credentials content/path for provider env fallback"
+        required: false
+      DATABRICKS_HOST:
+        description: "Optional Databricks workspace host for connector env fallback"
+        required: false
+      DATABRICKS_HTTP_PATH:
+        description: "Optional Databricks SQL warehouse HTTP path for env fallback"
+        required: false
+      DATABRICKS_ACCESS_TOKEN:
+        description: "Optional Databricks access token for connector env fallback"
+        required: false
     outputs:
       presentation-urls:
         description: "Comma-separated presentation URLs extracted from build JSON output"
@@ -102,6 +115,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GOOGLE_SLIDEFLOW_CREDENTIALS: ${{ secrets.GOOGLE_SLIDEFLOW_CREDENTIALS }}
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
+      DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
     outputs:
       presentation_urls: ${{ steps.extract_urls.outputs.presentation_urls }}
       doctor_result_json: ${{ steps.extract_json.outputs.doctor_result_json }}

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -27,7 +27,11 @@ on:
 jobs:
   weekly-slides:
     uses: joe-broadhead/slideflow/.github/workflows/reusable-slideflow-build.yml@<pinned_sha>
-    secrets: inherit
+    secrets:
+      GOOGLE_SLIDEFLOW_CREDENTIALS: ${{ secrets.GOOGLE_SLIDEFLOW_CREDENTIALS }}
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
+      DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
     with:
       config-file: config/weekly_exec_report.yml
       registry-files: |
@@ -64,7 +68,12 @@ jobs:
 
 ## Secrets and Environment
 
-- Use `secrets: inherit` in the caller job to pass required secrets to providers.
+- The reusable workflow maps these optional secrets into runtime environment variables:
+- `GOOGLE_SLIDEFLOW_CREDENTIALS`
+- `DATABRICKS_HOST`
+- `DATABRICKS_HTTP_PATH`
+- `DATABRICKS_ACCESS_TOKEN`
+- Callers can either pass those secrets explicitly or use `secrets: inherit` if the same names exist in the caller repository/org.
 - Your Slideflow config can continue to reference environment variables as usual.
 - For Google Slides builds, ensure credentials/folder IDs used by your config are available in the caller workflow environment.
 - Prefer pinning reusable workflow references to a commit SHA in production.

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -37,7 +37,11 @@ on:
 jobs:
   build:
     uses: joe-broadhead/slideflow/.github/workflows/reusable-slideflow-build.yml@<pinned_sha>
-    secrets: inherit
+    secrets:
+      GOOGLE_SLIDEFLOW_CREDENTIALS: ${{ secrets.GOOGLE_SLIDEFLOW_CREDENTIALS }}
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
+      DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
     with:
       config-file: config/weekly_exec_report.yml
       registry-files: registries/base_registry.py
@@ -52,8 +56,15 @@ jobs:
 Security notes:
 
 - Prefer pinning reusable workflow refs to a commit SHA.
-- Treat `secrets: inherit` as privileged; only call trusted workflows.
+- Treat inherited or explicitly-mapped secrets as privileged; only call trusted workflows.
 - Keep secrets out of YAML files.
+
+Supported reusable-workflow secret mappings:
+
+- `GOOGLE_SLIDEFLOW_CREDENTIALS`
+- `DATABRICKS_HOST`
+- `DATABRICKS_HTTP_PATH`
+- `DATABRICKS_ACCESS_TOKEN`
 
 ### Passing machine-readable outputs to downstream jobs
 


### PR DESCRIPTION
Summary
- add workflow_call secrets contract to reusable build workflow
- map provider-related secrets to runtime env vars in reusable build job
- update automation and deployments docs with explicit caller secret mappings

Issue
Closes #58

Added optional secrets:
GOOGLE_SLIDEFLOW_CREDENTIALS
DATABRICKS_HOST
DATABRICKS_HTTP_PATH
DATABRICKS_ACCESS_TOKEN

Validation
- ./.venv/bin/python -m pytest -q
- 146 passed, 1 skipped