### PR TITLE
Fix empty-data table refs and NaN color handling

### DIFF
--- a/slideflow/builtins/table_utils.py
+++ b/slideflow/builtins/table_utils.py
@@ -182,7 +182,10 @@ def growth_color_function(value: Any) -> str:
         - Handles type conversion errors gracefully
     """
     try:
-        return "#28a745" if float(value) >= 0 else "#dc3545"
+        numeric_value = float(value)
+        if pd.isna(numeric_value):
+            return "black"
+        return "#28a745" if numeric_value >= 0 else "#dc3545"
     except (ValueError, TypeError):
         return "black"
 
@@ -234,7 +237,10 @@ def performance_color_function(value: Any, threshold: float = 0.0) -> str:
         - Can be partially applied for use with create_dynamic_colors
     """
     try:
-        return "#28a745" if float(value) >= threshold else "#dc3545"
+        numeric_value = float(value)
+        if pd.isna(numeric_value):
+            return "black"
+        return "#28a745" if numeric_value >= threshold else "#dc3545"
     except (ValueError, TypeError):
         return "black"
 
@@ -298,6 +304,8 @@ def create_traffic_light_colors(
     """
     try:
         val = float(value)
+        if pd.isna(val):
+            return "black"
         if val >= good_threshold:
             return "#28a745"  # Green
         elif val >= warning_threshold:

--- a/slideflow/presentations/charts.py
+++ b/slideflow/presentations/charts.py
@@ -690,7 +690,8 @@ class PlotlyGraphObjects(BaseChart):
             config: Trace configuration dictionary that may contain column
                 references in the format '$column_name'.
             df: DataFrame containing the data columns. May be empty for static
-                charts, in which case column references are skipped.
+                charts, in which case direct column references are skipped and
+                list-based references are replaced with empty values.
 
         Returns:
             Processed configuration with column references replaced by actual
@@ -770,26 +771,38 @@ class PlotlyGraphObjects(BaseChart):
                 for item in value:
                     if isinstance(item, str):
                         match = list_column_ref_pattern.match(item)
-                        if match and has_rows and match.group(1) in df.columns:
-                            # Valid column reference
-                            series_values = df[match.group(1)]
-                            values = (
-                                series_values.tolist()
-                                if hasattr(series_values, "tolist")
-                                else list(series_values)
-                            )
+                        if match:
+                            list_column_name = match.group(1)
                             list_index_token = match.group(2)
-                            if list_index_token is None:
-                                processed_list.append(values)
+
+                            if has_rows and list_column_name in df.columns:
+                                # Valid column reference
+                                series_values = df[list_column_name]
+                                values = (
+                                    series_values.tolist()
+                                    if hasattr(series_values, "tolist")
+                                    else list(series_values)
+                                )
+                                if list_index_token is None:
+                                    processed_list.append(values)
+                                else:
+                                    index_value = int(list_index_token)
+                                    try:
+                                        processed_list.append(values[index_value])
+                                    except IndexError as exc:
+                                        raise ChartGenerationError(
+                                            f"Index {index_value} out of range for column '{list_column_name}' "
+                                            f"with {len(values)} row(s)."
+                                        ) from exc
+                            elif not has_rows:
+                                # Preserve list structure for Plotly table configs.
+                                if list_index_token is None:
+                                    processed_list.append([])
+                                else:
+                                    processed_list.append(None)
                             else:
-                                index_value = int(list_index_token)
-                                try:
-                                    processed_list.append(values[index_value])
-                                except IndexError as exc:
-                                    raise ChartGenerationError(
-                                        f"Index {index_value} out of range for column '{match.group(1)}' "
-                                        f"with {len(values)} row(s)."
-                                    ) from exc
+                                # Not a resolvable column reference for this DataFrame.
+                                processed_list.append(item)
                         else:
                             # Not a column reference or column doesn't exist
                             processed_list.append(item)

--- a/tests/test_builtins_utilities.py
+++ b/tests/test_builtins_utilities.py
@@ -127,10 +127,12 @@ def test_color_and_table_helpers_generate_expected_color_maps(monkeypatch):
     assert growth_color_function(0) == "#28a745"
     assert growth_color_function(-0.1) == "#dc3545"
     assert growth_color_function("bad") == "black"
+    assert growth_color_function(float("nan")) == "black"
 
     assert performance_color_function(100, threshold=80) == "#28a745"
     assert performance_color_function(79.9, threshold=80) == "#dc3545"
     assert performance_color_function(None, threshold=80) == "black"
+    assert performance_color_function(float("nan"), threshold=80) == "black"
 
     assert (
         create_traffic_light_colors(90, good_threshold=80, warning_threshold=60)
@@ -146,6 +148,12 @@ def test_color_and_table_helpers_generate_expected_color_maps(monkeypatch):
     )
     assert (
         create_traffic_light_colors("x", good_threshold=80, warning_threshold=60)
+        == "black"
+    )
+    assert (
+        create_traffic_light_colors(
+            float("nan"), good_threshold=80, warning_threshold=60
+        )
         == "black"
     )
 

--- a/tests/test_plotly_chart_processing.py
+++ b/tests/test_plotly_chart_processing.py
@@ -48,6 +48,28 @@ def test_process_trace_config_column_reference_index_out_of_range_raises():
         chart._process_trace_config({"value": "$metric[3]"}, df)
 
 
+def test_process_trace_config_empty_df_replaces_list_column_refs_with_empty_values():
+    chart = _chart()
+    df = pd.DataFrame(
+        {"metric_a": [], "metric_b": [], "_color_col_0": [], "_color_col_1": []}
+    )
+
+    processed = chart._process_trace_config(
+        {
+            "cells": {
+                "values": ["$metric_a", "$metric_b"],
+                "font": {"color": ["$_color_col_0", "$_color_col_1"]},
+                "meta": ["$metric_a[0]"],
+            }
+        },
+        df,
+    )
+
+    assert processed["cells"]["values"] == [[], []]
+    assert processed["cells"]["font"]["color"] == [[], []]
+    assert processed["cells"]["meta"] == [None]
+
+
 class _FakeFigure:
     def to_plotly_json(self):
         return {"data": [], "layout": {}}


### PR DESCRIPTION
## Summary
- fix `PlotlyGraphObjects._process_trace_config` so list-based column references resolve safely when the dataframe is empty
- preserve list structure for table configs by converting empty-data refs to `[]` (and indexed refs to `None`) instead of leaving raw `$column` tokens
- fix color helpers so `NaN` values return `black` (matching function docs) instead of being treated as negative/red

## Why
Some table/chart configs rely on dynamic columns such as `$_color_col_*`. When a transform returns an empty dataframe, unresolved list refs can leak into Plotly config and cause rendering failures. Also, growth/performance color helpers currently color `NaN` as red, which is incorrect and inconsistent with documented behavior.

## Changes
- `slideflow/presentations/charts.py`
  - updated list processing in `_process_trace_config` for empty dataframes
- `slideflow/builtins/table_utils.py`
  - `growth_color_function`, `performance_color_function`, and `create_traffic_light_colors` now treat `NaN` as `black`
- `tests/test_plotly_chart_processing.py`
  - added coverage for empty-data list refs in nested table config
- `tests/test_builtins_utilities.py`
  - added `NaN` expectations for all three color helper paths

## Validation
- `PYTHONPATH=/private/tmp/slideflow-pr-color-fix pytest -q tests/test_plotly_chart_processing.py tests/test_builtins_utilities.py`
- Result: `11 passed`
