### PR TITLE
fix: resolve issue #106 correctness and doc alignment

### DIFF
--- a/slideflow/cli/theme.py
+++ b/slideflow/cli/theme.py
@@ -213,7 +213,7 @@ def print_config_summary(presentation_config: Any) -> None:
 def print_error(
     error_msg: Any, verbose: bool = False, error_code: Optional[str] = None
 ) -> None:
-    console.print("[bold red]❌ Validation Faliled[/bold red]")
+    console.print("[bold red]❌ Validation Failed[/bold red]")
     console.print("[red]━━━━━━━━━━━━━━━━━━━━━━━[/red]")
     console.print("[bold yellow]🚨 Error Detected:[/bold yellow]")
     if error_code:

--- a/slideflow/replacements/table.py
+++ b/slideflow/replacements/table.py
@@ -435,7 +435,6 @@ class TableReplacement(BaseReplacement):
             raise ValueError(
                 "Table replacement has no data to process. Provide `replacements` or `data_source`."
             )
-        assert df is not None
 
         df = self.apply_data_transforms(df)
 

--- a/slideflow/replacements/utils.py
+++ b/slideflow/replacements/utils.py
@@ -19,15 +19,12 @@ Example:
     >>> replacements = dataframe_to_replacement_object(df, 'PRODUCTS_')
     >>> # Returns:
     >>> # {
