### PR TITLE
test(dbt): add parity regression coverage for legacy/composable configs

### DIFF
--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -1053,9 +1053,9 @@ def test_legacy_and_composable_dbt_configs_resolve_equivalent_connectors():
         "compile",
         "profiles_dir",
     )
-    assert {
-        field: getattr(legacy_connector, field) for field in parity_fields
-    } == {field: getattr(composable_connector, field) for field in parity_fields}
+    assert {field: getattr(legacy_connector, field) for field in parity_fields} == {
+        field: getattr(composable_connector, field) for field in parity_fields
+    }
 
 
 def test_legacy_and_composable_dbt_configs_fetch_with_runtime_parity(monkeypatch):


### PR DESCRIPTION
## Summary
- add explicit parity tests between legacy databricks_dbt and composable dbt + warehouse: databricks
- verify both config shapes resolve to equivalent DBTDatabricksConnector runtime parameters
- verify runtime fetch outputs are equivalent and each config path retains expected cache behavior

## Validation
- ./.venv/bin/python -m ruff check slideflow tests scripts
- ./.venv/bin/python -m pytest -q

Closes #82