### PR TITLE
fix(workflows): stop reusable workflow file issue on push

### DIFF
--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -149,6 +149,7 @@ jobs:
       DBT_ACCESS_TOKEN: ${{ secrets.DBT_ACCESS_TOKEN || secrets.DBT_GIT_TOKEN }}
       DBT_ENV_SECRET_GIT_CREDENTIAL: ${{ secrets.DBT_ENV_SECRET_GIT_CREDENTIAL || secrets.DBT_ACCESS_TOKEN || secrets.DBT_GIT_TOKEN }}
       BIGQUERY_PROJECT: ${{ secrets.BIGQUERY_PROJECT }}
+      GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
     outputs:
       presentation_urls: ${{ steps.extract_urls.outputs.presentation_urls }}
       doctor_result_json: ${{ steps.extract_json.outputs.doctor_result_json }}
@@ -189,12 +190,13 @@ jobs:
           python -m pip check
 
       - name: Configure optional Google application credentials
-        if: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON != '' }}
         run: |
           set -euo pipefail
-          creds_file="${RUNNER_TEMP}/google-application-credentials.json"
-          printf '%s' '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}' > "$creds_file"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$creds_file" >> "$GITHUB_ENV"
+          if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS_JSON:-}" ]]; then
+            creds_file="${RUNNER_TEMP}/google-application-credentials.json"
+            printf '%s' "${GOOGLE_APPLICATION_CREDENTIALS_JSON}" > "$creds_file"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$creds_file" >> "$GITHUB_ENV"
+          fi
 
       - name: Validate and build
         id: run_build


### PR DESCRIPTION
## Summary
- remove direct `secrets.*` usage from the reusable workflow step-level `if` condition
- expose `GOOGLE_APPLICATION_CREDENTIALS_JSON` at job env level
- gate ADC file creation inside bash (`if [[ -n ... ]]`) to preserve behavior

## Why
GitHub marks workflows as invalid when secrets context is used directly in an `if` expression. That produced failing `.github/workflows/reusable-slideflow-build.yml` runs on push with no jobs.

## Validation
- YAML parses cleanly (`yaml.safe_load`)
- workflow behavior unchanged for callers: ADC file is still written only when secret is provided
