### PR TITLE
Add DBT_ACCESS_TOKEN support in reusable workflow (fallback to DBT_GIT_TOKEN)

### DIFF
--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -98,6 +98,9 @@ on:
       DBT_GIT_TOKEN:
         description: "Optional Git token for private databricks_dbt package_url clones"
         required: false
+      DBT_ACCESS_TOKEN:
+        description: "Optional DBT access token for dbt packages that require env_var('DBT_ACCESS_TOKEN')"
+        required: false
     outputs:
       presentation-urls:
         description: "Comma-separated presentation URLs extracted from build JSON output"
@@ -124,6 +127,7 @@ jobs:
       DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
       DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }}
+      DBT_ACCESS_TOKEN: ${{ secrets.DBT_ACCESS_TOKEN || secrets.DBT_GIT_TOKEN }}
     outputs:
       presentation_urls: ${{ steps.extract_urls.outputs.presentation_urls }}
       doctor_result_json: ${{ steps.extract_json.outputs.doctor_result_json }}

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -33,6 +33,7 @@ jobs:
       DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
       DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }} # optional; for private databricks_dbt repos
+      DBT_ACCESS_TOKEN: ${{ secrets.DBT_ACCESS_TOKEN }} # optional; falls back to DBT_GIT_TOKEN in reusable workflow
     with:
       config-file: config/weekly_exec_report.yml
       registry-files: |
@@ -75,6 +76,7 @@ jobs:
 - `DATABRICKS_HTTP_PATH`
 - `DATABRICKS_ACCESS_TOKEN`
 - `DBT_GIT_TOKEN` (optional; used when `databricks_dbt` `package_url` includes `$DBT_GIT_TOKEN`)
+- `DBT_ACCESS_TOKEN` (optional; if omitted, reusable workflow falls back to `DBT_GIT_TOKEN`)
 - Callers can either pass those secrets explicitly or use `secrets: inherit` if the same names exist in the caller repository/org.
 - Your Slideflow config can continue to reference environment variables as usual.
 - For Google Slides builds, ensure credentials/folder IDs used by your config are available in the caller workflow environment.

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -43,6 +43,7 @@ jobs:
       DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
       DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }} # optional; for private databricks_dbt repos
+      DBT_ACCESS_TOKEN: ${{ secrets.DBT_ACCESS_TOKEN }} # optional; falls back to DBT_GIT_TOKEN in reusable workflow
     with:
       config-file: config/weekly_exec_report.yml
       registry-files: registries/base_registry.py
@@ -67,6 +68,7 @@ Supported reusable-workflow secret mappings:
 - `DATABRICKS_HTTP_PATH`
 - `DATABRICKS_ACCESS_TOKEN`
 - `DBT_GIT_TOKEN` (optional; used when `databricks_dbt` `package_url` includes `$DBT_GIT_TOKEN`)
+- `DBT_ACCESS_TOKEN` (optional; if omitted, reusable workflow falls back to `DBT_GIT_TOKEN`)
 
 ### Passing machine-readable outputs to downstream jobs
 


### PR DESCRIPTION
## Summary
- add optional `DBT_ACCESS_TOKEN` secret to reusable workflow contract
- export `DBT_ACCESS_TOKEN` in reusable workflow job env
- fall back to `DBT_GIT_TOKEN` when `DBT_ACCESS_TOKEN` is not explicitly provided
- update automation/deployments docs with the new optional secret and fallback behavior

## Why
After adding `DBT_GIT_TOKEN` support, callers can clone private `package_url` repos, but some dbt projects/dependencies also require `env_var('DBT_ACCESS_TOKEN')` during dbt compile/deps.

Observed failure in caller run (`joe-broadhead/signals-slides`, run `22224895058`):
- dbt dependency checkout/auth error followed by
- `Env var required but not provided: 'DBT_ACCESS_TOKEN'`

This change keeps current behavior for existing callers and unblocks dbt projects that rely on `DBT_ACCESS_TOKEN`.

## Compatibility
Backward compatible:
- callers already passing only `DBT_GIT_TOKEN` continue to work (fallback)
- callers can optionally provide a distinct `DBT_ACCESS_TOKEN` when required