### PR TITLE
feat(google_docs): add section marker targeting and scoped replacements (issue #104, PR2)

### DIFF
--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -273,14 +273,16 @@ class GoogleDocsProvider(PresentationProvider):
             return []
         return [item for item in content if isinstance(item, dict)]
 
-    def _iter_text_runs(
-        self, elements: Iterable[Dict[str, Any]]
-    ) -> Iterable[Tuple[str, int, int]]:
+    def _iter_text_segments(
+        self, elements: Iterable[Dict[str, Any]], include_toc: bool = False
+    ) -> Iterable[_SectionTextSegment]:
         for element in elements:
             paragraph = element.get("paragraph")
             if isinstance(paragraph, dict):
                 para_elements = paragraph.get("elements", [])
                 if isinstance(para_elements, list):
+                    current_text: Optional[str] = None
+                    current_boundaries: Optional[List[int]] = None
                     for para_element in para_elements:
                         if not isinstance(para_element, dict):
                             continue
@@ -296,7 +298,31 @@ class GoogleDocsProvider(PresentationProvider):
                             and isinstance(end_index, int)
                             and end_index > start_index
                         ):
-                            yield text_content, start_index, end_index
+                            cumulative_units = self._utf16_cumulative_units(
+                                text_content
+                            )
+                            run_boundaries = [
+                                start_index + unit_offset
+                                for unit_offset in cumulative_units
+                            ]
+                            if current_text is None or current_boundaries is None:
+                                current_text = text_content
+                                current_boundaries = run_boundaries
+                            elif current_boundaries[-1] == run_boundaries[0]:
+                                current_text += text_content
+                                current_boundaries.extend(run_boundaries[1:])
+                            else:
+                                yield self._SectionTextSegment(
+                                    text=current_text,
+                                    boundaries=current_boundaries,
+                                )
+                                current_text = text_content
+                                current_boundaries = run_boundaries
+                    if current_text is not None and current_boundaries is not None:
+                        yield self._SectionTextSegment(
+                            text=current_text,
+                            boundaries=current_boundaries,
+                        )
 
             table = element.get("table")
             if isinstance(table, dict):
@@ -313,13 +339,19 @@ class GoogleDocsProvider(PresentationProvider):
                                 continue
                             cell_content = cell.get("content", [])
                             if isinstance(cell_content, list):
-                                yield from self._iter_text_runs(cell_content)
+                                yield from self._iter_text_segments(
+                                    cell_content,
+                                    include_toc=include_toc,
+                                )
 
-            toc = element.get("tableOfContents")
+            toc = element.get("tableOfContents") if include_toc else None
             if isinstance(toc, dict):
                 toc_content = toc.get("content", [])
                 if isinstance(toc_content, list):
-                    yield from self._iter_text_runs(toc_content)
+                    yield from self._iter_text_segments(
+                        toc_content,
+                        include_toc=True,
+                    )
 
     def _marker_regex(self) -> re.Pattern[str]:
         return re.compile(
@@ -357,12 +389,11 @@ class GoogleDocsProvider(PresentationProvider):
         content = self._get_document_content(document_id)
         marker_pattern = self._marker_regex()
         markers: List[Tuple[str, int, int]] = []
-        for text_content, start_index, _end_index in self._iter_text_runs(content):
-            cumulative_units = self._utf16_cumulative_units(text_content)
-            for marker_match in marker_pattern.finditer(text_content):
+        for segment in self._iter_text_segments(content):
+            for marker_match in marker_pattern.finditer(segment.text):
                 marker_id = marker_match.group("id").strip()
-                marker_start = start_index + cumulative_units[marker_match.start()]
-                marker_end = start_index + cumulative_units[marker_match.end()]
+                marker_start = segment.boundaries[marker_match.start()]
+                marker_end = segment.boundaries[marker_match.end()]
                 if marker_end > marker_start:
                     markers.append((marker_id, marker_start, marker_end))
 
@@ -421,7 +452,10 @@ class GoogleDocsProvider(PresentationProvider):
         self, content: List[Dict[str, Any]], section_start: int, section_end: int
     ) -> List[_SectionTextSegment]:
         segments: List[GoogleDocsProvider._SectionTextSegment] = []
