### PR TITLE
Centralize retry/sleep timing controls for build and rendering

### DIFF
--- a/slideflow/cli/commands/build.py
+++ b/slideflow/cli/commands/build.py
@@ -29,6 +29,7 @@ Example:
         slideflow build config.yaml --dry-run
 """
 
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -48,10 +49,20 @@ from slideflow.cli.theme import (
     print_build_progress,
     print_build_success,
 )
+from slideflow.constants import Timing
 from slideflow.presentations import PresentationBuilder
 from slideflow.presentations.config import PresentationConfig
 from slideflow.presentations.providers.factory import ProviderFactory
 from slideflow.utilities import ConfigLoader
+
+
+def _sleep_for_progress(seconds: float) -> None:
+    """Pace interactive progress output without slowing non-interactive runs."""
+    if seconds <= 0:
+        return
+    if not sys.stdout.isatty():
+        return
+    time.sleep(seconds)
 
 
 def build_single_presentation(
@@ -266,7 +277,7 @@ def build_command(
 
     try:
         print_build_progress(1, 6, "Loading configuration...")
-        time.sleep(0.5)
+        _sleep_for_progress(Timing.BUILD_PROGRESS_DELAY_INITIAL_S)
 
         raw_config = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
         config_registry = raw_config.get("registry")
@@ -322,15 +333,15 @@ def build_command(
             return []
 
         print_build_progress(2, 6, "Initializing presentation builder...")
-        time.sleep(0.3)
+        _sleep_for_progress(Timing.BUILD_PROGRESS_DELAY_STEP_S)
 
         print_build_progress(
             3, 6, f"Processing {total_presentations} presentation(s) concurrently..."
         )
-        time.sleep(0.5)
+        _sleep_for_progress(Timing.BUILD_PROGRESS_DELAY_INITIAL_S)
 
         print_build_progress(4, 6, "Starting concurrent generation...")
-        time.sleep(0.3)
+        _sleep_for_progress(Timing.BUILD_PROGRESS_DELAY_STEP_S)
 
         # Create thread lock for safe printing
         print_lock = threading.Lock()
@@ -339,7 +350,9 @@ def build_command(
         if threads:
             max_workers = threads
         else:
-            max_workers = min(total_presentations, 5)  # Max 5 concurrent presentations
+            max_workers = min(
+                total_presentations, Timing.BUILD_MAX_WORKERS_DEFAULT
+            )  # Max concurrent presentations by default
 
         results = []
         completed_count = 0
@@ -390,7 +403,7 @@ def build_command(
                     raise
 
         print_build_progress(6, 6, "All presentations deployed!")
-        time.sleep(0.3)
+        _sleep_for_progress(Timing.BUILD_PROGRESS_DELAY_STEP_S)
 
         # Sort results by original order and print summary
         results.sort(

--- a/slideflow/constants.py
+++ b/slideflow/constants.py
@@ -22,6 +22,7 @@ Key Constant Categories:
     - ErrorMessages: Standardized error message templates
     - Cache: Caching system configuration and operation types
     - Concurrency: Concurrent processing settings and limits
+    - Timing: Centralized retry/sleep/backoff defaults across workflows
     - Validation: Data validation thresholds and patterns
     - Environment: Environment variable names for external integrations
     - Status: Operation status indicators and state definitions
@@ -298,6 +299,33 @@ class Concurrency:
     DEFAULT_TIMEOUT_SECONDS = 30
     MAX_WORKERS_DEFAULT = 10
     THREAD_NAME_PREFIX = "slideflow-worker"
+
+
+class Timing:
+    """Timing and retry/backoff constants for runtime workflows.
+
+    These values centralize non-functional timing controls used in build,
+    chart export, and provider operations. Defaults preserve current behavior
+    while making tuning explicit and discoverable.
+    """
+
+    # Build command progress pacing and worker selection
+    BUILD_PROGRESS_DELAY_INITIAL_S = 0.5
+    BUILD_PROGRESS_DELAY_STEP_S = 0.3
+    BUILD_MAX_WORKERS_DEFAULT = 5
+
+    # Chart export process behavior
+    CHART_EXPORT_KALEIDO_START_TIMEOUT_S = 90
+    CHART_EXPORT_RETRY_TIMEOUTS_S = (30, 60, 90)
+
+    # Presentation chart and replacement pacing
+    PRESENTATION_CHART_MAX_RETRIES = 3
+    PRESENTATION_CHART_RETRY_DELAY_S = 3.0
+    PRESENTATION_CHART_RETRY_BACKOFF_MULTIPLIER = 1.0
+    PRESENTATION_TABLE_REPLACEMENT_DELAY_S = 1.0
+
+    # Google Drive permission propagation wait after upload
+    GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S = 2.0
 
 
 class Validation:

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -62,7 +62,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Callable, Dict, List, Optional
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from slideflow.constants import GoogleSlides
+from slideflow.constants import GoogleSlides, Timing
 from slideflow.presentations.positioning import compute_chart_dimensions
 from slideflow.presentations.providers.base import PresentationProvider
 from slideflow.replacements.base import BaseReplacement
@@ -549,8 +549,11 @@ class Presentation(BaseModel):
             for slide in self.slides:
                 # Generate charts for this slide
                 for chart in slide.charts:
-                    max_retries = 3
-                    delay_seconds = 3
+                    max_retries = Timing.PRESENTATION_CHART_MAX_RETRIES
+                    base_retry_delay_s = Timing.PRESENTATION_CHART_RETRY_DELAY_S
+                    backoff_multiplier = (
+                        Timing.PRESENTATION_CHART_RETRY_BACKOFF_MULTIPLIER
+                    )
                     for attempt in range(max_retries):
                         try:
                             df = (
@@ -594,10 +597,14 @@ class Presentation(BaseModel):
                             break  # Break out of retry loop on success
                         except Exception as e:
                             if attempt < max_retries - 1:
+                                delay_seconds = base_retry_delay_s * (
+                                    backoff_multiplier**attempt
+                                )
                                 logger.warning(
                                     f"Chart processing failed for '{chart.title or chart.type}' on slide '{slide.id}' (attempt {attempt + 1}/{max_retries}). Retrying in {delay_seconds} seconds. Error: {e}"
                                 )
-                                time.sleep(delay_seconds)
+                                if delay_seconds > 0:
+                                    time.sleep(delay_seconds)
                             else:
                                 logger.error(
                                     f"Chart processing failed for '{chart.title or chart.type}' on slide '{slide.id}' after {max_retries} attempts. Inserting error placeholder. Error: {e}"
@@ -659,7 +666,13 @@ class Presentation(BaseModel):
                             # Table replacements return a dictionary of placeholder->value
                             if isinstance(replacement_result, dict):
                                 for placeholder, value in replacement_result.items():
-                                    time.sleep(1)
+                                    if (
+                                        Timing.PRESENTATION_TABLE_REPLACEMENT_DELAY_S
+                                        > 0
+                                    ):
+                                        time.sleep(
+                                            Timing.PRESENTATION_TABLE_REPLACEMENT_DELAY_S
+                                        )
                                     replacements_made = (
                                         self.provider.replace_text_in_slide(
                                             presentation_id,

--- a/slideflow/presentations/charts.py
+++ b/slideflow/presentations/charts.py
@@ -68,7 +68,7 @@ from googleapiclient.http import MediaIoBaseUpload
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from slideflow.builtins.template_engine import get_template_engine
-from slideflow.constants import FileExtensions, GoogleSlides
+from slideflow.constants import FileExtensions, GoogleSlides, Timing
 from slideflow.data.connectors.base import BaseSourceConfig as DataSourceConfig
 from slideflow.presentations.positioning import safe_eval_expression
 from slideflow.presentations.providers.google_slides import _get_rate_limiter
@@ -139,7 +139,12 @@ def _plotly_to_image(
 
         # Reuse a single sync server per process to avoid repeatedly spawning
         # browser processes for each chart export.
-        kaleido.start_sync_server(n=1, timeout=90, headless=True, silence_warnings=True)
+        kaleido.start_sync_server(
+            n=1,
+            timeout=Timing.CHART_EXPORT_KALEIDO_START_TIMEOUT_S,
+            headless=True,
+            silence_warnings=True,
+        )
 
         # Force headless browser execution so local desktop runs avoid visible windows
         # and orchestrated runs remain deterministic.
@@ -160,12 +165,13 @@ def _plotly_to_image(
 def _execute_with_retry(func, *args, **kwargs):
     """
     Executes a function with a retry mechanism.
