### PR TITLE
feat(data): add DuckDB connector + dbt duckdb warehouse support

### DIFF
--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -25,7 +25,7 @@ SlideFlow follows a feature-preservation policy for this program of work.
 Compatibility checks must continue to cover:
 
 - CLI command and option availability
-- Data connectors (`csv`, `json`, `databricks`, `dbt`, `databricks_dbt`)
+- Data connectors (`csv`, `json`, `databricks`, `duckdb`, `dbt`, `databricks_dbt`)
 - Replacements (`text`, `table`, `ai_text`)
 - Charts (`plotly_go`, `custom`, `template`)
 - Template engine and registry resolution behavior

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -212,6 +212,19 @@ Optional per-source runtime tuning fields:
 - `retry_delay_min_s`
 - `retry_delay_max_s`
 
+### DuckDB SQL
+
+```yaml
+type: "duckdb"
+name: "local_duckdb_query"
+database: "/tmp/analytics.duckdb" # optional; defaults to ':memory:'
+read_only: true # optional; defaults to true
+file_search_path: # optional; list or comma-separated string
+  - "/tmp/data"
+  - "/tmp/snapshots"
+query: "SELECT * FROM sales_summary"
+```
+
 ### dbt on Databricks (composable, preferred)
 
 ```yaml
@@ -237,11 +250,14 @@ Optional alias disambiguation fields for `dbt`:
 
 Composable warehouse options:
 
-- `warehouse.type`: `databricks` or `bigquery`
+- `warehouse.type`: `databricks`, `bigquery`, or `duckdb`
 - `warehouse.project_id`: BigQuery project id override
 - `warehouse.location`: optional warehouse location/region
 - `warehouse.credentials_path`: optional path to BigQuery service-account JSON
 - `warehouse.credentials_json`: optional inline service-account JSON payload
+- `warehouse.database`: required for DuckDB warehouse (file path or `:memory:`)
+- `warehouse.read_only`: optional DuckDB read-only mode (default `true`)
+- `warehouse.file_search_path`: optional DuckDB file search path (list or comma-separated string)
 
 BigQuery variant example:
 
@@ -259,6 +275,26 @@ warehouse:
   project_id: "my-gcp-project"
   location: "US"
   credentials_path: "/path/to/service-account.json"
+
+DuckDB variant example:
+
+```yaml
+type: "dbt"
+name: "dbt_model_duckdb"
+model_alias: "revenue_model"
+dbt:
+  package_url: "https://$GIT_TOKEN@github.com/org/repo.git"
+  project_dir: "/tmp/dbt_project"
+  branch: "main"
+  target: "prod"
+warehouse:
+  type: "duckdb"
+  database: "/tmp/warehouse.duckdb"
+  read_only: true
+  file_search_path:
+    - "/tmp/dbt_project"
+    - "/tmp/data"
+```
 ```
 
 ### Legacy dbt on Databricks (`databricks_dbt`)

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -1,10 +1,11 @@
 # Data Connectors
 
-SlideFlow supports five connector types for chart/replacement data sources:
+SlideFlow supports six connector types for chart/replacement data sources:
 
 - `csv`
 - `json`
 - `databricks`
+- `duckdb`
 - `dbt` (composable, preferred)
 - `databricks_dbt` (legacy, still supported)
 
