### PR TITLE
build: harden dependency constraints for runtime stability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,17 @@ python -m pytest -q tests/live_tests -m live_google
 - Preserve backward compatibility unless a breaking change is explicitly planned.
 - Keep legacy `databricks_dbt` behavior compatible while extending composable `dbt`.
 
+## Dependency policy
+
+- Runtime dependencies in `pyproject.toml` (`[project.dependencies]`) must have
+  an explicit upper bound.
+- dbt adapter ranges must stay compatible with `dbt-core` (same supported minor
+  train).
+- Security-sensitive dependencies must include explicit minimum versions when
+  relevant (for example, `gitpython>=3.1.41`).
+- If you change constraints, run `python -m pip check` and relevant tests before
+  opening a PR.
+
 ## Pull request checklist
 
 1. Keep changes scoped to one concern.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,6 +46,15 @@ python -m mkdocs build --strict
 3. Keep compatibility for existing users unless a breaking change is explicitly planned.
 4. Update `CHANGELOG.md` for user-visible changes.
 
+## Dependency constraints policy
+
+- Keep runtime dependency constraints bounded (`min` + `max major/minor`) in
+  `pyproject.toml`.
+- Keep dbt adapter compatibility aligned with the supported `dbt-core` train.
+- Add explicit minimum versions for security-sensitive packages when needed.
+- When changing constraints, run `python -m pip check` and the relevant test
+  suites before opening a PR.
+
 ## Additional references
 
 - Root contributing guide: [`CONTRIBUTING.md`](https://github.com/joe-broadhead/slideflow/blob/master/CONTRIBUTING.md)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -66,9 +66,15 @@ python -m pip install -e ".[docs]"
 mkdocs build --strict
 ```
 
-4. Bump versions in `pyproject.toml` and `slideflow/__init__.py`.
-5. Create release branch `release/vX.Y.Z`.
-6. Push and monitor `CI`, `Docs`, and `Release` workflows.
+4. Verify dependency constraints are still within policy:
+
+- runtime dependencies have explicit upper bounds
+- dbt adapters remain compatible with the supported `dbt-core` range
+- security-sensitive dependency minimums are preserved
+
+5. Bump versions in `pyproject.toml` and `slideflow/__init__.py`.
+6. Create release branch `release/vX.Y.Z`.
+7. Push and monitor `CI`, `Docs`, and `Release` workflows.
 
 ## PyPI trusted publishing setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,31 +12,31 @@ authors = [
     { name = "Tom Lovett" }
 ]
 dependencies = [
-    "typer",
-    "pydantic>=2.0",
-    "pydantic[email]>=2.0",
-    "pyyaml",
+    "typer>=0.24,<1.0",
+    "pydantic>=2.0,<3.0",
+    "pydantic[email]>=2.0,<3.0",
+    "pyyaml>=6.0,<7.0",
     "pandas>=2.2,<2.4",
     "numpy>=2.0,<2.5",
-    "rich",
-    "plotly",
-    "kaleido",
-    "google-api-python-client",
-    "google-auth",
-    "google-auth-oauthlib",
-    "google-auth-httplib2",
-    "httplib2",
-    "gitpython",
-    "dbt-core",
-    "dbt-databricks",
-    "databricks-sql-connector",
+    "rich>=13.0,<15.0",
+    "plotly>=6.0,<7.0",
+    "kaleido>=1.0,<2.0",
+    "google-api-python-client>=2.0,<3.0",
+    "google-auth>=2.0,<3.0",
+    "google-auth-oauthlib>=1.0,<2.0",
+    "google-auth-httplib2>=0.2,<1.0",
+    "httplib2>=0.22,<1.0",
+    "gitpython>=3.1.41,<4.0",
+    "dbt-core>=1.10,<1.12",
+    "dbt-databricks>=1.10,<1.12",
+    "databricks-sql-connector>=4.0,<5.0",
 ]
 requires-python = ">=3.12"
 
 [project.optional-dependencies]
-ai = ["openai", "google-genai"]
-bigquery = ["google-cloud-bigquery", "dbt-bigquery"]
-duckdb = ["duckdb", "dbt-duckdb"]
+ai = ["openai>=1.0,<3.0", "google-genai>=1.0,<2.0"]
+bigquery = ["google-cloud-bigquery>=3.0,<4.0", "dbt-bigquery>=1.10,<1.12"]
+duckdb = ["duckdb>=1.0,<2.0", "dbt-duckdb>=1.9,<1.12"]
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",


### PR DESCRIPTION
## Summary
Implements issue #107 by adding bounded constraints for critical runtime dependencies and documenting the dependency policy for contributors and releases.

## Changes
### 1) Runtime and optional dependency bounds in `pyproject.toml`
- Added explicit lower/upper bounds for core runtime dependencies, including:
  - `dbt-core>=1.10,<1.12`
  - `dbt-databricks>=1.10,<1.12`
  - `gitpython>=3.1.41,<4.0`
  - bounded ranges for typer/pydantic/pyyaml/rich/plotly/kaleido/google auth stack/databricks SQL connector.
- Added bounded ranges for optional extras used in runtime feature paths:
  - `ai` (`openai`, `google-genai`)
  - `bigquery` (`google-cloud-bigquery`, `dbt-bigquery`)
  - `duckdb` (`duckdb`, `dbt-duckdb`)

### 2) Dependency policy documentation
- Updated `CONTRIBUTING.md` with a dependency policy section.
- Updated `docs/contributing.md` with dependency constraints policy.
- Updated `docs/release-process.md` pre-release checklist to explicitly verify dependency policy compliance.

## Validation
Executed locally in project `.venv`:
- `./.venv/bin/python -m pip check`
- `./.venv/bin/python -m ruff check slideflow tests scripts`
- `./.venv/bin/python -m black --check slideflow tests scripts`
- `./.venv/bin/python -m mypy slideflow`
- `./.venv/bin/python -m pytest -q`

All passed.

## Notes
- In this sandbox, `pip install -e ".[dev,ai]"` could not be re-resolved due network restrictions. CI will validate dependency resolution in a clean environment.

Closes #107