-    It will first try to generate a graph and wait 30 seconds.
-    If the process does not answer it will restart it with a 60 seconds timeout,
-    then 90 seconds. If it doesn't work at the end it will raise ChartGenerationError.
+
+    The timeout sequence is configured via ``Timing.CHART_EXPORT_RETRY_TIMEOUTS_S``.
+    If execution times out, the chart export worker is reset before retrying.
+    If all retries are exhausted, raises ChartGenerationError.
     """
     execution_id = uuid.uuid4().hex[:8]
-    timeouts = [30, 60, 90]
+    timeouts = Timing.CHART_EXPORT_RETRY_TIMEOUTS_S
     for i, timeout in enumerate(timeouts):
         executor = _get_chart_export_executor()
         try:

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -77,7 +77,7 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseUpload
 from pydantic import Field
 
-from slideflow.constants import Environment, GoogleSlides
+from slideflow.constants import Environment, GoogleSlides, Timing
 from slideflow.presentations.providers.base import (
     PresentationProvider,
     PresentationProviderConfig,
@@ -718,7 +718,8 @@ class GoogleSlidesProvider(PresentationProvider):
                 )
             )
 
-            time.sleep(2)
+            if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
+                time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
 
             public_url = f"https://drive.google.com/uc?id={file_id}"
             duration = time.time() - start_time

--- a/tests/test_charts_coverage_runtime.py
+++ b/tests/test_charts_coverage_runtime.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 import slideflow.presentations.charts as charts_module
-from slideflow.constants import GoogleSlides
+from slideflow.constants import GoogleSlides, Timing
 from slideflow.utilities.exceptions import ChartGenerationError
 
 
@@ -140,6 +140,47 @@ def test_execute_with_retry_raises_after_all_timeouts(monkeypatch):
     assert reset_calls == [True, True, True]
 
 
+def test_execute_with_retry_uses_configured_timeout_sequence(monkeypatch):
+    class _FutureTimeout:
+        def __init__(self) -> None:
+            self.timeouts: List[int] = []
+
+        def result(self, timeout: int) -> bytes:
+            self.timeouts.append(timeout)
+            raise TimeoutError()
+
+    class _Executor:
+        def __init__(self, future: _FutureTimeout) -> None:
+            self.future = future
+
+        def submit(self, func, *args, **kwargs):
+            return self.future
+
+    future = _FutureTimeout()
+    executor = _Executor(future)
+    reset_calls: List[bool] = []
+
+    monkeypatch.setattr(
+        charts_module,
+        "_get_chart_export_executor",
+        lambda: executor,
+    )
+    monkeypatch.setattr(
+        charts_module, "_reset_chart_export_executor", lambda: reset_calls.append(True)
+    )
+    monkeypatch.setattr(
+        charts_module.Timing,
+        "CHART_EXPORT_RETRY_TIMEOUTS_S",
+        (1, 2, 3),
+    )
+
+    with pytest.raises(ChartGenerationError, match="failed after all retries"):
+        charts_module._execute_with_retry(lambda: b"unused")
+
+    assert future.timeouts == [1, 2, 3]
+    assert reset_calls == [True, True, True]
+
+
 def test_plotly_to_image_without_scale_omits_scale_option(monkeypatch):
     calls: Dict[str, Any] = {}
 
@@ -164,6 +205,9 @@ def test_plotly_to_image_without_scale_omits_scale_option(monkeypatch):
 
     assert rendered == b"ok"
     assert calls["opts"] == {"format": "png", "width": 200, "height": 100}
+    assert (
+        calls["server_kwargs"]["timeout"] == Timing.CHART_EXPORT_KALEIDO_START_TIMEOUT_S
+    )
 
 
 def test_base_chart_validation_fetch_transform_and_upload(monkeypatch):

--- a/tests/test_connectors_and_providers_unit.py
+++ b/tests/test_connectors_and_providers_unit.py
@@ -534,6 +534,55 @@ def test_google_provider_execute_request_and_batch_update(monkeypatch):
     assert logs and logs[-1][0][2] is True
 
 
+def test_google_provider_upload_image_uses_configured_propagation_delay(monkeypatch):
+    provider = object.__new__(google_provider_module.GoogleSlidesProvider)
+    provider.config = SimpleNamespace(drive_folder_id="folder-1")
+
+    class _Files:
+        def create(self, **kwargs):
+            return ("file-create", kwargs)
+
+    class _Permissions:
+        def create(self, **kwargs):
+            return ("permission-create", kwargs)
+
+    provider.drive_service = SimpleNamespace(
+        files=lambda: _Files(),
+        permissions=lambda: _Permissions(),
+    )
+
+    executed = []
+
+    def _execute(request):
+        executed.append(request)
+        if len(executed) == 1:
+            return {"id": "file-1"}
+        return {}
+
+    monkeypatch.setattr(provider, "_execute_request", _execute)
+    monkeypatch.setattr(
+        google_provider_module,
+        "log_api_operation",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        google_provider_module.Timing,
+        "GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S",
+        0.25,
+    )
+    sleep_calls = []
+    monkeypatch.setattr(
+        google_provider_module.time, "sleep", lambda delay: sleep_calls.append(delay)
+    )
+
+    public_url, file_id = provider._upload_image_to_drive(b"image-bytes", "chart.png")
+
+    assert file_id == "file-1"
+    assert public_url == "https://drive.google.com/uc?id=file-1"
+    assert sleep_calls == [0.25]
+    assert len(executed) == 2
+
+
 def test_google_rate_limiter_singleton_update(monkeypatch):
     monkeypatch.setattr(google_provider_module, "_api_rate_limiter", None)
     rl1 = google_provider_module._get_rate_limiter(1.0)

--- a/tests/test_runtime_workflows_phase4.py
+++ b/tests/test_runtime_workflows_phase4.py
@@ -219,6 +219,83 @@ def test_build_command_non_dry_run_worker_failure_exits(tmp_path, monkeypatch):
     assert exc_info.value.code == 1
 
 
+def test_build_command_uses_configured_default_worker_cap(tmp_path, monkeypatch):
+    _stub_build_cli_output(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n",
+        encoding="utf-8",
+    )
+    params_path = tmp_path / "params.csv"
+    params_path.write_text("region\nus\neu\napac\n", encoding="utf-8")
+
+    class _Future:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def result(self):
+            return self._payload
+
+    captured = {}
+
+    class _Executor:
+        def __init__(self, max_workers):
+            captured["max_workers"] = max_workers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def submit(self, func, *args, **kwargs):
+            return _Future(func(*args, **kwargs))
+
+    monkeypatch.setattr(build_command_module, "ThreadPoolExecutor", _Executor)
+    monkeypatch.setattr(
+        build_command_module, "as_completed", lambda futures: list(futures)
+    )
+    monkeypatch.setattr(build_command_module.Timing, "BUILD_MAX_WORKERS_DEFAULT", 2)
+
+    def _fake_build_single(
+        config_file,
+        registry_files,
+        params,
+        index,
+        total,
+        print_lock,
+        requests_per_second=None,
+    ):
+        return (
+            f"{params['region']} Deck",
+            SimpleNamespace(presentation_url=f"https://example.com/{params['region']}"),
+            index,
+            params,
+        )
+
+    monkeypatch.setattr(
+        build_command_module, "build_single_presentation", _fake_build_single
+    )
+
+    result = build_command_module.build_command(
+        config_file=config_file,
+        registry_files=None,
+        params_path=params_path,
+        dry_run=False,
+        threads=None,
+    )
+
+    assert captured["max_workers"] == 2
+    assert len(result) == 3
+
+
 def test_presentation_builder_from_yaml_uses_loader_and_delegates(
     monkeypatch, tmp_path
 ):
@@ -466,7 +543,15 @@ def test_render_shares_presentation_and_processes_table_replacements(monkeypatch
 
 
 def test_render_inserts_error_placeholder_after_chart_retries(monkeypatch):
-    monkeypatch.setattr(base_module.time, "sleep", lambda *_: None)
+    sleep_calls = []
+    monkeypatch.setattr(
+        base_module.time, "sleep", lambda delay: sleep_calls.append(delay)
+    )
+    monkeypatch.setattr(base_module.Timing, "PRESENTATION_CHART_MAX_RETRIES", 3)
+    monkeypatch.setattr(base_module.Timing, "PRESENTATION_CHART_RETRY_DELAY_S", 1.5)
+    monkeypatch.setattr(
+        base_module.Timing, "PRESENTATION_CHART_RETRY_BACKOFF_MULTIPLIER", 2.0
+    )
 
     class FailingChart:
         type = "plotly_go"
@@ -535,3 +620,4 @@ def test_render_inserts_error_placeholder_after_chart_retries(monkeypatch):
         provider.insert_calls[0][1]
         == "https://drive.google.com/uc?id=10geCrUpKZmQBesbhjtepZ9NexE-HRkn4"
     )
+    assert sleep_calls == [1.5, 3.0]


### PR DESCRIPTION
## Summary
- centralize runtime timing values in `slideflow.constants.Timing`
- refactor build/render/provider/chart modules to consume shared timing constants
- add targeted tests for retry timeout sequencing, backoff delays, default worker cap, and upload propagation delay
- keep default runtime behavior unchanged while making delays tunable and explicit

## Why
Closes #110.

This removes scattered hardcoded timing/retry literals and reduces fixed delay overhead in non-interactive build runs, while preserving existing defaults and compatibility.

## Changes
### Constants
- Added `Timing` constants in `slideflow/constants.py` for:
  - build progress delays and default worker cap
  - chart export retry timeout sequence + Kaleido startup timeout
  - presentation chart retry delay/backoff and table replacement delay
  - Google Drive permission propagation delay

### Runtime refactors
- `slideflow/cli/commands/build.py`
  - replaced inline sleeps with `_sleep_for_progress()` using `Timing` constants
  - progress pacing now only applies in interactive TTY contexts
  - replaced hardcoded default max workers (`5`) with `Timing.BUILD_MAX_WORKERS_DEFAULT`
- `slideflow/presentations/base.py`
  - replaced hardcoded chart retry values (`max_retries=3`, `delay=3`) with `Timing`
  - introduced configurable retry backoff multiplier (default `1.0` to preserve behavior)
  - replaced table replacement sleep (`1s`) with `Timing` constant
- `slideflow/presentations/charts.py`
  - replaced hardcoded Kaleido server timeout (`90`) with `Timing`
  - replaced hardcoded retry timeout list (`[30, 60, 90]`) with `Timing` constant
- `slideflow/presentations/providers/google_slides.py`
  - replaced hardcoded upload propagation sleep (`2s`) with `Timing` constant

### Tests
- `tests/test_charts_coverage_runtime.py`
  - added coverage verifying retry uses configured timeout sequence
  - asserted Kaleido startup timeout aligns to `Timing`
- `tests/test_runtime_workflows_phase4.py`
  - added coverage for default worker cap honoring `Timing.BUILD_MAX_WORKERS_DEFAULT`
  - added coverage for retry backoff delay sequence in render path
- `tests/test_connectors_and_providers_unit.py`
  - added coverage for upload propagation delay honoring `Timing`

## Validation
- `./.venv/bin/python -m ruff check slideflow tests scripts`
- `./.venv/bin/python -m black --check slideflow tests scripts`
- `./.venv/bin/python -m mypy slideflow`
- `./.venv/bin/python -m pytest -q`
- targeted: `./.venv/bin/python -m pytest -q tests/test_charts_coverage_runtime.py tests/test_runtime_workflows_phase4.py tests/test_connectors_and_providers_unit.py`

All passed locally (full suite: `250 passed, 1 skipped`).