@@ -20,7 +21,8 @@ For a step-by-step migration from legacy `databricks_dbt` to composable
 | `csv` | local tabular files | no | none |
 | `json` | local API exports/events | no | none |
 | `databricks` | direct warehouse SQL | yes | `DATABRICKS_HOST`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_ACCESS_TOKEN` |
-| `dbt` | dbt model SQL executed on Databricks or BigQuery (composable config) | yes | Databricks env vars or BigQuery project/auth env vars (+ Git token env if needed) |
+| `duckdb` | direct local/in-memory SQL | no | none |
+| `dbt` | dbt model SQL executed on Databricks, BigQuery, or DuckDB (composable config) | yes/no (depends on warehouse and dbt repo) | Databricks env vars, BigQuery project/auth env vars, or none for local DuckDB (+ Git token env if needed) |
 | `databricks_dbt` | dbt model SQL executed on Databricks | yes | same Databricks env vars (+ Git token env if needed) |
 
 ## CSV
@@ -97,6 +99,28 @@ Tips:
 - Keep SQL deterministic for reporting workflows.
 - Limit columns to what chart/replacement logic needs.
 - Prefer validated parameter substitution (`{quarter}` from batch params) over string concatenation.
+
+## DuckDB SQL
+
+```yaml
+data_source:
+  type: "duckdb"
+  name: "local_duckdb_query"
+  database: "/tmp/analytics.duckdb" # optional; defaults to ':memory:'
+  read_only: true # optional; defaults to true
+  file_search_path: # optional; used for relative file references in DuckDB
+    - "/tmp/data"
+    - "/tmp/snapshots"
+  query: |
+    SELECT * FROM sales_summary
+```
+
+Notes:
+
+- Install DuckDB runtime deps:
+  `pip install "slideflow-presentations[duckdb]"`.
+- `file_search_path` can be a list or a comma-separated string.
+- If `file_search_path` is omitted, DuckDB uses its default file search behavior.
 
 ## dbt on Databricks (`dbt`, preferred)
 
@@ -179,6 +203,30 @@ BigQuery runtime options:
   - `warehouse.credentials_json`, or
   - Application Default Credentials (for example `GOOGLE_APPLICATION_CREDENTIALS`).
 
+## dbt on DuckDB (`dbt`)
+
+This connector shape compiles a dbt project, resolves a model's compiled SQL,
+then executes it on DuckDB.
+
+```yaml
+data_source:
+  type: "dbt"
+  name: "dbt_model_duckdb"
+  model_alias: "monthly_revenue_by_region"
+  dbt:
+    package_url: "https://$GIT_TOKEN@github.com/org/analytics-dbt.git"
+    project_dir: "/tmp/dbt_project_workspace"
+    branch: "main"
+    target: "prod"
+  warehouse:
+    type: "duckdb"
+    database: "/tmp/warehouse.duckdb" # required for dbt+duckdb
+    read_only: true # optional; defaults to true
+    file_search_path: # optional
+      - "/tmp/dbt_project_workspace"
+      - "/tmp/data"
+```
+
 ## Legacy dbt on Databricks (`databricks_dbt`)
 
 This legacy shape is still fully supported for backward compatibility.
@@ -216,7 +264,7 @@ Cache/compile tuning env vars:
 ## Recommended Workflow
 
 1. Start with local `csv`/`json` while designing charts and replacements.
-2. Move to `databricks` once schema and logic are stable.
+2. Move to `duckdb` or `databricks` once schema and logic are stable.
 3. Move to `dbt` when business logic should live in dbt models (`databricks_dbt` remains supported as legacy syntax).
 4. Run `slideflow validate` before `slideflow build` in CI/CD.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ SlideFlow generates Google Slides decks from structured YAML, data sources, and 
 
 - Declarative presentation builds via `slideflow build`
 - Fast preflight validation via `slideflow validate`
-- Data connectors for CSV, JSON, Databricks SQL, and dbt-on-Databricks
+- Data connectors for CSV, JSON, Databricks SQL, DuckDB SQL, and dbt warehouses
 - Dynamic replacements (`text`, `table`, `ai_text`)
 - Charts via Plotly graph objects, reusable templates, or custom Python functions
 - Batch deck generation with `--params-path` for high-volume reporting

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -104,7 +104,7 @@ that mode so you can validate the slides visually.
 Compatibility tests assert support remains in place for:
 
 - CLI commands/options (`slideflow build`, `slideflow validate`)
-- connectors (`csv`, `json`, `databricks`, `dbt`, `databricks_dbt`)
+- connectors (`csv`, `json`, `databricks`, `duckdb`, `dbt`, `databricks_dbt`)
 - replacements (`text`, `table`, `ai_text`)
 - charts (`plotly_go`, `custom`, `template`)
 - template/registry loading paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ requires-python = ">=3.12"
 [project.optional-dependencies]
 ai = ["openai", "google-genai"]
 bigquery = ["google-cloud-bigquery", "dbt-bigquery"]
+duckdb = ["duckdb", "dbt-duckdb"]
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",

--- a/slideflow/data/__init__.py
+++ b/slideflow/data/__init__.py
@@ -72,7 +72,8 @@ Available Data Sources:
     - CSV files: Simple file-based tabular data
     - JSON files: Structured data with various orientations
     - Databricks: SQL queries against Databricks warehouses
-    - DBT models: Compiled transformations with Databricks execution
+    - DuckDB: SQL queries against local/in-memory DuckDB databases
+    - DBT models: Compiled transformations with warehouse execution
 
 Components:
     DataSourceCache: Thread-safe singleton cache for DataFrame storage
@@ -95,9 +96,13 @@ from slideflow.data.connectors import (
     DBTBigQueryConnector,
     DBTDatabricksConnector,
     DBTDatabricksSourceConfig,
+    DBTDuckDBConnector,
     DBTProjectConfig,
     DBTSourceConfig,
     DBTWarehouseConfig,
+    DuckDBConnector,
+    DuckDBSourceConfig,
+    DuckDBSQLExecutor,
     JSONConnector,
     JSONSourceConfig,
     SQLExecutor,
@@ -121,8 +126,12 @@ __all__ = [
     "DatabricksConnector",
     "DatabricksSQLExecutor",
     "DatabricksSourceConfig",
+    "DuckDBConnector",
+    "DuckDBSQLExecutor",
+    "DuckDBSourceConfig",
     "DBTBigQueryConnector",
     "DBTDatabricksConnector",
+    "DBTDuckDBConnector",
     "DBTDatabricksSourceConfig",
     "DBTProjectConfig",
     "DBTWarehouseConfig",

--- a/slideflow/data/connectors/__init__.py
+++ b/slideflow/data/connectors/__init__.py
@@ -40,12 +40,14 @@ Available Connectors:
     - CSVConnector: For CSV file data sources
     - JSONConnector: For JSON file data sources
     - DatabricksConnector: For Databricks SQL warehouse connections
+    - DuckDBConnector: For DuckDB SQL connections
     - DBTDatabricksConnector: For DBT models in Databricks
 
 Available Configurations:
     - CSVSourceConfig: Configuration for CSV files
     - JSONSourceConfig: Configuration for JSON files
     - DatabricksSourceConfig: Configuration for Databricks connections
+    - DuckDBSourceConfig: Configuration for DuckDB connections
     - DBTDatabricksSourceConfig: Configuration for DBT models
 """
 
@@ -65,9 +67,15 @@ from slideflow.data.connectors.dbt import (
     DBTBigQueryConnector,
     DBTDatabricksConnector,
     DBTDatabricksSourceConfig,
+    DBTDuckDBConnector,
     DBTProjectConfig,
     DBTSourceConfig,
     DBTWarehouseConfig,
+)
+from slideflow.data.connectors.duckdb import (
+    DuckDBConnector,
+    DuckDBSourceConfig,
+    DuckDBSQLExecutor,
 )
 from slideflow.data.connectors.json import JSONConnector, JSONSourceConfig
 
@@ -84,8 +92,12 @@ __all__ = [
     "DatabricksConnector",
     "DatabricksSQLExecutor",
     "DatabricksSourceConfig",
+    "DuckDBConnector",
+    "DuckDBSQLExecutor",
+    "DuckDBSourceConfig",
     "DBTBigQueryConnector",
     "DBTDatabricksConnector",
+    "DBTDuckDBConnector",
     "DBTDatabricksSourceConfig",
     "DBTProjectConfig",
     "DBTWarehouseConfig",

--- a/slideflow/data/connectors/connect.py
+++ b/slideflow/data/connectors/connect.py
@@ -43,6 +43,7 @@ Supported Data Source Types:
     - "csv": CSV file data sources
     - "json": JSON file data sources
     - "databricks": Databricks SQL warehouse connections
+    - "duckdb": DuckDB SQL connections
     - "databricks_dbt": Legacy DBT models in Databricks
     - "dbt": Composable DBT source with explicit warehouse block
 """
@@ -54,6 +55,7 @@ from pydantic import Field
 from slideflow.data.connectors.csv import CSVSourceConfig
 from slideflow.data.connectors.databricks import DatabricksSourceConfig
 from slideflow.data.connectors.dbt import DBTDatabricksSourceConfig, DBTSourceConfig
+from slideflow.data.connectors.duckdb import DuckDBSourceConfig
 from slideflow.data.connectors.json import JSONSourceConfig
 
 DataSourceConfig = Annotated[
@@ -61,6 +63,7 @@ DataSourceConfig = Annotated[
         CSVSourceConfig,
         JSONSourceConfig,
         DatabricksSourceConfig,
+        DuckDBSourceConfig,
         DBTDatabricksSourceConfig,
         DBTSourceConfig,
     ],
@@ -76,6 +79,7 @@ The union includes all currently supported data source types:
 - CSVSourceConfig: For CSV file data sources
 - JSONSourceConfig: For JSON file data sources  
 - DatabricksSourceConfig: For Databricks SQL warehouse connections
+- DuckDBSourceConfig: For DuckDB SQL sources
 - DBTDatabricksSourceConfig: For DBT models in Databricks
 - DBTSourceConfig: For composable DBT + warehouse configurations
 

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -63,12 +63,13 @@ from typing import Any, Callable, ClassVar, Iterator, Literal, Optional, Type
 import pandas as pd
 from dbt.cli.main import dbtRunner
 from git import Repo
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from slideflow.constants import Defaults
 from slideflow.data.connectors.base import BaseSourceConfig, DataConnector, SQLExecutor
 from slideflow.data.connectors.bigquery import BigQuerySQLExecutor
 from slideflow.data.connectors.databricks import DatabricksSQLExecutor
+from slideflow.data.connectors.duckdb import DuckDBSQLExecutor
 from slideflow.utilities.exceptions import DataSourceError
 from slideflow.utilities.logging import get_logger, log_data_operation, log_performance
 
@@ -1174,6 +1175,62 @@ class DBTBigQueryConnector(BaseModel, DataConnector):
         return executor.execute(sql_text)
 
 
+class DBTDuckDBConnector(BaseModel, DataConnector):
+    """Connector that combines DBT model compilation with DuckDB execution."""
+
+    model_alias: str
+    model_unique_id: Optional[str] = None
+    model_package_name: Optional[str] = None
+    model_selector_name: Optional[str] = None
+    package_url: str
+    project_dir: str
+    profile_name: Optional[str] = None
+    branch: Optional[str] = None
+    target: str = Defaults.DBT_TARGET
+    vars: Optional[dict[str, Any]] = None
+    compile: bool = Defaults.DBT_COMPILE
+    profiles_dir: Optional[str] = None
+    database: str
+    read_only: bool = True
+    file_search_path: Optional[str | list[str]] = None
+    _manifest_connector: Optional[DBTManifestConnector] = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        self._manifest_connector = DBTManifestConnector(
+            package_url=self.package_url,
+            project_dir=self.project_dir,
+            branch=self.branch,
+            target=self.target,
+            vars=self.vars,
+            profiles_dir=self.profiles_dir,
+            compile=self.compile,
+            profile_name=self.profile_name,
+        )
+
+    def fetch_data(self) -> pd.DataFrame:
+        """Compile DBT model and execute the resulting SQL on DuckDB."""
+        if self._manifest_connector is None:
+            raise DataSourceError("DBT manifest connector is not initialized.")
+        sql_text = self._manifest_connector.get_compiled_query(
+            self.model_alias,
+            model_unique_id=self.model_unique_id,
+            model_package_name=self.model_package_name,
+            model_selector_name=self.model_selector_name,
+        )
+        if not sql_text:
+            raise DataSourceError(f"No compiled model '{self.model_alias}'")
+
+        executor = DuckDBSQLExecutor(
+            database=self.database,
+            read_only=self.read_only,
+            file_search_path=self.file_search_path,
+        )
+        return executor.execute(sql_text)
+
+
 class DBTDatabricksSourceConfig(BaseSourceConfig):
     """Configuration model for DBT models executed on Databricks.
 
@@ -1293,7 +1350,7 @@ class DBTProjectConfig(BaseModel):
 class DBTWarehouseConfig(BaseModel):
     """Warehouse execution backend for composable DBT sources."""
 
-    type: Literal["databricks", "bigquery"] = Field(
+    type: Literal["databricks", "bigquery", "duckdb"] = Field(
         "databricks", description="Warehouse backend type"
     )
     project_id: Optional[str] = Field(
@@ -1324,8 +1381,34 @@ class DBTWarehouseConfig(BaseModel):
             "when warehouse.type is 'bigquery'."
         ),
     )
+    database: Optional[str] = Field(
+        None,
+        description=(
+            "DuckDB database path (or ':memory:'). Required when "
+            "warehouse.type is 'duckdb'."
+        ),
+    )
+    read_only: bool = Field(
+        True,
+        description="Open DuckDB connection in read-only mode when using duckdb.",
+    )
+    file_search_path: Optional[str | list[str]] = Field(
+        None,
+        description=(
+            "Optional DuckDB file_search_path setting for resolving relative files "
+            "when warehouse.type is 'duckdb'."
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_duckdb_required_fields(self):
+        if self.type == "duckdb" and not self.database:
+            raise ValueError(
+                "warehouse.database is required when warehouse.type is 'duckdb'."
+            )
+        return self
 
 
 class DBTSourceConfig(BaseSourceConfig):
@@ -1390,5 +1473,23 @@ class DBTSourceConfig(BaseSourceConfig):
                 location=self.warehouse.location,
                 credentials_json=self.warehouse.credentials_json,
                 credentials_path=self.warehouse.credentials_path,
+            )
+        if self.warehouse.type == "duckdb":
+            return DBTDuckDBConnector(
+                model_alias=self.model_alias,
+                model_unique_id=self.model_unique_id,
+                model_package_name=self.model_package_name,
+                model_selector_name=self.model_selector_name,
+                package_url=self.dbt.package_url,
+                project_dir=self.dbt.project_dir,
+                profile_name=self.dbt.profile_name,
+                branch=self.dbt.branch,
+                target=self.dbt.target,
+                vars=self.dbt.vars,
+                compile=self.dbt.compile,
+                profiles_dir=self.dbt.profiles_dir,
+                database=self.warehouse.database or ":memory:",
+                read_only=self.warehouse.read_only,
+                file_search_path=self.warehouse.file_search_path,
             )
         raise DataSourceError(f"Unsupported DBT warehouse type '{self.warehouse.type}'")

--- a/slideflow/data/connectors/duckdb.py
+++ b/slideflow/data/connectors/duckdb.py
@@ -1,0 +1,218 @@
+"""DuckDB connector and SQL executor utilities for Slideflow.
+
+This module provides direct DuckDB query execution and a SQL executor for
+composable DBT warehouse routing.
+"""
+
+import importlib
+from typing import Any, ClassVar, Literal, Optional, Type
+
+import pandas as pd
+from pydantic import ConfigDict, Field
+
+from slideflow.data.connectors.base import BaseSourceConfig, DataConnector, SQLExecutor
+from slideflow.utilities.exceptions import DataSourceError
+
+
+def _safe_error_message(error: Exception) -> str:
+    """Get a non-empty single-line error message."""
+    message = str(error).strip()
+    if not message:
+        return error.__class__.__name__
+    first_line, _sep, _rest = message.partition("\n")
+    return first_line.strip() or error.__class__.__name__
+
+
+def _normalize_file_search_path(
+    file_search_path: Optional[str | list[str]],
+) -> Optional[str]:
+    """Normalize DuckDB file_search_path setting to a comma-separated string."""
+    if file_search_path is None:
+        return None
+    if isinstance(file_search_path, str):
+        normalized = file_search_path.strip()
+        return normalized or None
+
+    normalized_parts = [part.strip() for part in file_search_path if part.strip()]
+    if not normalized_parts:
+        return None
+    return ",".join(normalized_parts)
+
+
+class DuckDBConnectorError(DataSourceError):
+    """Typed DuckDB connector failure with coarse category metadata."""
+
+    def __init__(self, category: str, message: str):
+        self.category = category
+        super().__init__(f"duckdb[{category}] {message}")
+
+
+class DuckDBConnector(DataConnector):
+    """Execute SQL queries against DuckDB and return pandas DataFrames."""
+
+    def __init__(
+        self,
+        query: str,
+        database: Optional[str] = ":memory:",
+        read_only: bool = True,
+        file_search_path: Optional[str | list[str]] = None,
+    ) -> None:
+        self.query = query
+        self.database = database or ":memory:"
+        self.read_only = read_only
+        self.file_search_path = file_search_path
+        self._normalized_file_search_path = _normalize_file_search_path(
+            file_search_path
+        )
+        self._connection: Optional[Any] = None
+        self._file_search_path_applied = False
+
+    @staticmethod
+    def _load_duckdb_module() -> Any:
+        """Load duckdb lazily."""
+        try:
+            return importlib.import_module("duckdb")
+        except ImportError as error:  # pragma: no cover - exercised via unit tests
+            raise DuckDBConnectorError(
+                "configuration",
+                "duckdb is required for DuckDB execution. "
+                "Install with: pip install slideflow-presentations[duckdb]",
+            ) from error
+
+    def connect(self) -> Any:
+        """Initialize and cache a DuckDB connection."""
+        if self._connection is None:
+            duckdb_module = self._load_duckdb_module()
+            connect_fn = getattr(duckdb_module, "connect", None)
+            if connect_fn is None:  # pragma: no cover - defensive guard
+                raise DuckDBConnectorError(
+                    "configuration",
+                    "duckdb.connect is unavailable in installed duckdb package.",
+                )
+            try:
+                self._connection = connect_fn(
+                    database=self.database,
+                    read_only=self.read_only,
+                )
+            except Exception as error:
+                raise DuckDBConnectorError(
+                    "connection",
+                    "Failed to initialize DuckDB connection "
+                    f"({_safe_error_message(error)})",
+                ) from error
+        return self._connection
+
+    def disconnect(self) -> None:
+        """Release the cached DuckDB connection."""
+        connection = self._connection
+        self._connection = None
+        self._file_search_path_applied = False
+        if connection is None:
+            return
+        try:
+            connection.close()
+        except Exception:
+            # Best effort cleanup; keep original fetch/query errors intact.
+            pass
+
+    @staticmethod
+    def _cursor_to_dataframe(cursor: Any) -> pd.DataFrame:
+        """Convert DuckDB cursor/relation results to a pandas DataFrame."""
+        for method_name in ("fetch_df", "fetchdf", "df"):
+            method = getattr(cursor, method_name, None)
+            if callable(method):
+                return method()
+
+        fetchall = getattr(cursor, "fetchall", None)
+        if callable(fetchall):
+            rows = fetchall()
+            description = getattr(cursor, "description", None) or []
+            columns = [col[0] for col in description] if description else None
+            return pd.DataFrame(rows, columns=columns)
+
+        raise DuckDBConnectorError(
+            "query",
+            "DuckDB query result could not be converted to a DataFrame.",
+        )
+
+    def _apply_file_search_path(self, connection: Any) -> None:
+        """Apply DuckDB file_search_path setting once per connection."""
+        if self._file_search_path_applied:
+            return
+        if not self._normalized_file_search_path:
+            return
+
+        escaped = self._normalized_file_search_path.replace("'", "''")
+        try:
+            connection.execute(f"SET file_search_path = '{escaped}'")
+        except Exception as error:
+            raise DuckDBConnectorError(
+                "configuration",
+                "Failed to set DuckDB file_search_path "
+                f"({_safe_error_message(error)})",
+            ) from error
+        self._file_search_path_applied = True
+
+    def fetch_data(self) -> pd.DataFrame:
+        """Execute SQL against DuckDB and return a DataFrame."""
+        connection = self.connect()
+        self._apply_file_search_path(connection)
+        try:
+            cursor = connection.execute(self.query)
+            return self._cursor_to_dataframe(cursor)
+        except DuckDBConnectorError:
+            raise
+        except Exception as error:
+            raise DuckDBConnectorError(
+                "query",
+                f"Failed to execute DuckDB query ({_safe_error_message(error)})",
+            ) from error
+
+
+class DuckDBSQLExecutor(SQLExecutor):
+    """SQL executor that runs queries against DuckDB."""
+
+    def __init__(
+        self,
+        database: Optional[str] = ":memory:",
+        read_only: bool = True,
+        file_search_path: Optional[str | list[str]] = None,
+    ) -> None:
+        self.database = database
+        self.read_only = read_only
+        self.file_search_path = file_search_path
+
+    def execute(self, sql_query: str) -> pd.DataFrame:
+        """Execute SQL query text against DuckDB."""
+        connector = DuckDBConnector(
+            query=sql_query,
+            database=self.database,
+            read_only=self.read_only,
+            file_search_path=self.file_search_path,
+        )
+        return connector.fetch_data()
+
+
+class DuckDBSourceConfig(BaseSourceConfig):
+    """Configuration model for direct DuckDB SQL sources."""
+
+    type: Literal["duckdb"] = Field("duckdb", description="DuckDB SQL source")
+    query: str = Field(..., description="SQL query")
+    database: Optional[str] = Field(
+        ":memory:",
+        description="DuckDB database path or ':memory:'",
+    )
+    read_only: bool = Field(
+        True, description="Open DuckDB connection in read-only mode"
+    )
+    file_search_path: Optional[str | list[str]] = Field(
+        None,
+        description=(
+            "Optional DuckDB file_search_path setting for resolving relative files. "
+            "May be a comma-separated string or list of paths."
+        ),
+    )
+
+    connector_class: ClassVar[Type[DataConnector]] = DuckDBConnector
+
+    model_config = ConfigDict(extra="forbid")

--- a/tests/test_compatibility_matrix.py
+++ b/tests/test_compatibility_matrix.py
@@ -12,6 +12,7 @@ from slideflow.data.connectors import (
     DataSourceConfig,
     DBTDatabricksSourceConfig,
     DBTSourceConfig,
+    DuckDBSourceConfig,
     JSONSourceConfig,
 )
 from slideflow.presentations.charts import (
@@ -59,6 +60,14 @@ def test_cli_commands_remain_available():
                 "query": "SELECT 1",
             },
             DatabricksSourceConfig,
+        ),
+        (
+            {
+                "type": "duckdb",
+                "name": "source_duckdb",
+                "query": "SELECT 1",
+            },
+            DuckDBSourceConfig,
         ),
         (
             {

--- a/tests/test_duckdb_connector.py
+++ b/tests/test_duckdb_connector.py
@@ -1,0 +1,229 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+import slideflow.data.connectors.dbt as dbt_module
+import slideflow.data.connectors.duckdb as duckdb_module
+
+
+def test_duckdb_connector_connect_uses_database_and_read_only(monkeypatch):
+    captured = {}
+
+    class FakeConnection:
+        def execute(self, _sql):
+            return SimpleNamespace(fetch_df=lambda: pd.DataFrame({"value": [1]}))
+
+    class FakeDuckDB:
+        @staticmethod
+        def connect(*, database, read_only):
+            captured["database"] = database
+            captured["read_only"] = read_only
+            return FakeConnection()
+
+    monkeypatch.setattr(
+        duckdb_module.DuckDBConnector,
+        "_load_duckdb_module",
+        staticmethod(lambda: FakeDuckDB),
+    )
+
+    connector = duckdb_module.DuckDBConnector(
+        query="SELECT 1",
+        database="/tmp/example.duckdb",
+        read_only=False,
+    )
+    connector.connect()
+
+    assert captured["database"] == "/tmp/example.duckdb"
+    assert captured["read_only"] is False
+
+
+def test_duckdb_connector_fetch_data_applies_file_search_path_once(monkeypatch):
+    executed_sql: list[str] = []
+    closed = {"value": False}
+
+    class FakeCursor:
+        @staticmethod
+        def fetch_df():
+            return pd.DataFrame({"value": [1]})
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed_sql.append(sql)
+            return FakeCursor()
+
+        def close(self):
+            closed["value"] = True
+
+    class FakeDuckDB:
+        @staticmethod
+        def connect(*, database, read_only):
+            assert database == ":memory:"
+            assert read_only is True
+            return FakeConnection()
+
+    monkeypatch.setattr(
+        duckdb_module.DuckDBConnector,
+        "_load_duckdb_module",
+        staticmethod(lambda: FakeDuckDB),
+    )
+
+    connector = duckdb_module.DuckDBConnector(
+        query="SELECT 1 AS value",
+        file_search_path=["/data/base", "/data/shared"],
+    )
+
+    first = connector.fetch_data()
+    second = connector.fetch_data()
+    connector.disconnect()
+
+    assert first.to_dict(orient="records") == [{"value": 1}]
+    assert second.to_dict(orient="records") == [{"value": 1}]
+    assert executed_sql[0] == "SET file_search_path = '/data/base,/data/shared'"
+    assert executed_sql[1] == "SELECT 1 AS value"
+    assert executed_sql[2] == "SELECT 1 AS value"
+    assert closed["value"] is True
+
+
+def test_duckdb_sql_executor_delegates_to_connector(monkeypatch):
+    captured = {}
+
+    class ConnectorStub:
+        def __init__(
+            self,
+            query,
+            database=None,
+            read_only=True,
+            file_search_path=None,
+        ):
+            captured["query"] = query
+            captured["database"] = database
+            captured["read_only"] = read_only
+            captured["file_search_path"] = file_search_path
+
+        def fetch_data(self):
+            return pd.DataFrame({"value": [7]})
+
+    monkeypatch.setattr(duckdb_module, "DuckDBConnector", ConnectorStub)
+
+    executor = duckdb_module.DuckDBSQLExecutor(
+        database="/tmp/example.duckdb",
+        read_only=False,
+        file_search_path="/data",
+    )
+    result = executor.execute("SELECT 7 AS value")
+
+    assert captured["query"] == "SELECT 7 AS value"
+    assert captured["database"] == "/tmp/example.duckdb"
+    assert captured["read_only"] is False
+    assert captured["file_search_path"] == "/data"
+    assert result.to_dict(orient="records") == [{"value": 7}]
+
+
+def test_duckdb_source_config_defaults():
+    config = duckdb_module.DuckDBSourceConfig(
+        name="duck",
+        type="duckdb",
+        query="SELECT 1",
+    )
+
+    connector = config.get_connector()
+
+    assert isinstance(connector, duckdb_module.DuckDBConnector)
+    assert connector.database == ":memory:"
+    assert connector.read_only is True
+    assert connector.file_search_path is None
+
+
+def test_dbt_source_config_resolves_to_duckdb_connector():
+    config = dbt_module.DBTSourceConfig(
+        name="metrics",
+        type="dbt",
+        model_alias="metrics_model",
+        dbt={
+            "package_url": "https://github.com/org/repo.git",
+            "project_dir": "/tmp/workspace",
+        },
+        warehouse={
+            "type": "duckdb",
+            "database": "/tmp/warehouse.duckdb",
+            "read_only": False,
+            "file_search_path": ["/tmp/workspace"],
+        },
+    )
+
+    connector = config.get_connector()
+    assert isinstance(connector, dbt_module.DBTDuckDBConnector)
+    assert connector.database == "/tmp/warehouse.duckdb"
+    assert connector.read_only is False
+    assert connector.file_search_path == ["/tmp/workspace"]
+
+
+def test_dbt_source_config_duckdb_requires_database():
+    with pytest.raises(
+        ValidationError,
+        match="warehouse.database is required when warehouse.type is 'duckdb'",
+    ):
+        dbt_module.DBTSourceConfig(
+            name="metrics",
+            type="dbt",
+            model_alias="metrics_model",
+            dbt={
+                "package_url": "https://github.com/org/repo.git",
+                "project_dir": "/tmp/workspace",
+            },
+            warehouse={"type": "duckdb"},
+        )
+
+
+def test_dbt_duckdb_connector_executes_compiled_sql(monkeypatch):
+    captured = {}
+
+    class ManifestStub:
+        def __init__(self, **_kwargs):
+            pass
+
+        def get_compiled_query(self, model_alias, **selectors):
+            captured["model_alias"] = model_alias
+            captured["selectors"] = selectors
+            return "SELECT 1 AS answer"
+
+    class ExecutorStub:
+        def __init__(self, database, read_only, file_search_path):
+            captured["database"] = database
+            captured["read_only"] = read_only
+            captured["file_search_path"] = file_search_path
+
+        def execute(self, sql_query):
+            captured["sql_query"] = sql_query
+            return pd.DataFrame({"answer": [1]})
+
+    monkeypatch.setattr(dbt_module, "DBTManifestConnector", ManifestStub)
+    monkeypatch.setattr(dbt_module, "DuckDBSQLExecutor", ExecutorStub)
+
+    connector = dbt_module.DBTDuckDBConnector(
+        model_alias="metrics_model",
+        model_unique_id="model.pkg.metrics_model",
+        model_package_name="pkg",
+        model_selector_name="metrics_model",
+        package_url="https://github.com/org/repo.git",
+        project_dir="/tmp/workspace",
+        database="/tmp/warehouse.duckdb",
+        read_only=False,
+        file_search_path=["/tmp/workspace"],
+    )
+
+    result = connector.fetch_data()
+
+    assert result.to_dict(orient="records") == [{"answer": 1}]
+    assert captured["model_alias"] == "metrics_model"
+    assert captured["selectors"] == {
+        "model_unique_id": "model.pkg.metrics_model",
+        "model_package_name": "pkg",
+        "model_selector_name": "metrics_model",
+    }
+    assert captured["database"] == "/tmp/warehouse.duckdb"
+    assert captured["read_only"] is False
+    assert captured["file_search_path"] == ["/tmp/workspace"]
+    assert captured["sql_query"] == "SELECT 1 AS answer"


### PR DESCRIPTION
## Summary
This PR implements Issue #101 by adding first-class DuckDB support in both direct data sources and composable dbt warehouse routing, while preserving backward compatibility for existing connectors and legacy `databricks_dbt` configs.

Closes #101

## What changed
- Added new DuckDB connector module: `slideflow/data/connectors/duckdb.py`
  - `DuckDBConnector`
  - `DuckDBSQLExecutor`
  - `DuckDBSourceConfig`
  - `DuckDBConnectorError`
- Added DuckDB to connector unions/exports:
  - `slideflow/data/connectors/connect.py`
  - `slideflow/data/connectors/__init__.py`
  - `slideflow/data/__init__.py`
- Extended composable dbt warehouse support in `slideflow/data/connectors/dbt.py`:
  - Added `DBTDuckDBConnector`
  - Extended `DBTWarehouseConfig.type` with `duckdb`
  - Added duckdb warehouse fields: `database`, `read_only`, `file_search_path`
  - Added validation: `warehouse.database` is required when `warehouse.type: duckdb`
  - Added routing in `DBTSourceConfig.get_connector()`
- Added optional dependency extra in `pyproject.toml`:
  - `duckdb = ["duckdb", "dbt-duckdb"]`

## DuckDB-specific behavior
- Direct source supports:
  - `database` (default `:memory:`)
  - `read_only` (default `true`)
  - `file_search_path` (optional; string or list)
- When `file_search_path` is provided, connector applies:
  - `SET file_search_path = ...`
  - once per connection
- If omitted, DuckDB default file search behavior is preserved.

## Backward compatibility
- Existing `csv`, `json`, `databricks`, `dbt`, `databricks_dbt` behavior remains intact.
- Changes are additive only; no breaking schema migration required.

## Docs updated
- `docs/data-connectors.md`
- `docs/config-reference.md`
- `docs/index.md`
- `docs/compatibility-policy.md`
- `docs/testing.md`

## Tests added/updated
- Added `tests/test_duckdb_connector.py` covering:
  - direct connector connect/fetch
  - `file_search_path` application
  - SQL executor delegation
  - default config behavior
  - composable dbt duckdb routing
  - dbt duckdb required field validation
  - dbt duckdb execution path
- Updated `tests/test_compatibility_matrix.py` to include `duckdb` type support.

## Validation run
- `./.venv/bin/python -m black --check slideflow tests`
- `./.venv/bin/python -m ruff check slideflow tests`
- `./.venv/bin/python -m pytest -q tests/test_duckdb_connector.py tests/test_bigquery_connector.py tests/test_dbt_sanitization.py tests/test_compatibility_matrix.py`
- `./.venv/bin/python -m pytest -q`

Results:
- Black: pass
- Ruff: pass
- Targeted tests: pass
- Full suite: `241 passed, 1 skipped`

## Residual risk
- Runtime behavior depends on optional extras being installed for DuckDB/dbt-duckdb in environments that use these paths.
- `file_search_path` semantics are delegated to DuckDB; we pass values through with normalization and explicit connection-level setting.
