### PR TITLE
Harden error paths and unify safe error formatting

### DIFF
--- a/slideflow/cli/commands/doctor.py
+++ b/slideflow/cli/commands/doctor.py
@@ -16,6 +16,7 @@ from slideflow.constants import Environment
 from slideflow.presentations.config import PresentationConfig
 from slideflow.presentations.providers.factory import ProviderFactory
 from slideflow.utilities import ConfigLoader
+from slideflow.utilities.error_messages import safe_error_line
 
 CheckSeverity = Literal["error", "warning", "info"]
 
@@ -28,11 +29,7 @@ def _check(
 
 def _first_error_line(error: Exception) -> str:
     """Return a safe single-line error description."""
-    first_line, _sep, _rest = str(error).partition("\n")
-    first_line = first_line.strip()
-    if first_line:
-        return first_line
-    return type(error).__name__
+    return safe_error_line(error)
 
 
 def _resolve_binary_candidate(candidate: Optional[str]) -> Optional[str]:

--- a/slideflow/cli/commands/validate.py
+++ b/slideflow/cli/commands/validate.py
@@ -52,6 +52,7 @@ from slideflow.cli.theme import (
 from slideflow.presentations.builder import PresentationBuilder
 from slideflow.presentations.config import PresentationConfig
 from slideflow.utilities import ConfigLoader
+from slideflow.utilities.error_messages import safe_error_line
 
 _GOOGLE_SLIDES_CONTRACT_FIELDS = (
     "slides(objectId,pageElements(shape(text(textElements(textRun(content))))))"
@@ -68,11 +69,7 @@ class ProviderContractValidationError(ValueError):
 
 def _first_error_line(error: Exception) -> str:
     """Return a safe single-line error description."""
-    lines = str(error).splitlines()
-    first_line = lines[0].strip() if lines else ""
-    if first_line:
-        return first_line
-    return type(error).__name__
+    return safe_error_line(error)
 
 
 def _collect_expected_contract(

--- a/slideflow/data/cache.py
+++ b/slideflow/data/cache.py
@@ -51,6 +51,10 @@ from typing import Any, Callable, Dict, Optional
 import pandas as pd
 
 from slideflow.constants import Defaults, Environment
+from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def _resolve_data_cache_max_entries() -> int:
@@ -194,8 +198,13 @@ class DataSourceCache:
         if hasattr(value, "model_dump") and callable(value.model_dump):
             try:
                 return DataSourceCache._normalize_for_key(value.model_dump())
-            except Exception:
-                pass
+            except Exception as error:
+                logger.debug(
+                    "Data cache key normalization: model_dump failed (%s); "
+                    "falling back to repr().",
+                    safe_error_line(error),
+                    exc_info=True,
+                )
 
         return repr(value)
 

--- a/slideflow/data/connectors/bigquery.py
+++ b/slideflow/data/connectors/bigquery.py
@@ -21,6 +21,7 @@ from google.auth.exceptions import DefaultCredentialsError
 
 from slideflow.constants import Environment
 from slideflow.data.connectors.base import DataConnector, SQLExecutor
+from slideflow.utilities.error_messages import safe_error_line
 from slideflow.utilities.exceptions import DataSourceError
 from slideflow.utilities.logging import (
     get_logger,
@@ -29,15 +30,6 @@ from slideflow.utilities.logging import (
 )
 
 logger = get_logger(__name__)
-
-
-def _safe_error_message(error: Exception) -> str:
-    """Get a non-empty single-line error message."""
-    message = str(error).strip()
-    if not message:
-        return error.__class__.__name__
-    first_line, _sep, _rest = message.partition("\n")
-    return first_line.strip() or error.__class__.__name__
 
 
 class BigQueryConnectorError(DataSourceError):
@@ -113,7 +105,7 @@ class BigQueryConnector(DataConnector):
         if isinstance(error, DefaultCredentialsError):
             return "authentication"
 
-        message = _safe_error_message(error).lower()
+        message = safe_error_line(error).lower()
         if any(
             token in message
             for token in (
@@ -165,7 +157,7 @@ class BigQueryConnector(DataConnector):
                 raise BigQueryConnectorError(
                     "configuration",
                     "Failed to load BigQuery credentials from credentials_json "
-                    f"({_safe_error_message(error)})",
+                    f"({safe_error_line(error)})",
                 ) from error
 
             inferred_project = payload.get("project_id") or getattr(
@@ -183,7 +175,7 @@ class BigQueryConnector(DataConnector):
                 raise BigQueryConnectorError(
                     "configuration",
                     "Failed to load BigQuery credentials from credentials_path "
-                    f"({_safe_error_message(error)})",
+                    f"({safe_error_line(error)})",
                 ) from error
 
             inferred_project = getattr(credentials, "project_id", None)
@@ -224,7 +216,7 @@ class BigQueryConnector(DataConnector):
                 raise BigQueryConnectorError(
                     category,
                     "Failed to initialize BigQuery client "
-                    f"({_safe_error_message(error)})",
+                    f"({safe_error_line(error)})",
                 ) from error
         return self._client
 
@@ -274,7 +266,7 @@ class BigQueryConnector(DataConnector):
                 if isinstance(error, BigQueryConnectorError)
                 else BigQueryConnectorError(
                     self._categorize_error(error),
-                    f"BigQuery query failed ({_safe_error_message(error)})",
+                    f"BigQuery query failed ({safe_error_line(error)})",
                 )
             )
             log_api_operation(

--- a/slideflow/data/connectors/databricks.py
+++ b/slideflow/data/connectors/databricks.py
@@ -49,6 +49,7 @@ from pydantic import ConfigDict, Field
 
 from slideflow.constants import Defaults, Environment
 from slideflow.data.connectors.base import BaseSourceConfig, DataConnector, SQLExecutor
+from slideflow.utilities.error_messages import safe_error_line
 from slideflow.utilities.exceptions import DataSourceError
 from slideflow.utilities.logging import (
     get_logger,
@@ -81,15 +82,6 @@ def _resolve_positive_int_from_env(env_var: str, default: int) -> int:
     except ValueError:
         return default
     return parsed if parsed > 0 else default
-
-
-def _safe_error_message(error: Exception) -> str:
-    """Get a non-empty single-line error message."""
-    message = str(error).strip()
-    if not message:
-        return error.__class__.__name__
-    first_line, _sep, _rest = message.partition("\n")
-    return first_line.strip() or error.__class__.__name__
 
 
 class DatabricksConnectorError(DataSourceError):
@@ -185,7 +177,7 @@ class DatabricksConnector(DataConnector):
     @staticmethod
     def _categorize_error(error: Exception) -> str:
         """Classify Databricks execution failures into stable categories."""
-        message = _safe_error_message(error).lower()
+        message = safe_error_line(error).lower()
         if any(
             token in message
             for token in (
@@ -284,7 +276,7 @@ class DatabricksConnector(DataConnector):
                 category = self._categorize_connect_error(error)
                 raise DatabricksConnectorError(
                     category,
-                    f"Failed to connect to Databricks ({_safe_error_message(error)})",
+                    f"Failed to connect to Databricks ({safe_error_line(error)})",
                 ) from error
         return self._connection
 
@@ -362,7 +354,7 @@ class DatabricksConnector(DataConnector):
                 if isinstance(e, DatabricksConnectorError)
                 else DatabricksConnectorError(
                     self._categorize_error(e),
-                    f"Databricks query failed ({_safe_error_message(e)})",
+                    f"Databricks query failed ({safe_error_line(e)})",
                 )
             )
             log_api_operation(

--- a/slideflow/data/connectors/duckdb.py
+++ b/slideflow/data/connectors/duckdb.py
@@ -11,16 +11,8 @@ import pandas as pd
 from pydantic import ConfigDict, Field
 
 from slideflow.data.connectors.base import BaseSourceConfig, DataConnector, SQLExecutor
+from slideflow.utilities.error_messages import safe_error_line
 from slideflow.utilities.exceptions import DataSourceError
-
-
-def _safe_error_message(error: Exception) -> str:
-    """Get a non-empty single-line error message."""
-    message = str(error).strip()
-    if not message:
-        return error.__class__.__name__
-    first_line, _sep, _rest = message.partition("\n")
-    return first_line.strip() or error.__class__.__name__
 
 
 def _normalize_file_search_path(
@@ -98,7 +90,7 @@ class DuckDBConnector(DataConnector):
                 raise DuckDBConnectorError(
                     "connection",
                     "Failed to initialize DuckDB connection "
-                    f"({_safe_error_message(error)})",
+                    f"({safe_error_line(error)})",
                 ) from error
         return self._connection
 
@@ -148,8 +140,7 @@ class DuckDBConnector(DataConnector):
         except Exception as error:
             raise DuckDBConnectorError(
                 "configuration",
-                "Failed to set DuckDB file_search_path "
-                f"({_safe_error_message(error)})",
+                "Failed to set DuckDB file_search_path " f"({safe_error_line(error)})",
             ) from error
         self._file_search_path_applied = True
 
@@ -165,7 +156,7 @@ class DuckDBConnector(DataConnector):
         except Exception as error:
             raise DuckDBConnectorError(
                 "query",
-                f"Failed to execute DuckDB query ({_safe_error_message(error)})",
+                f"Failed to execute DuckDB query ({safe_error_line(error)})",
             ) from error
 
 

--- a/slideflow/replacements/ai_text.py
+++ b/slideflow/replacements/ai_text.py
@@ -82,7 +82,11 @@ from slideflow.ai.providers import AIProvider
 from slideflow.ai.registry import get_provider_class
 from slideflow.data.connectors.connect import DataSourceConfig
 from slideflow.replacements.base import BaseReplacement
+from slideflow.utilities.error_messages import safe_error_line
 from slideflow.utilities.exceptions import ReplacementError
+from slideflow.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class AITextReplacement(BaseReplacement):
@@ -358,7 +362,14 @@ class AITextReplacement(BaseReplacement):
                 if df is not None:
                     try:
                         df = self.apply_data_transforms(df)
-                    except Exception:
+                    except Exception as error:
+                        logger.warning(
+                            "AI text replacement fallback: data transform failed for "
+                            "source '%s' (%s)",
+                            name,
+                            safe_error_line(error),
+                            exc_info=True,
+                        )
                         return f'Summary unable to be generated as data source "{name}" was not available'
                     data = df.to_dict(orient="records")
                     prompt += f"\n\nData from {name}:\n{data}"

--- a/slideflow/utilities/__init__.py
+++ b/slideflow/utilities/__init__.py
@@ -54,6 +54,7 @@ Performance Features:
 
 from slideflow.utilities.config import ConfigLoader
 from slideflow.utilities.data_transforms import apply_data_transforms
+from slideflow.utilities.error_messages import safe_error_line
 from slideflow.utilities.exceptions import (
     APIError,
     APIRateLimitError,
@@ -78,6 +79,7 @@ from slideflow.utilities.logging import (
 __all__ = [
     "ConfigLoader",
     "apply_data_transforms",
+    "safe_error_line",
     "SlideFlowError",
     "ConfigurationError",
     "DataSourceError",

--- a/slideflow/utilities/error_messages.py
+++ b/slideflow/utilities/error_messages.py
@@ -1,0 +1,22 @@
+"""Helpers for concise, safe exception message rendering."""
+
+from typing import Optional
+
+
+def safe_error_line(error: BaseException, fallback: Optional[str] = None) -> str:
+    """Return a non-empty single-line error message.
+
+    - Collapses multi-line exception strings to the first line.
+    - Falls back to exception class name when the message is empty.
+    - Uses explicit fallback text when provided.
+    """
+    message = str(error).strip()
+    if message:
+        first_line = message.splitlines()[0].strip()
+        if first_line:
+            return first_line
+
+    if fallback:
+        return fallback
+
+    return error.__class__.__name__

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,16 @@
+from slideflow.utilities.error_messages import safe_error_line
+
+
+def test_safe_error_line_returns_first_line_for_multiline_errors():
+    error = RuntimeError("first line\nsecond line")
+    assert safe_error_line(error) == "first line"
+
+
+def test_safe_error_line_handles_carriage_return_only_separator():
+    error = RuntimeError("first line\rsecond line")
+    assert safe_error_line(error) == "first line"
+
+
+def test_safe_error_line_falls_back_to_exception_type_when_empty():
+    error = RuntimeError("")
+    assert safe_error_line(error) == "RuntimeError"

--- a/tests/test_replacements_and_transforms.py
+++ b/tests/test_replacements_and_transforms.py
@@ -228,6 +228,13 @@ def test_ai_text_replacement_data_context_and_transform_failure_fallback(monkeyp
     def fail_transform(_frame):
         raise RuntimeError("boom")
 
+    warning_calls = []
+    monkeypatch.setattr(
+        ai_text_module.logger,
+        "warning",
+        lambda *args, **kwargs: warning_calls.append((args, kwargs)),
+    )
+
     failing = AITextReplacement.model_construct(
         type="ai_text",
         placeholder="{{AI_FAIL}}",
@@ -241,3 +248,4 @@ def test_ai_text_replacement_data_context_and_transform_failure_fallback(monkeyp
         failing.get_replacement()
         == 'Summary unable to be generated as data source "sales" was not available'
     )
+    assert warning_calls

--- a/tests/test_runtime_utilities.py
+++ b/tests/test_runtime_utilities.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import pandas as pd
 import pytest
 
+import slideflow.data.cache as data_cache_module
 import slideflow.utilities.rate_limiter as rate_limiter_module
 from slideflow.constants import Environment
 from slideflow.data.cache import DataSourceCache, get_data_cache
@@ -107,6 +108,30 @@ def test_data_source_cache_key_generation_distinguishes_tuple_from_list():
         vars={"dimensions": ["region", "segment"]},
     )
     assert key_with_tuple != key_with_list
+
+
+def test_data_source_cache_logs_model_dump_normalization_failures(monkeypatch):
+    cache = DataSourceCache()
+    debug_calls = []
+    monkeypatch.setattr(
+        data_cache_module.logger,
+        "debug",
+        lambda *args, **kwargs: debug_calls.append((args, kwargs)),
+    )
+
+    class BrokenDump:
+        def model_dump(self):
+            raise RuntimeError("boom")
+
+        def __repr__(self):
+            return "<BrokenDump>"
+
+    key = cache._generate_key("dbt", vars={"broken": BrokenDump()})
+
+    assert key
+    assert debug_calls
+    first_args = debug_calls[0][0]
+    assert "model_dump failed" in first_args[0]
 
 
 def test_data_source_cache_enforces_lru_entry_cap(monkeypatch):


### PR DESCRIPTION
## Summary
- add shared `safe_error_line` utility for robust first-line error extraction
- replace duplicated connector/CLI helpers with shared utility usage
- harden error observability in AI text transforms and cache normalization paths
- add tests for odd/empty exception strings and new logging behavior

## Why
Closes #111 by removing silent failure paths, deduplicating safe error formatting, and preserving stable CLI-facing error behavior while improving internal diagnostics.

## Changes
- New utility: `slideflow/utilities/error_messages.py`
- CLI: doctor/validate now use shared safe error helper
- Connectors: databricks/bigquery/duckdb deduplicated onto shared helper
- AI replacements: log transform exceptions (warning + traceback) before safe fallback
- Cache normalization: debug-log model dump normalization failures instead of silent pass
- Tests: added `tests/test_error_messages.py` and updated existing tests for logging behavior

## Validation
- `./.venv/bin/python -m ruff check slideflow tests scripts`
- `./.venv/bin/python -m black --check slideflow tests scripts`
- `./.venv/bin/python -m mypy slideflow`
- `./.venv/bin/python -m pytest -q`

## Notes
- CLI output contract and machine-readable behavior are unchanged.
- Live test remains skipped unless `SLIDEFLOW_RUN_LIVE=1`.