### PR TITLE
test: complete issue #113 coverage + strict marker enforcement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ check_untyped_defs = true
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-addopts = "-ra"
+addopts = "-ra --strict-markers"
 testpaths = ["tests"]
 markers = [
     "integration: integration tests that may hit external systems",

--- a/tests/test_connectors_csv_json_connect.py
+++ b/tests/test_connectors_csv_json_connect.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+import slideflow.data.connectors.connect as connect_module
+import slideflow.data.connectors.csv as csv_module
+import slideflow.data.connectors.json as json_module
+from slideflow.constants import Defaults
+
+
+def test_csv_connector_fetch_data_reads_rows_and_logs(tmp_path: Path, monkeypatch):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("name,value\nalpha,1\nbeta,2\n", encoding="utf-8")
+
+    log_calls = []
+    monkeypatch.setattr(
+        csv_module,
+        "log_data_operation",
+        lambda *args, **kwargs: log_calls.append((args, kwargs)),
+    )
+
+    connector = csv_module.CSVConnector(str(csv_path))
+    df = connector.fetch_data()
+
+    assert len(df) == 2
+    assert df.to_dict(orient="records")[0]["name"] == "alpha"
+    assert log_calls == [
+        (("fetch", "csv", 2), {"file_path": str(csv_path)}),
+    ]
+
+
+def test_csv_source_config_fetch_data_uses_connector(tmp_path: Path):
+    csv_path = tmp_path / "source.csv"
+    csv_path.write_text("city,metric\nparis,10\n", encoding="utf-8")
+
+    source = csv_module.CSVSourceConfig(
+        name="cities",
+        type="csv",
+        file_path=csv_path,
+    )
+    df = source.fetch_data()
+
+    assert len(df) == 1
+    assert df.to_dict(orient="records")[0]["city"] == "paris"
+
+
+def test_json_connector_fetch_data_uses_orient_and_logs(tmp_path: Path, monkeypatch):
+    json_path = tmp_path / "records.json"
+    json_path.write_text('[{"k":"a","v":1},{"k":"b","v":2}]', encoding="utf-8")
+
+    read_calls = []
+    log_calls = []
+
+    def _fake_read_json(path, orient):
+        read_calls.append((path, orient))
+        return pd.DataFrame({"k": ["a", "b"], "v": [1, 2]})
+
+    monkeypatch.setattr(json_module.pd, "read_json", _fake_read_json)
+    monkeypatch.setattr(
+        json_module,
+        "log_data_operation",
+        lambda *args, **kwargs: log_calls.append((args, kwargs)),
+    )
+
+    connector = json_module.JSONConnector(str(json_path), orient="records")
+    df = connector.fetch_data()
+
+    assert len(df) == 2
+    assert read_calls == [(str(json_path), "records")]
+    assert log_calls == [
+        (
+            ("fetch", "json", 2),
+            {"file_path": str(json_path), "orient": "records"},
+        )
+    ]
+
+
+def test_json_source_config_defaults_orient_from_constants(tmp_path: Path):
+    json_path = tmp_path / "default.json"
+    json_path.write_text('[{"id":1}]', encoding="utf-8")
+
+    source = json_module.JSONSourceConfig(
+        name="default_json",
+        type="json",
+        file_path=json_path,
+    )
+
+    assert source.orient == Defaults.JSON_ORIENT
+
+
+def test_data_source_config_discriminator_supports_csv_and_json(tmp_path: Path):
+    csv_path = tmp_path / "union.csv"
+    csv_path.write_text("a,b\n1,2\n", encoding="utf-8")
+    json_path = tmp_path / "union.json"
+    json_path.write_text('[{"x":1}]', encoding="utf-8")
+
+    adapter = TypeAdapter(connect_module.DataSourceConfig)
+    csv_cfg = adapter.validate_python(
+        {
+            "type": "csv",
+            "name": "csv_source",
+            "file_path": str(csv_path),
+        }
+    )
+    json_cfg = adapter.validate_python(
+        {
+            "type": "json",
+            "name": "json_source",
+            "file_path": str(json_path),
+            "orient": "records",
+        }
+    )
+
+    assert isinstance(csv_cfg, csv_module.CSVSourceConfig)
+    assert isinstance(json_cfg, json_module.JSONSourceConfig)
+
+
+def test_data_source_config_rejects_unknown_type():
+    adapter = TypeAdapter(connect_module.DataSourceConfig)
+
+    with pytest.raises(ValidationError, match="union_tag_invalid"):
+        adapter.validate_python(
+            {
+                "type": "missing_type",
+                "name": "bad",
+            }
+        )

--- a/tests/test_logging_module.py
+++ b/tests/test_logging_module.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+
+import slideflow.utilities.logging as logging_module
+
+
+def test_setup_logging_uses_expected_defaults_and_force(monkeypatch):
+    calls = []
+    slideflow_logger = logging.getLogger("slideflow")
+    original_level = slideflow_logger.level
+
+    monkeypatch.setattr(
+        logging_module.logging,
+        "basicConfig",
+        lambda *args, **kwargs: calls.append(kwargs),
+    )
+
+    try:
+        logging_module.setup_logging(level="warning", enable_debug=True)
+
+        assert calls
+        kwargs = calls[0]
+        assert kwargs["force"] is True
+        assert kwargs["level"] == logging.WARNING
+        assert "%(name)s" in kwargs["format"]
+        assert slideflow_logger.level == logging.DEBUG
+    finally:
+        slideflow_logger.setLevel(original_level)
+
+
+def test_setup_logging_without_module_names_uses_simple_format(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        logging_module.logging,
+        "basicConfig",
+        lambda *args, **kwargs: calls.append(kwargs),
+    )
+
+    logging_module.setup_logging(level="INFO", show_module_names=False)
+
+    assert calls
+    assert calls[0]["format"] == "%(asctime)s - %(levelname)s - %(message)s"
+
+
+def test_log_performance_formats_duration_and_context(monkeypatch):
+    messages = []
+    fake_logger = type(
+        "FakeLogger", (), {"info": lambda self, msg: messages.append(msg)}
+    )()
+    monkeypatch.setattr(logging_module, "get_logger", lambda _name: fake_logger)
+
+    logging_module.log_performance("build", 1.2345, rows=10, source="csv")
+
+    assert messages == ["build completed in 1.23s (rows=10, source=csv)"]
+
+
+def test_log_data_operation_formats_records_and_context(monkeypatch):
+    messages = []
+    fake_logger = type(
+        "FakeLogger", (), {"info": lambda self, msg: messages.append(msg)}
+    )()
+    monkeypatch.setattr(logging_module, "get_logger", lambda _name: fake_logger)
+
+    logging_module.log_data_operation(
+        "fetch", "csv", record_count=2, file_path="/tmp/a.csv"
+    )
+
+    assert messages == ["fetch from csv (2 records) [file_path=/tmp/a.csv]"]
+
+
+def test_log_api_operation_uses_status_symbol_and_level(monkeypatch):
+    calls = []
+
+    class FakeLogger:
+        def log(self, level, message):
+            calls.append((level, message))
+
+    monkeypatch.setattr(logging_module, "get_logger", lambda _name: FakeLogger())
+
+    logging_module.log_api_operation(
+        "google_slides", "batch_update", success=True, duration=0.5
+    )
+    logging_module.log_api_operation(
+        "google_slides", "batch_update", success=False, error="timeout"
+    )
+
+    assert calls[0] == (logging.INFO, "✓ google_slides.batch_update (0.50s)")
+    assert calls[1] == (
+        logging.ERROR,
+        "✗ google_slides.batch_update [error=timeout]",
+    )

--- a/tests/test_replacements_utils_module.py
+++ b/tests/test_replacements_utils_module.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from slideflow.replacements.utils import dataframe_to_replacement_object
+
+
+def test_dataframe_to_replacement_object_uses_1_based_coordinates_and_prefix():
+    df = pd.DataFrame(
+        {
+            "Name": ["alpha", "beta"],
+            "Value": [10, 20],
+        }
+    )
+
+    result = dataframe_to_replacement_object(df, prefix="ITEM_")
+
+    assert result == {
+        "{{ITEM_1,1}}": "alpha",
+        "{{ITEM_1,2}}": 10,
+        "{{ITEM_2,1}}": "beta",
+        "{{ITEM_2,2}}": 20,
+    }
+
+
+def test_dataframe_to_replacement_object_returns_empty_dict_for_empty_dataframe():
+    df = pd.DataFrame()
+    assert dataframe_to_replacement_object(df, prefix="EMPTY_") == {}
+
+
+def test_dataframe_to_replacement_object_preserves_values_without_header_row():
+    df = pd.DataFrame({"A": ["x"], "B": ["y"]})
+    result = dataframe_to_replacement_object(df)
+
+    assert "{{1,1}}" in result
+    assert "{{1,2}}" in result
+    assert "{{2,1}}" not in result
+    assert result["{{1,1}}"] == "x"
+    assert result["{{1,2}}"] == "y"


### PR DESCRIPTION
## Summary
- enable strict pytest marker enforcement with --strict-markers
- add focused tests for CSV/JSON connector paths and datasource discriminator validation
- add focused tests for replacements utility coordinate mapping behavior
- add focused tests for logging utility setup and structured logging helpers

## Why
Issue #113 called for hardening around untested modules and marker drift. This PR closes the identified coverage gaps and makes unknown marker usage fail fast.

## Validation
- ./.venv/bin/python -m ruff check slideflow tests scripts
- ./.venv/bin/python -m black --check slideflow tests scripts
- ./.venv/bin/python -m mypy slideflow
- ./.venv/bin/python -m pytest -q

Closes #113