### PR TITLE
docs: refresh contributing guidance and mkdocs coverage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "README.md"
+      - "CONTRIBUTING.md"
+      - "CHANGELOG.md"
   push:
     branches:
       - master
@@ -14,6 +16,8 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "README.md"
+      - "CONTRIBUTING.md"
+      - "CHANGELOG.md"
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Safer first-line error extraction across CLI/connector paths to avoid empty-message indexing failures.
 - DBT manifest lookup now fails deterministically on alias collisions with actionable selector guidance.
 - DBT/data cache behavior hardened for concurrent builds to reduce duplicate compile/fetch work.
+- Registry module loading is now thread-safe during concurrent builds, preventing transient import-state collisions when multiple workers resolve registries at once.
+- Reusable workflow configuration now avoids invalid `secrets` expression usage in step-level conditions, preventing workflow-file validation failures on push events.
 
 ## [0.0.5] - 2026-02-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+Thanks for contributing to SlideFlow.
+
+## Development setup
+
+1. Use Python 3.12+.
+2. Create and activate a virtual environment.
+3. Install project dependencies with dev extras.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev,ai]"
+```
+
+## Local quality gates (run before opening a PR)
+
+```bash
+python -m pip check
+python -m black --check slideflow tests scripts
+python -m ruff check slideflow tests scripts
+python -m mypy slideflow
+python -m pytest -q
+```
+
+Docs validation:
+
+```bash
+python -m pip install \
+  "mkdocs>=1.6" \
+  "mkdocs-material>=9.5" \
+  "mkdocs-minify-plugin>=0.8" \
+  "pymdown-extensions>=10.0"
+python -m mkdocs build --strict
+```
+
+Optional marker suites:
+
+```bash
+python -m pytest -q -m integration
+python -m pytest -q -m e2e
+```
+
+Live Google suite (optional, requires credentials):
+
+```bash
+python -m pytest -q tests/live_tests -m live_google
+```
+
+## Contribution expectations
+
+- Include regression tests for bug fixes.
+- Update docs in the same PR when behavior or interfaces change.
+- Preserve backward compatibility unless a breaking change is explicitly planned.
+- Keep legacy `databricks_dbt` behavior compatible while extending composable `dbt`.
+
+## Pull request checklist
+
+1. Keep changes scoped to one concern.
+2. Ensure CI checks pass.
+3. Add/update tests for new behavior.
+4. Update `CHANGELOG.md` when user-visible behavior changes.
+5. Include migration notes if config shape or defaults changed.
+
+## Release and docs references
+
+- Release process: `docs/release-process.md`
+- Compatibility policy: `docs/compatibility-policy.md`
+- Testing guidance: `docs/testing.md`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **SlideFlow is a Python-based tool for generating beautiful, data-driven presentations directly from your data sources.**
 
-[Key Features](#-key-features) • [How It Works](#-how-it-works) • [Installation](#-installation) • [Getting Started](#-getting-started) • [CLI Usage](#-cli-usage) • [Configuration](#-configuration) • [Customization](#-customization) • [Contributing](#-contributing)
+[Key Features](#-key-features) • [How It Works](#-how-it-works) • [Installation](#-installation) • [Getting Started](#-getting-started) • [CLI Usage](#-cli-usage) • [Configuration](#-configuration) • [Customization](#-customization) • [Contributing](CONTRIBUTING.md)
 
 </div>
 
@@ -37,6 +37,7 @@ SlideFlow was built to solve a simple problem: automating the tedious process of
 -   📊 **Connect Directly to Your Data:** Pull data from CSV files, JSON, Databricks, or even your dbt models. No more manual data exports.
 -   ⚡ **Automate Your Reporting:** Stop the manual work. Reduce errors and save time. Your presentations are always up-to-date with your latest data.
 -   🚀 **Scale Instantly:** Need to create a presentation for every customer, region, or product? Generate hundreds of personalized presentations at once from a single template.
+-   🤖 **Production Automation Ready:** Run scheduled builds in GitHub Actions with the reusable SlideFlow workflow and machine-readable JSON outputs.
 
 ---
 
@@ -191,6 +192,13 @@ function_registry = {
 ```
 
 You can then reference `format_as_usd` in your YAML configuration.
+
+---
+
+## 🤝 Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, local quality gates,
+test expectations, and PR checklist.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,54 @@
+# Contributing
+
+SlideFlow expects contribution changes to be tested and documented in the same PR.
+
+## Local setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev,ai]"
+```
+
+## Required local gates
+
+```bash
+python -m pip check
+python -m black --check slideflow tests scripts
+python -m ruff check slideflow tests scripts
+python -m mypy slideflow
+python -m pytest -q
+```
+
+Optional marker suites:
+
+```bash
+python -m pytest -q -m integration
+python -m pytest -q -m e2e
+```
+
+Docs validation:
+
+```bash
+python -m pip install \
+  "mkdocs>=1.6" \
+  "mkdocs-material>=9.5" \
+  "mkdocs-minify-plugin>=0.8" \
+  "pymdown-extensions>=10.0"
+python -m mkdocs build --strict
+```
+
+## PR checklist
+
+1. Add regression tests for bug fixes.
+2. Update docs for behavior/interface changes.
+3. Keep compatibility for existing users unless a breaking change is explicitly planned.
+4. Update `CHANGELOG.md` for user-visible changes.
+
+## Additional references
+
+- Root contributing guide: [`CONTRIBUTING.md`](https://github.com/joe-broadhead/slideflow/blob/master/CONTRIBUTING.md)
+- Testing details: [Testing](testing.md)
+- Compatibility rules: [Compatibility Policy](compatibility-policy.md)
+- Release steps: [Release Process](release-process.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
       - Release: release-process.md
       - Changelog: changelog.md
   - Development:
+      - Contributing: contributing.md
       - Compatibility Policy: compatibility-policy.md
       - CI & Quality: ci-quality.md
       - Agent Skills: agent-skills.md


### PR DESCRIPTION
## Summary
- add a dedicated root `CONTRIBUTING.md` with current local quality gates and PR checklist
- add `docs/contributing.md` and wire it into MkDocs nav under Development
- fix README Contributing link + add explicit Contributing section
- refresh README value prop to include reusable workflow + machine-readable outputs
- update `CHANGELOG.md` Unreleased with recent merged fixes (#97/#98)
- expand Docs workflow path filters to include `CONTRIBUTING.md` and `CHANGELOG.md`

## Why
The docs/build-level checks were mostly healthy, but contribution guidance and release notes had freshness gaps after recent merges. This keeps docs and docs CI aligned with current project behavior.

## Validation
- docs/file/anchor integrity sweep: `DOC_CHECK_OK`
- workflow YAML parse check: `DOCS_WORKFLOW_YAML_OK`
- note: local `mkdocs build --strict` could not run in this session due transient DNS restrictions for installing mkdocs deps; CI Docs job remains authoritative.