-        for text_content, run_start, run_end in self._iter_text_runs(content):
+        for base_segment in self._iter_text_segments(content):
+            text_content = base_segment.text
+            run_start = base_segment.boundaries[0]
+            run_end = base_segment.boundaries[-1]
             overlap_start = max(section_start, run_start)
             overlap_end = min(section_end, run_end)
             if overlap_start >= overlap_end:

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -39,33 +39,85 @@ def _http_error(
     return error
 
 
-def _document_from_paragraph_texts(*paragraph_texts: str) -> Dict[str, Any]:
+def _document_from_paragraph_run_groups(
+    *paragraph_run_groups: Tuple[str, ...],
+) -> Dict[str, Any]:
     content: List[Dict[str, Any]] = []
     cursor = 1
-    for paragraph_text in paragraph_texts:
-        start_index = cursor
-        end_index = cursor + len(paragraph_text)
+    for paragraph_runs in paragraph_run_groups:
+        paragraph_start = cursor
+        paragraph_elements: List[Dict[str, Any]] = []
+        for run_text in paragraph_runs:
+            start_index = cursor
+            end_index = cursor + _utf16_units(run_text)
+            paragraph_elements.append(
+                {
+                    "startIndex": start_index,
+                    "endIndex": end_index,
+                    "textRun": {"content": run_text},
+                }
+            )
+            cursor = end_index
+        paragraph_end = cursor
         content.append(
             {
-                "startIndex": start_index,
-                "endIndex": end_index,
-                "paragraph": {
-                    "elements": [
-                        {
-                            "startIndex": start_index,
-                            "endIndex": end_index,
-                            "textRun": {"content": paragraph_text},
-                        }
-                    ]
-                },
+                "startIndex": paragraph_start,
+                "endIndex": paragraph_end,
+                "paragraph": {"elements": paragraph_elements},
             }
         )
-        cursor = end_index
     return {"body": {"content": content}}
 
 
 def _utf16_units(text: str) -> int:
     return len(text.encode("utf-16-le")) // 2
+
+
+def _document_from_paragraph_texts(*paragraph_texts: str) -> Dict[str, Any]:
+    return _document_from_paragraph_run_groups(
+        *[(paragraph_text,) for paragraph_text in paragraph_texts]
+    )
+
+
+def _append_toc_copy(document: Dict[str, Any], toc_text: str) -> Dict[str, Any]:
+    body = document.setdefault("body", {})
+    content = body.setdefault("content", [])
+    if not isinstance(content, list):
+        return document
+
+    cursor = 1
+    if content:
+        last = content[-1]
+        if isinstance(last, dict):
+            last_end = last.get("endIndex")
+            if isinstance(last_end, int):
+                cursor = last_end
+
+    toc_start = cursor
+    toc_end = toc_start + _utf16_units(toc_text)
+    toc_content = [
+        {
+            "startIndex": toc_start,
+            "endIndex": toc_end,
+            "paragraph": {
+                "elements": [
+                    {
+                        "startIndex": toc_start,
+                        "endIndex": toc_end,
+                        "textRun": {"content": toc_text},
+                    }
+                ]
+            },
+        }
+    ]
+    content.append(
+        {
+            "startIndex": toc_start,
+            "endIndex": toc_end,
+            "tableOfContents": {"content": toc_content},
+        }
+    )
+    return document
 
 
 def test_google_docs_provider_init_success(monkeypatch):
@@ -315,6 +367,69 @@ def test_replace_text_handles_utf16_indices_with_emoji():
     assert delete_range["endIndex"] == expected_end
     insert_payload = replace_requests[1]["insertText"]
     assert insert_payload["location"]["index"] == expected_start
+
+
+def test_marker_detection_handles_adjacent_text_runs():
+    provider = _provider_without_init()
+    _attach_default_docs_config(provider)
+    provider.docs_service = SimpleNamespace(
+        documents=lambda: SimpleNamespace(
+            batchUpdate=lambda **kwargs: ("batch-update", kwargs),
+            get=lambda **kwargs: ("doc-get", kwargs),
+        )
+    )
+    mock_document = _document_from_paragraph_run_groups(
+        ("{{SECTION:", "section-1}} Alpha {{PLACEHOLDER}}\n"),
+        ("{{SECTION:section-2}} Tail\n",),
+    )
+
+    requests: List[Any] = []
+
+    def _exec(request: Any) -> Any:
+        requests.append(request)
+        if request[0] == "doc-get":
+            return mock_document
+        return {}
+
+    provider._execute_request = _exec
+
+    provider.insert_chart_to_slide(
+        "doc-split", "section-1", "https://img.example/chart.png", 10, 20, 300, 200
+    )
+    insert_payload = requests[1][1]["body"]["requests"][0]["insertInlineImage"]
+    assert insert_payload["location"]["index"] == 1 + _utf16_units(
+        "{{SECTION:section-1}}"
+    )
+
+    replaced = provider.replace_text_in_slide(
+        "doc-split", "section-1", "{{PLACEHOLDER}}", "VALUE"
+    )
+    assert replaced == 1
+
+
+def test_marker_resolution_ignores_table_of_contents_copies():
+    provider = _provider_without_init()
+    _attach_default_docs_config(provider)
+    provider.docs_service = SimpleNamespace(
+        documents=lambda: SimpleNamespace(
+            batchUpdate=lambda **kwargs: ("batch-update", kwargs),
+            get=lambda **kwargs: ("doc-get", kwargs),
+        )
+    )
+    mock_document = _document_from_paragraph_texts(
+        "{{SECTION:section-1}} Alpha {{PLACEHOLDER}}\n",
+        "{{SECTION:section-2}} Tail\n",
+    )
+    _append_toc_copy(mock_document, "{{SECTION:section-1}}")
+
+    provider._execute_request = lambda request: (
+        mock_document if request[0] == "doc-get" else {}
+    )
+
+    replaced = provider.replace_text_in_slide(
+        "doc-toc", "section-1", "{{PLACEHOLDER}}", "VALUE"
+    )
+    assert replaced == 1
 
 
 def test_upload_share_and_delete_paths():


### PR DESCRIPTION
## Summary
PR2 for issue #104: implement marker-anchored section semantics for the new `google_docs` provider.

### What this adds
- Treats `slide.id` as a section marker ID for Docs provider operations.
- Resolves marker anchors from template tokens (e.g. `{{SECTION:intro}}`).
- Inserts charts inline at the resolved section start (after marker token).
- Replaces placeholders only within the resolved section range (not globally).
- Raises deterministic `RenderingError` for:
  - missing section markers
  - duplicate section markers
  - no markers present in template
- Supports nested text extraction across paragraphs/tables/TOC for marker and replacement scanning.

### Key implementation notes
- Added section parsing/resolution helpers in `google_docs` provider:
  - `_get_document_content`
  - `_iter_text_runs`
  - `_marker_regex`
  - `_resolve_section_anchor`
  - `_build_section_text_index`
- Replacement logic now performs reverse-order `deleteContentRange + insertText` edits to avoid index drift.

## Tests
Updated provider coverage tests to enforce new contract:
- chart insertion uses marker section start index
- replacements are section-scoped
- missing marker raises
- duplicate markers raise

## Validation run
- `./.venv/bin/python -m black --check slideflow/presentations/providers/google_docs.py tests/test_google_docs_provider_coverage.py`
- `./.venv/bin/python -m ruff check slideflow/presentations/providers/google_docs.py tests/test_google_docs_provider_coverage.py`
- `./.venv/bin/python -m pytest -q tests/test_google_docs_provider_coverage.py`
- `./.venv/bin/python -m pytest -q`
- `./.venv/bin/python -m ruff check slideflow tests scripts`
- `./.venv/bin/python -m mypy slideflow`

All passed locally.

## Out of scope for this PR
- marker cleanup/removal flow (`remove_section_markers`) orchestration across full render lifecycle
- provider-contract-check integration for docs marker taxonomy
- doctor-specific docs marker diagnostics

Those remain follow-up PRs in the issue #104 stream.
