### PR TITLE
Add DBT_ENV_SECRET_GIT_CREDENTIAL support to reusable workflow

### DIFF
--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -101,6 +101,9 @@ on:
       DBT_ACCESS_TOKEN:
         description: "Optional DBT access token for dbt packages that require env_var('DBT_ACCESS_TOKEN')"
         required: false
+      DBT_ENV_SECRET_GIT_CREDENTIAL:
+        description: "Optional git credential for dbt deps private package clones"
+        required: false
     outputs:
       presentation-urls:
         description: "Comma-separated presentation URLs extracted from build JSON output"
@@ -128,6 +131,7 @@ jobs:
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
       DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }}
       DBT_ACCESS_TOKEN: ${{ secrets.DBT_ACCESS_TOKEN || secrets.DBT_GIT_TOKEN }}
+      DBT_ENV_SECRET_GIT_CREDENTIAL: ${{ secrets.DBT_ENV_SECRET_GIT_CREDENTIAL || secrets.DBT_ACCESS_TOKEN || secrets.DBT_GIT_TOKEN }}
     outputs:
       presentation_urls: ${{ steps.extract_urls.outputs.presentation_urls }}
       doctor_result_json: ${{ steps.extract_json.outputs.doctor_result_json }}

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -34,6 +34,7 @@ jobs:
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
       DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }} # optional; for private databricks_dbt repos
       DBT_ACCESS_TOKEN: ${{ secrets.DBT_ACCESS_TOKEN }} # optional; falls back to DBT_GIT_TOKEN in reusable workflow
+      DBT_ENV_SECRET_GIT_CREDENTIAL: ${{ secrets.DBT_ENV_SECRET_GIT_CREDENTIAL }} # optional; falls back to DBT_ACCESS_TOKEN, then DBT_GIT_TOKEN
     with:
       config-file: config/weekly_exec_report.yml
       registry-files: |
@@ -77,6 +78,7 @@ jobs:
 - `DATABRICKS_ACCESS_TOKEN`
 - `DBT_GIT_TOKEN` (optional; used when `databricks_dbt` `package_url` includes `$DBT_GIT_TOKEN`)
 - `DBT_ACCESS_TOKEN` (optional; if omitted, reusable workflow falls back to `DBT_GIT_TOKEN`)
+- `DBT_ENV_SECRET_GIT_CREDENTIAL` (optional; if omitted, reusable workflow falls back to `DBT_ACCESS_TOKEN`, then `DBT_GIT_TOKEN`)
 - Callers can either pass those secrets explicitly or use `secrets: inherit` if the same names exist in the caller repository/org.
 - Your Slideflow config can continue to reference environment variables as usual.
 - For Google Slides builds, ensure credentials/folder IDs used by your config are available in the caller workflow environment.
@@ -90,5 +92,7 @@ data_source:
   package_url: https://$DBT_GIT_TOKEN@github.com/org/private-dbt-project.git
   model_alias: revenue_monthly
 ```
+
+If your dbt dependencies use `env_var('DBT_ENV_SECRET_GIT_CREDENTIAL')`, pass `DBT_ENV_SECRET_GIT_CREDENTIAL` as an optional secret (or rely on fallback to `DBT_ACCESS_TOKEN` / `DBT_GIT_TOKEN`).
 
 For deployment patterns beyond GitHub Actions, see [Deployments](deployments.md).

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -44,6 +44,7 @@ jobs:
       DATABRICKS_ACCESS_TOKEN: ${{ secrets.DATABRICKS_ACCESS_TOKEN }}
       DBT_GIT_TOKEN: ${{ secrets.DBT_GIT_TOKEN }} # optional; for private databricks_dbt repos
       DBT_ACCESS_TOKEN: ${{ secrets.DBT_ACCESS_TOKEN }} # optional; falls back to DBT_GIT_TOKEN in reusable workflow
+      DBT_ENV_SECRET_GIT_CREDENTIAL: ${{ secrets.DBT_ENV_SECRET_GIT_CREDENTIAL }} # optional; falls back to DBT_ACCESS_TOKEN, then DBT_GIT_TOKEN
     with:
       config-file: config/weekly_exec_report.yml
       registry-files: registries/base_registry.py
@@ -69,6 +70,7 @@ Supported reusable-workflow secret mappings:
 - `DATABRICKS_ACCESS_TOKEN`
 - `DBT_GIT_TOKEN` (optional; used when `databricks_dbt` `package_url` includes `$DBT_GIT_TOKEN`)
 - `DBT_ACCESS_TOKEN` (optional; if omitted, reusable workflow falls back to `DBT_GIT_TOKEN`)
+- `DBT_ENV_SECRET_GIT_CREDENTIAL` (optional; if omitted, reusable workflow falls back to `DBT_ACCESS_TOKEN`, then `DBT_GIT_TOKEN`)
 
 ### Passing machine-readable outputs to downstream jobs
 
@@ -124,7 +126,8 @@ If using Databricks connectors, set:
 - `DATABRICKS_HTTP_PATH`
 - `DATABRICKS_ACCESS_TOKEN`
 
-If using `databricks_dbt`, also ensure Git token env vars used in `package_url` are available.
+If using `databricks_dbt`, also ensure Git token env vars used in `package_url` are available.  
+If your dbt packages rely on `env_var('DBT_ENV_SECRET_GIT_CREDENTIAL')`, set `DBT_ENV_SECRET_GIT_CREDENTIAL` (or rely on the reusable-workflow fallback chain).
 
 Private dbt repo example:
 


### PR DESCRIPTION
## Summary
- add optional `DBT_ENV_SECRET_GIT_CREDENTIAL` secret to reusable workflow contract
- export `DBT_ENV_SECRET_GIT_CREDENTIAL` in reusable workflow job env
- apply fallback order: `DBT_ENV_SECRET_GIT_CREDENTIAL -> DBT_ACCESS_TOKEN -> DBT_GIT_TOKEN`
- update reusable-workflow docs with the new optional secret and fallback behavior

## Why
Some dbt projects/dependencies rely on `env_var('DBT_ENV_SECRET_GIT_CREDENTIAL')` during `dbt deps`.

This makes the reusable workflow compatible with that standard env var while preserving current behavior.

Fixes #63