### PR TITLE
test: harden runtime coverage for charts and Google provider

### DIFF
--- a/tests/test_charts_coverage_runtime.py
+++ b/tests/test_charts_coverage_runtime.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+from concurrent.futures import TimeoutError
+from types import SimpleNamespace
+from typing import Any, Dict, List, Literal, Optional
+
+import pandas as pd
+import pytest
+
+import slideflow.presentations.charts as charts_module
+from slideflow.constants import GoogleSlides
+from slideflow.utilities.exceptions import ChartGenerationError
+
+
+class _MinimalChart(charts_module.BaseChart):
+    type: Literal["minimal"] = "minimal"
+
+    def generate_chart_image(self, df: pd.DataFrame) -> bytes:
+        return b"image-bytes"
+
+
+def test_reset_chart_export_executor_terminates_processes_and_shutdowns():
+    class _Process:
+        def __init__(self) -> None:
+            self.terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+    class _Executor:
+        def __init__(self) -> None:
+            self._processes = {"a": _Process(), "b": _Process()}
+            self.shutdown_calls: List[Dict[str, Any]] = []
+
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+    executor = _Executor()
+    charts_module._CHART_EXPORT_EXECUTOR = executor
+
+    charts_module._reset_chart_export_executor()
+
+    assert charts_module._CHART_EXPORT_EXECUTOR is None
+    assert all(process.terminated for process in executor._processes.values())
+    assert executor.shutdown_calls == [{"wait": False, "cancel_futures": True}]
+
+
+def test_reset_chart_export_executor_handles_terminate_and_shutdown_errors():
+    class _Process:
+        def terminate(self) -> None:
+            raise RuntimeError("terminate failed")
+
+    class _Executor:
+        _processes = {"bad": _Process()}
+
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            raise RuntimeError("shutdown failed")
+
+    charts_module._CHART_EXPORT_EXECUTOR = _Executor()
+
+    charts_module._reset_chart_export_executor()
+
+    assert charts_module._CHART_EXPORT_EXECUTOR is None
+
+
+def test_execute_with_retry_timeout_then_success(monkeypatch):
+    class _FutureTimeout:
+        def result(self, timeout: int) -> bytes:
+            raise TimeoutError()
+
+    class _FutureSuccess:
+        def result(self, timeout: int) -> bytes:
+            return b"ok"
+
+    class _Executor:
+        def __init__(self, future: Any) -> None:
+            self._future = future
+
+        def submit(self, func, *args, **kwargs):
+            return self._future
+
+    executors = iter([_Executor(_FutureTimeout()), _Executor(_FutureSuccess())])
+    reset_calls: List[bool] = []
+    monkeypatch.setattr(
+        charts_module, "_get_chart_export_executor", lambda: next(executors)
+    )
+    monkeypatch.setattr(
+        charts_module, "_reset_chart_export_executor", lambda: reset_calls.append(True)
+    )
+
+    result = charts_module._execute_with_retry(lambda: b"unused")
+
+    assert result == b"ok"
+    assert reset_calls == [True]
+
+
+def test_execute_with_retry_resets_and_reraises_non_timeout(monkeypatch):
+    class _FutureError:
+        def result(self, timeout: int) -> bytes:
+            raise RuntimeError("boom")
+
+    class _Executor:
+        def submit(self, func, *args, **kwargs):
+            return _FutureError()
+
+    reset_calls: List[bool] = []
+    monkeypatch.setattr(
+        charts_module, "_get_chart_export_executor", lambda: _Executor()
+    )
+    monkeypatch.setattr(
+        charts_module, "_reset_chart_export_executor", lambda: reset_calls.append(True)
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        charts_module._execute_with_retry(lambda: b"unused")
+
+    assert reset_calls == [True]
+
+
+def test_execute_with_retry_raises_after_all_timeouts(monkeypatch):
+    class _FutureTimeout:
+        def result(self, timeout: int) -> bytes:
+            raise TimeoutError()
+
+    class _Executor:
+        def submit(self, func, *args, **kwargs):
+            return _FutureTimeout()
+
+    reset_calls: List[bool] = []
+    monkeypatch.setattr(
+        charts_module, "_get_chart_export_executor", lambda: _Executor()
+    )
+    monkeypatch.setattr(
+        charts_module, "_reset_chart_export_executor", lambda: reset_calls.append(True)
+    )
+
+    with pytest.raises(ChartGenerationError, match="failed after all retries"):
+        charts_module._execute_with_retry(lambda: b"unused")
+
+    assert reset_calls == [True, True, True]
+
+
+def test_plotly_to_image_without_scale_omits_scale_option(monkeypatch):
+    calls: Dict[str, Any] = {}
+
+    class _FakeFigure:
+        def to_plotly_json(self):
+            return {"data": [], "layout": {}}
+
+    class _Kaleido:
+        @staticmethod
+        def start_sync_server(**kwargs):
+            calls["server_kwargs"] = kwargs
+
+        @staticmethod
+        def calc_fig_sync(fig_json, opts=None):
+            calls["fig_json"] = fig_json
+            calls["opts"] = opts
+            return b"ok"
+
+    monkeypatch.setitem(__import__("sys").modules, "kaleido", _Kaleido)
+
+    rendered = charts_module._plotly_to_image(_FakeFigure(), "png", 200, 100, None)
+
+    assert rendered == b"ok"
+    assert calls["opts"] == {"format": "png", "width": 200, "height": 100}
+
+
+def test_base_chart_validation_fetch_transform_and_upload(monkeypatch):
+    chart = _MinimalChart(type="minimal", title="My Chart")
+
+    with pytest.raises(ChartGenerationError, match="dimensions_format must be"):
+        _MinimalChart(type="minimal", dimensions_format="pixels")
+    with pytest.raises(ChartGenerationError, match="horizontal-vertical"):
+        _MinimalChart(type="minimal", alignment_format="center")
+    with pytest.raises(ChartGenerationError, match="horizontal alignment must be"):
+        _MinimalChart(type="minimal", alignment_format="middle-top")
+    with pytest.raises(ChartGenerationError, match="vertical alignment must be"):
+        _MinimalChart(type="minimal", alignment_format="left-middle")
+
+    class _Source:
+        def fetch_data(self):
+            return pd.DataFrame({"x": [1]})
+
+    chart.data_source = _Source()  # type: ignore[assignment]
+    fetched = chart.fetch_data()
+    assert isinstance(fetched, pd.DataFrame)
+    assert list(fetched["x"]) == [1]
+
+    monkeypatch.setattr(
+        charts_module,
+        "apply_data_transforms",
+        lambda transforms, df: pd.DataFrame({"x": [1], "y": [2]}),
+    )
+    transformed = chart.apply_data_transforms(pd.DataFrame({"x": [1]}))
+    assert list(transformed["y"]) == [2]
+
+    wait_calls: List[int] = []
+
+    class _Limiter:
+        def wait(self) -> None:
+            wait_calls.append(1)
+
+    monkeypatch.setattr(charts_module, "_get_rate_limiter", lambda _rps: _Limiter())
+    monkeypatch.setattr(charts_module.uuid, "uuid4", lambda: type("U", (), {"hex": "abc12345dead"})())  # type: ignore[misc]
+
+    class _Request:
+        def __init__(self, response: Dict[str, Any]) -> None:
+            self.response = response
+            self.retries: List[Optional[int]] = []
+
+        def execute(self, num_retries: Optional[int] = None):
+            self.retries.append(num_retries)
+            return self.response
+
+    file_create_request = _Request({"id": "file-1"})
+    permission_request = _Request({})
+
+    class _Files:
+        def __init__(self) -> None:
+            self.create_calls: List[Dict[str, Any]] = []
+
+        def create(self, **kwargs):
+            self.create_calls.append(kwargs)
+            return file_create_request
+
+    class _Permissions:
+        def __init__(self) -> None:
+            self.create_calls: List[Dict[str, Any]] = []
+
+        def create(self, **kwargs):
+            self.create_calls.append(kwargs)
+            return permission_request
+
+    files_api = _Files()
+    permissions_api = _Permissions()
+    drive_service = type(
+        "DriveService",
+        (),
+        {
+            "files": lambda self: files_api,
+            "permissions": lambda self: permissions_api,
+        },
+    )()
+
+    public_url, file_id = chart._upload_to_drive(b"bytes", drive_service)
+
+    assert public_url == "https://drive.google.com/uc?id=file-1"
+    assert file_id == "file-1"
+    assert file_create_request.retries == [3]
+    assert permission_request.retries == [3]
+    assert len(wait_calls) == 2
+
+
+def test_generate_public_url_uses_empty_dataframe_when_no_source(monkeypatch):
+    class _ObservedChart(_MinimalChart):
+        seen_df: Optional[pd.DataFrame] = None
+
+        def generate_chart_image(self, df: pd.DataFrame) -> bytes:
+            self.seen_df = df
+            return b"img"
+
+    chart = _ObservedChart(type="minimal", title="Observed")
+    monkeypatch.setattr(chart, "_upload_to_drive", lambda image, _svc: ("url", "fid"))
+
+    url, file_id = chart.generate_public_url(drive_service=object())
+
+    assert (url, file_id) == ("url", "fid")
+    assert isinstance(chart.seen_df, pd.DataFrame)
+    assert len(chart.seen_df) == 0
+
+
+def test_plotly_generate_chart_image_evaluates_expressions_and_scale(monkeypatch):
+    trace_calls: List[Dict[str, Any]] = []
+    layout_calls: List[Dict[str, Any]] = []
+    retry_calls: List[Any] = []
+
+    class _FakeTrace:
+        def __init__(self, **kwargs) -> None:
+            trace_calls.append(kwargs)
+
+    class _FakeFigure:
+        def add_trace(self, trace) -> None:
+            return None
+
+        def update_layout(self, **kwargs) -> None:
+            layout_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        charts_module,
+        "go",
+        type("GO", (), {"Figure": _FakeFigure, "Bar": _FakeTrace}),
+    )
+    monkeypatch.setattr(charts_module, "safe_eval_expression", lambda expr: 150 if "width" in expr else 90)  # type: ignore[arg-type]
+    monkeypatch.setattr(
+        charts_module,
+        "_execute_with_retry",
+        lambda func, fig, fmt, width, height, scale: retry_calls.append(
+            (func, fmt, width, height, scale)
+        )
+        or b"rendered",
+    )
+
+    chart = charts_module.PlotlyGraphObjects(
+        type="plotly_go",
+        title="Demo",
+        width="width_expr",
+        height="height_expr",
+        traces=[{"type": "bar", "x": [1], "y": [2]}],
+        layout_config={"showlegend": False},
+        scale=1.5,
+    )
+
+    rendered = chart.generate_chart_image(pd.DataFrame())
+
+    expected_width = int(150 * GoogleSlides.POINTS_TO_PIXELS_RATIO)
+    expected_height = int(90 * GoogleSlides.POINTS_TO_PIXELS_RATIO)
+
+    assert rendered == b"rendered"
+    assert trace_calls == [{"x": [1], "y": [2]}]
+    assert {"showlegend": False} in layout_calls
+    assert any(call.get("title") == "Demo" for call in layout_calls)
+    assert retry_calls[0][1:] == ("png", expected_width, expected_height, 1.5)
+
+
+def test_plotly_trace_config_invalid_index_token_raises_missing_column():
+    chart = charts_module.PlotlyGraphObjects(type="plotly_go", traces=[])
+    df = pd.DataFrame({"metric": [1, 2]})
+
+    with pytest.raises(
+        ChartGenerationError, match="Column 'metric\\[bad\\]' not found"
+    ):
+        chart._process_trace_config({"value": "$metric[bad]"}, df)
+
+
+def test_custom_chart_process_config_and_generate(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    def _chart_fn(df: pd.DataFrame, config: Dict[str, Any], _chart) -> bytes:
+        captured["df_columns"] = list(df.columns)
+        captured["config"] = config
+        return b"custom-bytes"
+
+    chart = charts_module.CustomChart(
+        type="custom",
+        title="Custom Title",
+        chart_fn=_chart_fn,
+        chart_config={
+            "series": "$value",
+            "nested": {"inner": "$value"},
+            "labels": ["$value", "literal"],
+        },
+    )
+
+    output = chart.generate_chart_image(pd.DataFrame({"value": [10, 20]}))
+
+    assert output == b"custom-bytes"
+    assert captured["df_columns"] == ["value"]
+    assert list(captured["config"]["series"]) == [10, 20]
+    assert list(captured["config"]["nested"]["inner"]) == [10, 20]
+    assert list(captured["config"]["labels"][0]) == [10, 20]
+    assert captured["config"]["labels"][1] == "literal"
+    assert captured["config"]["title"] == "Custom Title"
+
+
+def test_custom_chart_process_config_missing_column_raises():
+    chart = charts_module.CustomChart(
+        type="custom", chart_fn=lambda *_: b"", chart_config={}
+    )
+    fake_df = SimpleNamespace(columns=["x"], empty=False, shape=(1, 1))
+
+    with pytest.raises(ChartGenerationError, match="Column 'missing' not found"):
+        chart._process_config({"value": "$missing"}, fake_df)
+
+
+def test_template_chart_renders_and_combines_transforms(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    class _Engine:
+        def render_template(self, template_name: str, template_config: Dict[str, Any]):
+            captured["template_name"] = template_name
+            captured["template_config"] = template_config
+            return {
+                "traces": [{"type": "bar", "x": [1], "y": [2]}],
+                "layout_config": {"showlegend": False},
+                "data_transforms": [{"type": "template_transform"}],
+            }
+
+    class _FakePlotlyChart:
+        def __init__(self, **kwargs):
+            captured["plotly_kwargs"] = kwargs
+
+        def generate_chart_image(self, df: pd.DataFrame) -> bytes:
+            captured["df_rows"] = len(df)
+            captured["df_columns"] = list(df.columns)
+            return b"template-bytes"
+
+    monkeypatch.setattr(charts_module, "get_template_engine", lambda: _Engine())
+    monkeypatch.setattr(charts_module, "PlotlyGraphObjects", _FakePlotlyChart)
+
+    chart = charts_module.TemplateChart(
+        type="template",
+        title="Template Title",
+        template_name="my_template",
+        template_config={"region": "EU"},
+        data_transforms=[{"type": "user_transform"}],
+        width=420,
+        height=315,
+        x=10,
+        y=20,
+    )
+
+    output = chart.generate_chart_image(pd.DataFrame({"a": [1]}))
+
+    assert output == b"template-bytes"
+    assert captured["template_name"] == "my_template"
+    assert captured["template_config"] == {"region": "EU"}
+    assert captured["plotly_kwargs"]["title"] == "Template Title"
+    assert captured["plotly_kwargs"]["traces"] == [{"type": "bar", "x": [1], "y": [2]}]
+    assert captured["plotly_kwargs"]["data_transforms"] == [
+        {"type": "user_transform"},
+        {"type": "template_transform"},
+    ]
+    assert captured["df_rows"] == 1
+    assert captured["df_columns"] == ["a"]

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+import slideflow.presentations.providers.google_slides as google_provider_module
+from slideflow.presentations.providers.google_slides import (
+    GoogleSlidesProvider,
+    GoogleSlidesProviderConfig,
+)
+from slideflow.utilities.exceptions import AuthenticationError
+
+
+def _provider_without_init() -> GoogleSlidesProvider:
+    return object.__new__(google_provider_module.GoogleSlidesProvider)
+
+
+def _http_error(
+    message: str, status: Optional[int] = None, content: Optional[bytes] = None
+):
+    error = google_provider_module.HttpError(message)
+    if status is not None:
+        error.resp = SimpleNamespace(status=status)
+    if content is not None:
+        error.content = content
+    return error
+
+
+def test_google_provider_init_success(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        google_provider_module,
+        "handle_google_credentials",
+        lambda _credentials: {"client_email": "svc@example.com"},
+    )
+    monkeypatch.setattr(
+        google_provider_module.Credentials,
+        "from_service_account_info",
+        lambda info, scopes: captured.update({"info": info, "scopes": scopes})
+        or "creds",
+    )
+    monkeypatch.setattr(
+        google_provider_module,
+        "build",
+        lambda service, version, credentials: f"{service}:{version}:{credentials}",
+    )
+    monkeypatch.setattr(
+        google_provider_module, "_get_rate_limiter", lambda rps: f"rl:{rps}"
+    )
+
+    provider = GoogleSlidesProvider(
+        GoogleSlidesProviderConfig(
+            credentials='{"type":"service_account"}', requests_per_second=2.5
+        )
+    )
+
+    assert provider.slides_service == "slides:v1:creds"
+    assert provider.drive_service == "drive:v3:creds"
+    assert provider.rate_limiter == "rl:2.5"
+    assert captured["info"] == {"client_email": "svc@example.com"}
+    assert captured["scopes"] == google_provider_module.GoogleSlidesProvider.SCOPES
+
+
+def test_google_provider_init_authentication_failure(monkeypatch):
+    monkeypatch.setattr(
+        google_provider_module,
+        "handle_google_credentials",
+        lambda _credentials: {"invalid": True},
+    )
+    monkeypatch.setattr(
+        google_provider_module.Credentials,
+        "from_service_account_info",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad creds")),
+    )
+
+    with pytest.raises(AuthenticationError, match="Credentials authentication failed"):
+        GoogleSlidesProvider(GoogleSlidesProviderConfig(credentials='{"invalid":true}'))
+
+
+@pytest.mark.parametrize(
+    ("dimension", "expected"),
+    [
+        (None, None),
+        ({}, None),
+        ({"magnitude": "bad", "unit": "PT"}, None),
+        ({"magnitude": 12700, "unit": "EMU"}, 1),
+        ({"magnitude": 20, "unit": "PT"}, 20),
+        ({"magnitude": 20, "unit": "PX"}, None),
+    ],
+)
+def test_dimension_to_points_variants(dimension, expected):
+    assert (
+        google_provider_module.GoogleSlidesProvider._dimension_to_points(dimension)
+        == expected
+    )
+
+
+def test_run_preflight_checks_without_credentials(monkeypatch):
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace(credentials=None, requests_per_second=1.0)
+    provider.slides_service = None
+    provider.drive_service = None
+    provider.rate_limiter = None
+    monkeypatch.delenv("GOOGLE_SLIDEFLOW_CREDENTIALS", raising=False)
+
+    checks = provider.run_preflight_checks()
+    check_map = {name: ok for name, ok, _ in checks}
+
+    assert check_map["google_credentials_present"] is False
+    assert check_map["slides_service_initialized"] is False
+    assert check_map["drive_service_initialized"] is False
+    assert check_map["rate_limiter_initialized"] is False
+
+
+def test_share_presentation_success_and_error(monkeypatch):
+    provider = _provider_without_init()
+    requests: List[Any] = []
+    created_permissions: List[Dict[str, Any]] = []
+
+    class _Permissions:
+        def create(self, **kwargs):
+            created_permissions.append(kwargs)
+            return ("permission-create", kwargs)
+
+    provider.drive_service = SimpleNamespace(permissions=lambda: _Permissions())
+
+    def _exec(request):
+        requests.append(request)
+        return {}
+
+    provider._execute_request = _exec
+
+    provider.share_presentation(
+        "pres-1", ["a@example.com", "b@example.com"], role="reader"
+    )
+
+    assert len(requests) == 2
+    assert created_permissions[0]["fileId"] == "pres-1"
+    assert created_permissions[0]["body"]["emailAddress"] == "a@example.com"
+
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(
+        _http_error("share failed")
+    )
+
+    with pytest.raises(google_provider_module.HttpError):
+        provider.share_presentation("pres-2", ["x@example.com"], role="writer")
+
+
+def test_get_presentation_page_size_logs_failure_on_exception(monkeypatch):
+    provider = _provider_without_init()
+    provider.slides_service = SimpleNamespace(
+        presentations=lambda: SimpleNamespace(
+            get=lambda **_kwargs: ("get-page-size", None)
+        )
+    )
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(
+        RuntimeError("api down")
+    )
+
+    logs: List[Tuple[Tuple[Any, ...], Dict[str, Any]]] = []
+    monkeypatch.setattr(
+        google_provider_module, "log_api_operation", lambda *a, **k: logs.append((a, k))
+    )
+
+    assert provider.get_presentation_page_size("pres-1") is None
+    assert logs and logs[-1][1]["success"] is False
+
+
+def test_get_or_create_destination_folder_paths(monkeypatch):
+    provider = _provider_without_init()
+    google_provider_module._folder_id_cache.clear()
+
+    provider.config = SimpleNamespace(
+        presentation_folder_id=None,
+        new_folder_name="child",
+        new_folder_name_fn=None,
+    )
+    assert provider._get_or_create_destination_folder() is None
+
+    provider.config = SimpleNamespace(
+        presentation_folder_id="parent-1",
+        new_folder_name="child",
+        new_folder_name_fn=None,
+    )
+    google_provider_module._folder_id_cache[("parent-1", "child")] = "cached-folder"
+    assert provider._get_or_create_destination_folder() == "cached-folder"
+
+    google_provider_module._folder_id_cache.clear()
+    files_api = SimpleNamespace(
+        list=lambda **kwargs: ("list", kwargs),
+        create=lambda **kwargs: ("create", kwargs),
+    )
+    provider.drive_service = SimpleNamespace(files=lambda: files_api)
+
+    provider._execute_request = lambda request: (
+        {"files": [{"id": "existing-folder"}]} if request[0] == "list" else {}
+    )
+    assert provider._get_or_create_destination_folder() == "existing-folder"
+
+    google_provider_module._folder_id_cache.clear()
+    provider._execute_request = lambda request: (
+        {"files": []} if request[0] == "list" else {"id": "created-folder"}
+    )
+    assert provider._get_or_create_destination_folder() == "created-folder"
+
+    google_provider_module._folder_id_cache.clear()
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(
+        _http_error("folder lookup failed")
+    )
+    assert provider._get_or_create_destination_folder() == "parent-1"
+
+
+def test_create_presentation_success_move_warning_and_failure(monkeypatch):
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace()
+
+    calls: List[Any] = []
+    provider.slides_service = SimpleNamespace(
+        presentations=lambda: SimpleNamespace(
+            create=lambda **kwargs: ("slides-create", kwargs)
+        )
+    )
+    provider.drive_service = SimpleNamespace(
+        files=lambda: SimpleNamespace(
+            get=lambda **kwargs: ("drive-get", kwargs),
+            update=lambda **kwargs: ("drive-update", kwargs),
+        )
+    )
+
+    provider._get_or_create_destination_folder = lambda: None
+    provider._execute_request = lambda request: (
+        {"presentationId": "pres-1"} if request[0] == "slides-create" else {}
+    )
+    log_calls: List[Tuple[Tuple[Any, ...], Dict[str, Any]]] = []
+    monkeypatch.setattr(
+        google_provider_module,
+        "log_api_operation",
+        lambda *a, **k: log_calls.append((a, k)),
+    )
+    assert provider._create_presentation("Deck A") == "pres-1"
+    assert log_calls[-1][1]["presentation_id"] == "pres-1"
+
+    provider._get_or_create_destination_folder = lambda: "folder-1"
+
+    def _exec_success(request):
+        calls.append(request)
+        if request[0] == "slides-create":
+            return {"presentationId": "pres-2"}
+        if request[0] == "drive-get":
+            return {"parents": ["old-parent"]}
+        if request[0] == "drive-update":
+            return {"id": "pres-2"}
+        return {}
+
+    provider._execute_request = _exec_success
+    assert provider._create_presentation("Deck B") == "pres-2"
+    drive_update_call = [c for c in calls if c[0] == "drive-update"][0][1]
+    assert drive_update_call["removeParents"] == "old-parent"
+
+    def _exec_move_fails(request):
+        if request[0] == "slides-create":
+            return {"presentationId": "pres-3"}
+        if request[0] == "drive-get":
+            return {"parents": ["old-parent"]}
+        if request[0] == "drive-update":
+            raise _http_error("move failed")
+        return {}
+
+    provider._execute_request = _exec_move_fails
+    assert provider._create_presentation("Deck C") == "pres-3"
+
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(
+        _http_error("create failed")
+    )
+    with pytest.raises(google_provider_module.HttpError):
+        provider._create_presentation("Deck D")
+
+
+def test_copy_template_success_and_error():
+    provider = _provider_without_init()
+    provider.drive_service = SimpleNamespace(
+        files=lambda: SimpleNamespace(copy=lambda **kwargs: ("drive-copy", kwargs))
+    )
+
+    provider._get_or_create_destination_folder = lambda: "folder-1"
+    provider._execute_request = lambda request: {"id": "copied-1"}
+    assert provider._copy_template("template-1", "Deck 1") == "copied-1"
+
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(
+        _http_error("copy failed")
+    )
+    with pytest.raises(google_provider_module.HttpError):
+        provider._copy_template("template-2", "Deck 2")
+
+
+def test_upload_image_to_drive_success_and_error(monkeypatch):
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace(drive_folder_id=None)
+    provider._get_or_create_destination_folder = lambda: "folder-1"
+
+    provider.drive_service = SimpleNamespace(
+        files=lambda: SimpleNamespace(create=lambda **kwargs: ("files-create", kwargs)),
+        permissions=lambda: SimpleNamespace(
+            create=lambda **kwargs: ("perm-create", kwargs)
+        ),
+    )
+
+    logs: List[Tuple[Tuple[Any, ...], Dict[str, Any]]] = []
+    monkeypatch.setattr(
+        google_provider_module, "log_api_operation", lambda *a, **k: logs.append((a, k))
+    )
+    monkeypatch.setattr(google_provider_module.time, "sleep", lambda _seconds: None)
+
+    provider._execute_request = lambda request: (
+        {"id": "file-123"} if request[0] == "files-create" else {}
+    )
+    public_url, file_id = provider._upload_image_to_drive(b"png-bytes", "chart.png")
+    assert public_url == "https://drive.google.com/uc?id=file-123"
+    assert file_id == "file-123"
+    assert logs[-1][0][2] is True
+
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(
+        _http_error("upload failed")
+    )
+    with pytest.raises(google_provider_module.HttpError):
+        provider._upload_image_to_drive(b"png-bytes", "chart.png")
+
+
+def test_batch_update_error_logs_and_raises(monkeypatch):
+    provider = _provider_without_init()
+    provider.slides_service = SimpleNamespace(
+        presentations=lambda: SimpleNamespace(
+            batchUpdate=lambda **kwargs: ("batch-update", kwargs)
+        )
+    )
+    logs: List[Tuple[Tuple[Any, ...], Dict[str, Any]]] = []
+    monkeypatch.setattr(
+        google_provider_module, "log_api_operation", lambda *a, **k: logs.append((a, k))
+    )
+
+    error = _http_error("batch failed", content=b'{"error":"invalid"}')
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(error)
+
+    with pytest.raises(google_provider_module.HttpError):
+        provider._batch_update("pres-1", [{"replaceAllText": {}}])
+
+    assert logs and logs[-1][0][2] is False
+    assert logs[-1][1]["error"] == '{"error":"invalid"}'
+
+
+def test_delete_chart_image_handles_permission_and_other_errors():
+    provider = _provider_without_init()
+    provider.drive_service = SimpleNamespace(
+        files=lambda: SimpleNamespace(update=lambda **kwargs: ("files-update", kwargs))
+    )
+
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(
+        _http_error("forbidden", status=403)
+    )
+    provider.delete_chart_image("file-1")
+
+    provider._execute_request = lambda _request: (_ for _ in ()).throw(
+        _http_error("server", status=500)
+    )
+    provider.delete_chart_image("file-2")


### PR DESCRIPTION
## Summary
- add targeted runtime-path tests for chart export execution and retry/reset behavior
- add targeted runtime/error-path tests for Google Slides provider operations (init/auth, folder resolution, create/copy/upload/batch/delete/share)
- cover previously under-tested branches in slideflow/presentations/charts.py and slideflow/presentations/providers/google_slides.py

## Coverage impact
- slideflow/presentations/charts.py: 49% -> 91%
- slideflow/presentations/providers/google_slides.py: 47% -> 99%

## Validation
- ./.venv/bin/python -m ruff check tests/test_charts_coverage_runtime.py tests/test_google_slides_provider_coverage.py
- ./.venv/bin/python -m black --check tests/test_charts_coverage_runtime.py tests/test_google_slides_provider_coverage.py
- ./.venv/bin/python -m pytest -q
- ./.venv/bin/python -m coverage run -m pytest -q && ./.venv/bin/python -m coverage report -m slideflow/presentations/charts.py slideflow/presentations/providers/google_slides.py

Closes #74
