### PR TITLE
chore(build): refresh uv.lock after v0.0.6 release

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2927,7 +2927,7 @@ wheels = [
 
 [[package]]
 name = "slideflow-presentations"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "databricks-sql-connector" },


### PR DESCRIPTION
## Summary
- refresh `uv.lock` after the v0.0.6 version bump
- fixes CI failures from `uv lock --check` on master/release branches

## Validation
- `./.venv/bin/python -m black --check slideflow tests scripts`
- `./.venv/bin/python -m ruff check slideflow tests scripts`
- `./.venv/bin/python -m pytest -q`