### PR TITLE
docs: sync changelog and connector runtime docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,33 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - Additive composable DBT connector config (`type: dbt`) with nested `dbt` + `warehouse` blocks.
+- Warehouse execution abstraction for DBT-compiled SQL and pluggable warehouse backends.
+- BigQuery SQL executor support for composable DBT sources (`warehouse.type: bigquery`).
+- Deterministic DBT manifest model resolution index with explicit disambiguation selectors:
+  - `model_unique_id`
+  - `model_package_name`
+  - `model_selector_name`
+- Bounded data-source cache controls via `SLIDEFLOW_DATA_CACHE_MAX_ENTRIES`.
 - Dedicated DBT migration guide with side-by-side legacy/composable examples and explicit selector disambiguation guidance.
+- NumPy/Pandas ABI compatibility checker script (`scripts/ci/check_numpy_binary_compatibility.py`) enforced in CI/release workflows.
 
 ### Changed
 
-- Documentation now treats `type: dbt` as the preferred DBT config shape while keeping `databricks_dbt` documented as legacy-compatible syntax.
-- Explicit compatibility statement: `databricks_dbt` remains supported and migration to `dbt` is optional/non-breaking.
+- `databricks_dbt` remains supported and now runs through the composable DBT runtime path for backward-compatible behavior.
+- Databricks connector now supports explicit timeout/retry tuning and typed error categories.
+- Release workflow is idempotent for reruns:
+  - skips PyPI publish when version already exists
+  - skips tag/release creation when already present
+- Reusable workflow now supports BigQuery/ADC secret mapping:
+  - `BIGQUERY_PROJECT`
+  - `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+- Documentation now treats `type: dbt` as the preferred DBT config shape while keeping `databricks_dbt` as legacy-compatible syntax.
+
+### Fixed
+
+- Safer first-line error extraction across CLI/connector paths to avoid empty-message indexing failures.
+- DBT manifest lookup now fails deterministically on alias collisions with actionable selector guidance.
+- DBT/data cache behavior hardened for concurrent builds to reduce duplicate compile/fetch work.
 
 ## [0.0.5] - 2026-02-21
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -190,6 +190,12 @@ orient: "records"
 type: "databricks"
 name: "warehouse_query"
 query: "SELECT * FROM mart.sales LIMIT 100"
+# optional connector runtime overrides:
+# socket_timeout_s: 300
+# retry_max_attempts: 30
+# retry_max_duration_s: 900
+# retry_delay_min_s: 1
+# retry_delay_max_s: 60
 ```
 
 Requires env vars:
@@ -197,6 +203,14 @@ Requires env vars:
 - `DATABRICKS_HOST`
 - `DATABRICKS_HTTP_PATH`
 - `DATABRICKS_ACCESS_TOKEN`
+
+Optional per-source runtime tuning fields:
+
+- `socket_timeout_s`
+- `retry_max_attempts`
+- `retry_max_duration_s`
+- `retry_delay_min_s`
+- `retry_delay_max_s`
 
 ### dbt on Databricks (composable, preferred)
 

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -68,6 +68,12 @@ data_source:
     SELECT month, revenue, target
     FROM mart.revenue_summary
     WHERE fiscal_quarter = '{quarter}'
+  # optional connector runtime overrides:
+  # socket_timeout_s: 300
+  # retry_max_attempts: 30
+  # retry_max_duration_s: 900
+  # retry_delay_min_s: 1
+  # retry_delay_max_s: 60
 ```
 
 Required environment:
@@ -77,6 +83,14 @@ export DATABRICKS_HOST="<workspace-hostname>"
 export DATABRICKS_HTTP_PATH="<sql-warehouse-http-path>"
 export DATABRICKS_ACCESS_TOKEN="<token>"
 ```
+
+Optional Databricks connector runtime env tuning:
+
+- `SLIDEFLOW_DATABRICKS_SOCKET_TIMEOUT_S`
+- `SLIDEFLOW_DATABRICKS_RETRY_MAX_ATTEMPTS`
+- `SLIDEFLOW_DATABRICKS_RETRY_MAX_DURATION_S`
+- `SLIDEFLOW_DATABRICKS_RETRY_DELAY_MIN_S`
+- `SLIDEFLOW_DATABRICKS_RETRY_DELAY_MAX_S`
 
 Tips:
 
@@ -192,8 +206,9 @@ SlideFlow caches connector fetches by config identity, which helps when:
 
 Treat connectors as read-only sources during a run for predictable results.
 
-DBT compile/cache tuning env vars:
+Cache/compile tuning env vars:
 
+- `SLIDEFLOW_DATA_CACHE_MAX_ENTRIES` (global source cache cap)
 - `SLIDEFLOW_DBT_CACHE_MAX_ENTRIES` (default from built-in constants)
 - `SLIDEFLOW_DBT_COMPILE_FAILURE_BACKOFF_S`
 - `SLIDEFLOW_DBT_FAILURE_CACHE_MAX_ENTRIES`


### PR DESCRIPTION
Summary:
- update unreleased changelog entries to match all post-v0.0.5 delivered changes
- document Databricks connector runtime tuning fields in config reference
- document Databricks env tuning and global cache cap env vars in connector docs

Scope: docs-only; no runtime behavior changes.

Validation note: strict docs build was not runnable locally because mkdocs was missing from the local venv; CI Docs workflow will validate strictly.