### PR TITLE
Add DBT_GIT_TOKEN support to reusable build workflow

### DIFF
--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -95,6 +95,9 @@ on:
       DATABRICKS_ACCESS_TOKEN:
         description: "Optional Databricks access token for connector env fallback"
         required: false
+      DBT_GIT_TOKEN:
+        description: "Optional Git token for private databricks_dbt package_url clones"
+        required: false
     outputs:
       presentation-urls:
         description: "Comma-separated presentation URLs extracted from build JSON output"
@@ -120,6 +123,7 @@ jobs:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
       DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
+      DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }}
     outputs:
       presentation_urls: ${{ steps.extract_urls.outputs.presentation_urls }}
       doctor_result_json: ${{ steps.extract_json.outputs.doctor_result_json }}

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -32,6 +32,7 @@ jobs:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
       DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
+      DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }} # optional; for private databricks_dbt repos
     with:
       config-file: config/weekly_exec_report.yml
       registry-files: |
@@ -73,9 +74,19 @@ jobs:
 - `DATABRICKS_HOST`
 - `DATABRICKS_HTTP_PATH`
 - `DATABRICKS_ACCESS_TOKEN`
+- `DBT_GIT_TOKEN` (optional; used when `databricks_dbt` `package_url` includes `$DBT_GIT_TOKEN`)
 - Callers can either pass those secrets explicitly or use `secrets: inherit` if the same names exist in the caller repository/org.
 - Your Slideflow config can continue to reference environment variables as usual.
 - For Google Slides builds, ensure credentials/folder IDs used by your config are available in the caller workflow environment.
 - Prefer pinning reusable workflow references to a commit SHA in production.
+
+Example `databricks_dbt` source for a private dbt repo:
+
+```yaml
+data_source:
+  type: databricks_dbt
+  package_url: https://$DBT_GIT_TOKEN@github.com/org/private-dbt-project.git
+  model_alias: revenue_monthly
+```
 
 For deployment patterns beyond GitHub Actions, see [Deployments](deployments.md).

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -42,6 +42,7 @@ jobs:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
       DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
+      DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }} # optional; for private databricks_dbt repos
     with:
       config-file: config/weekly_exec_report.yml
       registry-files: registries/base_registry.py
@@ -65,6 +66,7 @@ Supported reusable-workflow secret mappings:
 - `DATABRICKS_HOST`
 - `DATABRICKS_HTTP_PATH`
 - `DATABRICKS_ACCESS_TOKEN`
+- `DBT_GIT_TOKEN` (optional; used when `databricks_dbt` `package_url` includes `$DBT_GIT_TOKEN`)
 
 ### Passing machine-readable outputs to downstream jobs
 
@@ -121,6 +123,15 @@ If using Databricks connectors, set:
 - `DATABRICKS_ACCESS_TOKEN`
 
 If using `databricks_dbt`, also ensure Git token env vars used in `package_url` are available.
+
+Private dbt repo example:
+
+```yaml
+data_source:
+  type: databricks_dbt
+  package_url: https://$DBT_GIT_TOKEN@github.com/org/private-dbt-project.git
+  model_alias: monthly_revenue_by_region
+```
 
 ## Cloud Run
 


### PR DESCRIPTION
## Summary
- add optional `DBT_GIT_TOKEN` secret to reusable workflow contract
- expose `DBT_GIT_TOKEN` in job env so `databricks_dbt` can clone private dbt repos
- document private dbt repo usage in automation/deployments docs

## Why
Fixes private `databricks_dbt` clone failures in reusable workflow callers where `package_url` uses env token expansion.

Fixes #60