-    >>> #     '{{PRODUCTS_1,1}}': 'Product',
-    >>> #     '{{PRODUCTS_1,2}}': 'Sales',
-    >>> #     '{{PRODUCTS_1,3}}': 'Growth',
-    >>> #     '{{PRODUCTS_2,1}}': 'Widget',
-    >>> #     '{{PRODUCTS_2,2}}': 125.5,
-    >>> #     '{{PRODUCTS_2,3}}': 15.3,
-    >>> #     '{{PRODUCTS_3,1}}': 'Gadget',
-    >>> #     '{{PRODUCTS_3,2}}': 89.2,
-    >>> #     '{{PRODUCTS_3,3}}': -5.1
+    >>> #     '{{PRODUCTS_1,1}}': 'Widget',
+    >>> #     '{{PRODUCTS_1,2}}': 125.5,
+    >>> #     '{{PRODUCTS_1,3}}': 15.3,
+    >>> #     '{{PRODUCTS_2,1}}': 'Gadget',
+    >>> #     '{{PRODUCTS_2,2}}': 89.2,
+    >>> #     '{{PRODUCTS_2,3}}': -5.1
     >>> # }
 """
 
@@ -43,7 +40,7 @@ def dataframe_to_replacement_object(df: pd.DataFrame, prefix: str = "") -> dict:
 
     The placeholder format follows the pattern {{prefix[row],[col]}} where:
     - prefix: Optional namespace string to group related replacements
-    - row: 1-based row index (includes column headers as row 1)
+    - row: 1-based row index for DataFrame values
     - col: 1-based column index
 
     This coordinate system allows templates to reference specific table
@@ -51,7 +48,6 @@ def dataframe_to_replacement_object(df: pd.DataFrame, prefix: str = "") -> dict:
 
     Args:
         df: Input DataFrame containing the tabular data to convert.
-            Column names become the first row of replacements.
         prefix: Optional string prefix for placeholder keys. Useful for
             namespacing when multiple tables are used in the same template.
             Should typically end with an underscore for readability.
@@ -73,12 +69,12 @@ def dataframe_to_replacement_object(df: pd.DataFrame, prefix: str = "") -> dict:
         >>> result = dataframe_to_replacement_object(df, 'SALES_')
         >>>
         >>> # Generated placeholders:
-        >>> # {{SALES_1,1}} = 'Quarter'  (column header)
-        >>> # {{SALES_1,2}} = 'Revenue'  (column header)
-        >>> # {{SALES_1,3}} = 'Growth'   (column header)
-        >>> # {{SALES_2,1}} = 'Q1'       (first data row)
-        >>> # {{SALES_2,2}} = 100        (first data row)
-        >>> # {{SALES_2,3}} = 5.2        (first data row)
+        >>> # {{SALES_1,1}} = 'Q1'       (first data row)
+        >>> # {{SALES_1,2}} = 100        (first data row)
+        >>> # {{SALES_1,3}} = 5.2        (first data row)
+        >>> # {{SALES_2,1}} = 'Q2'       (second data row)
+        >>> # {{SALES_2,2}} = 120        (second data row)
+        >>> # {{SALES_2,3}} = 8.1        (second data row)
         >>> # ... and so on
 
         Template usage:
@@ -91,7 +87,7 @@ def dataframe_to_replacement_object(df: pd.DataFrame, prefix: str = "") -> dict:
 
         >>> df = pd.DataFrame({'Name': ['Alice'], 'Age': [30]})
         >>> result = dataframe_to_replacement_object(df)
-        >>> # Returns: {'{{1,1}}': 'Name', '{{1,2}}': 'Age', '{{2,1}}': 'Alice', '{{2,2}}': 30}
+        >>> # Returns: {'{{1,1}}': 'Alice', '{{1,2}}': 30}
 
         Empty DataFrame handling:
 

--- a/tests/test_cli_output_and_main.py
+++ b/tests/test_cli_output_and_main.py
@@ -41,6 +41,7 @@ def test_theme_output_helpers_emit_expected_messages(monkeypatch):
 
     rendered = [str(args[0]) for args, _ in calls if args]
     assert any("Validation Complete" in entry for entry in rendered)
+    assert any("Validation Failed" in entry for entry in rendered)
     assert any("Build Complete" in entry for entry in rendered)
     assert any("line1" in entry for entry in rendered)
     assert all(

--- a/tests/test_replacements_utils.py
+++ b/tests/test_replacements_utils.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+from slideflow.replacements.utils import dataframe_to_replacement_object
+
+
+def test_dataframe_to_replacement_object_uses_values_not_headers():
+    df = pd.DataFrame(
+        {
+            "Quarter": ["Q1", "Q2"],
+            "Revenue": [100, 120],
+        }
+    )
+
+    assert dataframe_to_replacement_object(df, "SALES_") == {
+        "{{SALES_1,1}}": "Q1",
+        "{{SALES_1,2}}": 100,
+        "{{SALES_2,1}}": "Q2",
+        "{{SALES_2,2}}": 120,
+    }
+
+
+def test_dataframe_to_replacement_object_returns_empty_mapping_for_empty_df():
+    df = pd.DataFrame()
+
+    assert dataframe_to_replacement_object(df, "EMPTY_") == {}


### PR DESCRIPTION
## Summary
This PR completes issue #106 with focused, non-breaking correctness fixes.

## Changes
1. Fixed user-facing typo in validation error output
   - `slideflow/cli/theme.py`
   - `Validation Faliled` -> `Validation Failed`

2. Aligned `dataframe_to_replacement_object` documentation with implementation
   - `slideflow/replacements/utils.py`
   - Updated module/function docstrings and examples to match actual behavior (maps DataFrame values only; headers are not included).

3. Removed redundant assertion after explicit guard
   - `slideflow/replacements/table.py`
   - Deleted unreachable `assert df is not None` immediately after `if df is None: raise ...`

4. Added targeted regression tests
   - New: `tests/test_replacements_utils.py`
     - verifies value-only mapping behavior
     - verifies empty DataFrame returns empty mapping
   - Updated: `tests/test_cli_output_and_main.py`
     - asserts corrected `Validation Failed` text is emitted

## Validation
- `./.venv/bin/python -m pytest -q tests/test_cli_output_and_main.py tests/test_replacements_utils.py tests/test_table_replacement.py tests/test_replacements_and_transforms.py`
- `./.venv/bin/python -m ruff check slideflow/cli/theme.py slideflow/replacements/utils.py slideflow/replacements/table.py tests/test_cli_output_and_main.py tests/test_replacements_utils.py`
- `./.venv/bin/python -m black --check slideflow/cli/theme.py slideflow/replacements/utils.py slideflow/replacements/table.py tests/test_cli_output_and_main.py tests/test_replacements_utils.py`

All passed locally.

Closes #106