### PR TITLE
Deduplicate CLI helper rendering and remove import-time logging setup

### DIFF
--- a/slideflow/cli/utils.py
+++ b/slideflow/cli/utils.py
@@ -1,171 +1,29 @@
-"""CLI utility functions for Slideflow.
+"""Compatibility wrappers for CLI output helpers.
 
-This module provides utility functions used by the CLI commands for common
-operations like displaying validation headers, configuration summaries, and
-error handling. These utilities complement the main theme module with simpler,
-more focused functionality.
-
-The utilities focus on:
-    - Simple text output and formatting
-    - Error handling and display
-    - Configuration summary generation
-    - Consistent message formatting
-
-Note:
-    This module appears to contain duplicate functionality with theme.py.
-    The functions here may be legacy implementations that could be consolidated
-    with the main theme system for consistency.
-
-Example:
-    >>> from slideflow.cli.utils import print_config_summary
-    >>> print_config_summary(presentation_config)
+This module intentionally delegates to :mod:`slideflow.cli.theme` to keep a
+single source of truth for CLI rendering behavior while preserving the legacy
+`slideflow.cli.utils` import surface.
 """
 
 from pathlib import Path
 
-from rich.console import Console
-from rich.panel import Panel
-
+import slideflow.cli.theme as theme
 from slideflow.presentations.config import PresentationConfig
 
-console = Console()
+# Backward-compatible alias for callers/tests that reference this module member.
+console = theme.console
 
 
 def print_validation_header(config_file: Path) -> None:
-    """Print a formatted header for validation operations.
-
-    Displays a simple panel with the validation header and target file.
-    This is an alternative to the main theme's validation header with
-    a more minimal design.
-
-    Args:
-        config_file: Path to the configuration file being validated.
-
-    Example:
-        >>> print_validation_header(Path("config.yaml"))
-        # Displays simple validation header panel
-
-    Note:
-        This function duplicates functionality in theme.py and may be
-        consolidated in future versions.
-    """
-    console.print(
-        Panel.fit(
-            f"[bold blue]Slideflow Configuration Validator[/bold blue]\n"
-            f"Validating: [cyan]{config_file}[/cyan]",
-            border_style="blue",
-        )
-    )
+    """Render validation header via the shared theme implementation."""
+    theme.print_validation_header(str(config_file))
 
 
 def print_config_summary(presentation_config: PresentationConfig) -> None:
-    """Print a summary of the validated configuration.
-
-    Displays a text-based summary of the presentation configuration including
-    slide count, data sources, replacements, and charts. This provides a
-    simpler alternative to the table-based summary in theme.py.
-
-    Args:
-        presentation_config: Validated PresentationConfig object containing
-            the complete presentation structure and metadata.
-
-    Example:
-        >>> print_config_summary(config)
-        # Displays:
-        # Summary:
-        #   📄 Presentation: Q3 Report
-        #   📊 Slides: 5
-        #   🗃️ Data sources: 3
-        #      Types: csv, databricks
-        #   🔄 Replacements: 12
-        #   📈 Charts: 4
-
-    Note:
-        This function duplicates functionality in theme.py with a different
-        format. Consider consolidating for consistency.
-    """
-    presentation = presentation_config.presentation
-    slides_count = len(presentation.slides)
-
-    console.print("\n[cyan]Summary:[/cyan]")
-    console.print(f"  📄 Presentation: {presentation.name}")
-    console.print(f"  📊 Slides: {slides_count}")
-
-    data_source_types = set()
-    data_sources_count = 0
-
-    if (
-        hasattr(presentation_config, "data_sources")
-        and presentation_config.data_sources
-    ):
-        data_sources_count += len(presentation_config.data_sources)
-        for ds_config in presentation_config.data_sources.values():
-            data_source_types.add(ds_config.type)
-
-    for slide in presentation.slides:
-        for replacement_spec in slide.replacements:
-            # replacement_spec.config is a dict that may contain data_source
-            if (
-                isinstance(replacement_spec.config, dict)
-                and "data_source" in replacement_spec.config
-            ):
-                ds_config = replacement_spec.config["data_source"]
-                if ds_config and isinstance(ds_config, dict) and "type" in ds_config:
-                    data_sources_count += 1
-                    data_source_types.add(ds_config["type"])
-
-        for chart_spec in slide.charts:
-            # chart_spec.config is a dict that may contain data_source
-            if (
-                isinstance(chart_spec.config, dict)
-                and "data_source" in chart_spec.config
-            ):
-                ds_config = chart_spec.config["data_source"]
-                if ds_config and isinstance(ds_config, dict) and "type" in ds_config:
-                    data_sources_count += 1
-                    data_source_types.add(ds_config["type"])
-
-    if data_sources_count > 0:
-        console.print(f"  🗃️  Data sources: {data_sources_count}")
-        if data_source_types:
-            types_str = ", ".join(sorted(data_source_types))
-            console.print(f"     Types: {types_str}")
-
-    total_replacements = sum(len(slide.replacements) for slide in presentation.slides)
-    total_charts = sum(len(slide.charts) for slide in presentation.slides)
-
-    if total_replacements:
-        console.print(f"  🔄 Replacements: {total_replacements}")
-    if total_charts:
-        console.print(f"  📈 Charts: {total_charts}")
+    """Render config summary via the shared theme implementation."""
+    theme.print_config_summary(presentation_config)
 
 
 def handle_validation_error(error: Exception, verbose: bool = False) -> None:
-    """Handle and display validation errors consistently.
-
-    Provides standardized error formatting for validation failures.
-    Can display either brief or detailed error information based on
-    the verbose setting.
-
-    Args:
-        error: Exception that occurred during validation.
-        verbose: If True, displays the complete error message including
-            stack traces. If False, shows only the first line for brevity.
-
-    Example:
-        >>> try:
-        ...     validate_config(config)
-        ... except Exception as e:
-        ...     handle_validation_error(e, verbose=True)
-
-    Note:
-        This function provides similar functionality to print_error in
-        theme.py but with a different interface. Consider consolidating.
-    """
-    console.print("[red]❌ Validation failed:[/red]")
-    if verbose:
-        console.print(f"[red]{str(error)}[/red]")
-    else:
-        # Show first line of error only
-        error_msg = str(error).split("\n")[0]
-        console.print(f"[red]{error_msg}[/red]")
+    """Render validation errors via the shared theme implementation."""
+    theme.print_error(error, verbose=verbose)

--- a/slideflow/utilities/logging.py
+++ b/slideflow/utilities/logging.py
@@ -443,4 +443,6 @@ def log_api_operation(
     logger.log(level, " ".join(message_parts))
 
 
-setup_logging()
+# Logging is intentionally not configured at import time.
+# CLI entrypoints (and embedding applications) should call setup_logging()
+# explicitly to control levels/format/handlers.

--- a/tests/test_cli_output_and_main.py
+++ b/tests/test_cli_output_and_main.py
@@ -1,9 +1,11 @@
+import importlib
 from pathlib import Path
 from types import SimpleNamespace
 
 import slideflow.cli.main as cli_main_module
 import slideflow.cli.theme as theme_module
 import slideflow.cli.utils as cli_utils_module
+import slideflow.utilities.logging as logging_module
 
 
 def _sample_presentation_config():
@@ -76,22 +78,54 @@ def test_theme_validation_error_verbose_includes_full_message(monkeypatch):
 
 
 def test_cli_utils_helpers_emit_summary_and_error(monkeypatch):
-    calls = []
+    header_calls = []
+    summary_calls = []
+    error_calls = []
+
     monkeypatch.setattr(
-        cli_utils_module.console, "print", lambda *a, **k: calls.append((a, k))
+        cli_utils_module.theme,
+        "print_validation_header",
+        lambda config_file: header_calls.append(config_file),
+    )
+    monkeypatch.setattr(
+        cli_utils_module.theme,
+        "print_config_summary",
+        lambda config: summary_calls.append(config),
+    )
+    monkeypatch.setattr(
+        cli_utils_module.theme,
+        "print_error",
+        lambda error_msg, verbose=False, error_code=None: error_calls.append(
+            (error_msg, verbose, error_code)
+        ),
     )
 
+    config = _sample_presentation_config()
     cli_utils_module.print_validation_header(Path("config.yml"))
-    cli_utils_module.print_config_summary(_sample_presentation_config())
+    cli_utils_module.print_config_summary(config)
     cli_utils_module.handle_validation_error(RuntimeError("simple error"))
     cli_utils_module.handle_validation_error(RuntimeError("line1\nline2"), verbose=True)
 
-    rendered = [str(args[0]) for args, _ in calls if args]
-    assert calls
-    assert any("Summary" in entry for entry in rendered)
-    assert any("Presentation: Demo Deck" in entry for entry in rendered)
-    assert any("simple error" in entry for entry in rendered)
-    assert any("line1\nline2" in entry for entry in rendered)
+    assert header_calls == ["config.yml"]
+    assert summary_calls == [config]
+    assert len(error_calls) == 2
+    assert str(error_calls[0][0]) == "simple error"
+    assert error_calls[0][1] is False
+    assert str(error_calls[1][0]) == "line1\nline2"
+    assert error_calls[1][1] is True
+
+
+def test_logging_module_import_does_not_auto_configure_basic_config(monkeypatch):
+    basic_config_calls = []
+    monkeypatch.setattr(
+        logging_module.logging,
+        "basicConfig",
+        lambda *args, **kwargs: basic_config_calls.append((args, kwargs)),
+    )
+
+    importlib.reload(logging_module)
+
+    assert basic_config_calls == []
 
 
 def test_main_sets_log_level_and_prints_banner_only_without_subcommand(monkeypatch):


### PR DESCRIPTION
## Summary
- make `slideflow.cli.utils` a compatibility wrapper over `slideflow.cli.theme`
- remove duplicate validation header/summary/error rendering implementations
- remove import-time `setup_logging()` side effect from `slideflow.utilities.logging`
- add/adjust tests to verify delegation and no import-time logging initialization

## Why
Closes #112.

This keeps one source of truth for CLI rendering and avoids global logging configuration on module import, while preserving CLI UX and backward-compatible import surfaces.

## Changes
- `slideflow/cli/utils.py`
  - removed duplicate rendering logic
  - delegates `print_validation_header`, `print_config_summary`, and `handle_validation_error` to `slideflow.cli.theme`
  - preserved `console` module member as compatibility alias (`theme.console`)
- `slideflow/utilities/logging.py`
  - removed module-level `setup_logging()` invocation
  - added explicit note that logging must be configured by entrypoints/apps
- `tests/test_cli_output_and_main.py`
  - updated legacy utils test to assert delegation behavior
  - added test ensuring `slideflow.utilities.logging` import does not auto-call `basicConfig`

## Validation
- `./.venv/bin/python -m ruff check slideflow tests scripts`
- `./.venv/bin/python -m black --check slideflow tests scripts`
- `./.venv/bin/python -m mypy slideflow`
- `./.venv/bin/python -m pytest -q`
- targeted: `./.venv/bin/python -m pytest -q tests/test_cli_output_and_main.py tests/test_cli_commands.py tests/test_runtime_workflows_phase4.py`

All passed locally (`251 passed, 1 skipped` in full suite).