### PR TITLE
docs(google_docs): complete provider docs and references

### DIFF
--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -58,7 +58,7 @@ on:
         default: true
         type: boolean
       run-provider-contract-check:
-        description: "Run provider contract checks during validate (Google Slides)"
+        description: "Run provider contract checks during validate (Google Slides/Docs)"
         required: false
         default: false
         type: boolean

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
        Direct from your data.
 ```
 
-**SlideFlow is a Python-based tool for generating beautiful, data-driven presentations directly from your data sources.**
+**SlideFlow is a Python-based tool for generating beautiful, data-driven decks and docs directly from your data sources.**
 
 [Key Features](#-key-features) • [How It Works](#-how-it-works) • [Installation](#-installation) • [Getting Started](#-getting-started) • [CLI Usage](#-cli-usage) • [Configuration](#-configuration) • [Customization](#-customization) • [Contributing](CONTRIBUTING.md)
 
@@ -35,7 +35,7 @@ SlideFlow was built to solve a simple problem: automating the tedious process of
 
 -   🎨 **Beautiful, Consistent Visuals:** Leverage the power of Plotly for stunning, replicable charts. Use YAML templates to create a library of reusable chart designs.
 -   📊 **Connect Directly to Your Data:** Pull data from CSV files, JSON, Databricks, or even your dbt models. No more manual data exports.
--   ⚡ **Automate Your Reporting:** Stop the manual work. Reduce errors and save time. Your presentations are always up-to-date with your latest data.
+-   ⚡ **Automate Your Reporting:** Stop the manual work. Reduce errors and save time. Your decks/docs are always up-to-date with your latest data.
 -   🚀 **Scale Instantly:** Need to create a presentation for every customer, region, or product? Generate hundreds of personalized presentations at once from a single template.
 -   🤖 **Production Automation Ready:** Run scheduled builds in GitHub Actions with the reusable SlideFlow workflow and machine-readable JSON outputs.
 
@@ -66,6 +66,9 @@ SlideFlow was built to solve a simple problem: automating the tedious process of
     -   `slideflow doctor`: Run preflight diagnostics before validate/build.
     -   `slideflow templates`: Inspect available template names and parameter contracts.
     -   Generate multiple presentations from a single template using a CSV parameter file.
+-   **Multiple Output Providers:**
+    -   `google_slides`: Build slide decks from template slides.
+    -   `google_docs`: Build marker-anchored documents for newsletter/report workflows.
 
 ---
 
@@ -73,9 +76,9 @@ SlideFlow was built to solve a simple problem: automating the tedious process of
 
 SlideFlow works in three simple steps:
 
-1.  **Define:** You create a YAML file that defines your presentation. This includes the Google Slides template to use, the data sources to connect to, and the content for each slide (text, charts, etc.).
+1.  **Define:** You create a YAML file that defines your build target. This includes a Google Slides or Google Docs template, data sources, and per-section content (text, charts, etc.).
 2.  **Connect & Transform:** SlideFlow connects to your specified data sources, fetches the data, and applies any transformations you\'ve defined.
-3.  **Build:** SlideFlow creates a new presentation, populates it with your data and charts, and saves it to your Google Drive.
+3.  **Build:** SlideFlow creates a new deck/document, populates it with your data and charts, and saves it to Google Drive.
 
 ---
 
@@ -89,16 +92,18 @@ pip install slideflow-presentations
 
 ## 🧑‍💻 Getting Started
 
-To create your first presentation, you\'ll need:
+To create your first output, you\'ll need:
 
-1.  **A Google Slides Template:** Create a Google Slides presentation with the layout and branding you want. Note the ID of each slide you want to populate.
+1.  **A Template:** Use either:
+    - Google Slides template with slide IDs for target slides, or
+    - Google Docs template with section markers like `{{SECTION:intro}}`.
 2.  **Your Data:** Have your data ready in a CSV file, or have your Databricks credentials configured.
 3.  **A YAML Configuration File:** This is where you\'ll define your presentation. See the [Configuration](#-configuration) section for more details.
-4.  **Google Cloud Credentials:** You'll need a Google Cloud service account with access to the Google Slides and Google Drive APIs. Provide your credentials in one of the following ways:
+4.  **Google Cloud Credentials:** You'll need a Google Cloud service account with access to the required Google APIs (Slides/Docs + Drive). Provide credentials with one of:
 
     -   Set the `credentials` field in your `config.yml` to the path of your JSON credentials file.
     -   Set the `credentials` field in your `config.yml` to the JSON content of your credentials file as a string.
-    -   Set the `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable to the path of your JSON credentials file or the content of the file itself.
+    -   Set `GOOGLE_DOCS_CREDENTIALS` (for `google_docs`) or `GOOGLE_SLIDEFLOW_CREDENTIALS` (shared fallback) to a path/raw JSON.
 
 Once you have these, you can run the `build` command:
 
@@ -157,7 +162,7 @@ presentation:
         # ... chart definitions
 
 provider:
-  type: "google_slides"
+  type: "google_slides" # or "google_docs"
   config:
     credentials: "/path/to/your/credentials.json"
     template_id: "your_google_slides_template_id"
@@ -166,7 +171,10 @@ template_paths:
   - "./templates"
 ```
 
-For more detailed information on the configuration options, please see the documentation.
+For provider-specific behavior, see:
+
+- [Google Slides Provider](https://joe-broadhead.github.io/slideflow/providers/google-slides/)
+- [Google Docs Provider](https://joe-broadhead.github.io/slideflow/providers/google-docs/)
 
 ---
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,6 +1,6 @@
 # Automation
 
-Use Slideflow's reusable workflow to run scheduled deck builds for business teams.
+Use Slideflow's reusable workflow to run scheduled deck/doc builds for business teams.
 
 ## Reusable Workflow
 
@@ -66,7 +66,7 @@ jobs:
 - `run-doctor` (optional): Run `slideflow doctor` before validate/build. Default `true`.
 - `strict-doctor` (optional): Make doctor fail on error-severity findings. Default `false`.
 - `run-validate` (optional): Run `slideflow validate` before build. Default `true`.
-- `run-provider-contract-check` (optional): Add `--provider-contract-check` to validate. Default `false`.
+- `run-provider-contract-check` (optional): Add `--provider-contract-check` to validate (`google_slides` and `google_docs`). Default `false`.
 - `provider-contract-params-path` (optional): CSV path for validate contract checks; falls back to `params-path` when unset.
 - `dry-run` (optional): Run build with `--dry-run`. Default `false`.
 - `threads` (optional): Value passed to `--threads`.
@@ -76,7 +76,7 @@ jobs:
 
 ## Outputs
 
-- `presentation-urls`: Comma-separated Google Slides URLs extracted from build JSON output.
+- `presentation-urls`: Comma-separated build URLs extracted from build JSON output (Google Slides or Google Docs).
 - `doctor-result-json`: JSON summary emitted by `slideflow doctor --output-json`.
 - `validate-result-json`: JSON summary emitted by `slideflow validate --output-json`.
 - `build-result-json`: JSON summary emitted by `slideflow build --output-json`.
@@ -113,7 +113,8 @@ jobs:
 - `GOOGLE_APPLICATION_CREDENTIALS_JSON` (optional; creates `GOOGLE_APPLICATION_CREDENTIALS` file during workflow run)
 - Callers can either pass those secrets explicitly or use `secrets: inherit` if the same names exist in the caller repository/org.
 - Your Slideflow config can continue to reference environment variables as usual.
-- For Google Slides builds, ensure credentials/folder IDs used by your config are available in the caller workflow environment.
+- For `google_slides` and `google_docs` builds, ensure credentials/folder IDs used by your config are available in the caller workflow environment.
+- `google_docs` provider can use `GOOGLE_SLIDEFLOW_CREDENTIALS` in this workflow (or `provider.config.credentials`).
 - Prefer pinning reusable workflow references to a commit SHA in production.
 
 Example `dbt` source for a private dbt repo:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,6 +53,11 @@ slideflow validate config.yml --output-json validate-result.json
 slideflow validate config.yml --provider-contract-check --params-path variants.csv
 ```
 
+Provider contract behavior:
+
+- `google_slides`: validates slide IDs and placeholders in template decks.
+- `google_docs`: validates section markers and placeholders in template docs.
+
 ## `slideflow build`
 
 ```bash

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -9,7 +9,7 @@ presentation:
   slides: [...]
 
 provider:
-  type: "google_slides"
+  type: "google_slides" # or "google_docs"
   config: {...}
 
 template_paths: ["./templates"] # optional additional paths (prepended before defaults)
@@ -30,7 +30,7 @@ registry: ["./registry.py"] # optional
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `id` | `str` | yes | Target slide ID in template |
+| `id` | `str` | yes | `google_slides`: target slide object ID, `google_docs`: target section marker id |
 | `title` | `str` | no | Metadata only |
 | `replacements` | `list` | no | `text`, `table`, `ai_text` specs |
 | `charts` | `list` | no | `plotly_go`, `template`, `custom` specs |
@@ -42,6 +42,7 @@ registry: ["./registry.py"] # optional
 Supported values:
 
 - `google_slides`
+- `google_docs`
 
 ### `provider.config` for `google_slides`
 
@@ -59,6 +60,31 @@ Supported values:
 | `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
 
 For provider setup and operational behavior, see [Google Slides Provider](providers/google-slides.md).
+
+### `provider.config` for `google_docs`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `credentials` | `str` | conditionally | Path/raw JSON; can also come from env |
+| `template_id` | `str` | recommended | Source template document ID |
+| `document_folder_id` | `str` | no | Folder for generated docs |
+| `drive_folder_id` | `str` | no | Folder for uploaded chart images |
+| `section_marker_prefix` | `str` | no | Marker prefix (default `{{SECTION:`) |
+| `section_marker_suffix` | `str` | no | Marker suffix (default `}}`) |
+| `remove_section_markers` | `bool` | no | Reserved config field; currently not applied at render time |
+| `default_chart_width_pt` | `float` | no | Reserved config field; currently not applied at render time |
+| `share_with` | `list[str]` | no | Emails to share generated document with |
+| `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
+| `requests_per_second` | `float` | no | API rate limit override |
+| `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
+
+Credential precedence for `google_docs`:
+
+1. `provider.config.credentials`
+2. `GOOGLE_DOCS_CREDENTIALS`
+3. `GOOGLE_SLIDEFLOW_CREDENTIALS`
+
+For provider setup and marker behavior, see [Google Docs Provider](providers/google-docs.md).
 
 ## Replacements
 
@@ -124,6 +150,10 @@ Common positioning fields in chart config:
 - `alignment_format`: `left|center|right` + `top|center|bottom` (for example `center-top`)
 - `scale`: image scaling factor
 - `data_transforms`: optional ordered transform pipeline
+
+Provider note:
+
+- `google_docs` inserts charts inline and ignores positional fields (`x`, `y`, alignment).
 
 ### `plotly_go`
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -12,7 +12,7 @@ For all orchestrated environments, ensure:
 
 - Python 3.12+
 - SlideFlow package installed (and `ai` extras if using `ai_text` providers)
-- Access to required data systems (Drive/Slides/Databricks/Git)
+- Access to required data systems (Drive/Slides/Docs/Databricks/Git)
 - Correct environment variables and secrets
 
 For chart image rendering, provide a Chrome/Chromium binary available to Kaleido.
@@ -77,11 +77,14 @@ Supported reusable-workflow secret mappings:
 - `BIGQUERY_PROJECT` (optional; project id fallback for `warehouse.type: bigquery`)
 - `GOOGLE_APPLICATION_CREDENTIALS_JSON` (optional; service-account JSON used to create `GOOGLE_APPLICATION_CREDENTIALS` file)
 
+For `google_docs` provider runs with the reusable workflow, use `GOOGLE_SLIDEFLOW_CREDENTIALS`
+as the credentials secret mapping (or set `provider.config.credentials` directly in config).
+
 ### Passing machine-readable outputs to downstream jobs
 
 The reusable workflow exposes:
 
-- `presentation-urls`: comma-separated Google Slides URLs
+- `presentation-urls`: comma-separated build URLs extracted from JSON output (Google Slides or Google Docs)
 - `build-result-json`: JSON summary from `slideflow build --output-json`
 - `validate-result-json`: JSON summary from `slideflow validate --output-json`
 - `doctor-result-json`: JSON summary from `slideflow doctor --output-json`
@@ -191,6 +194,8 @@ Operational notes:
 - `slideflow validate` enforced before `slideflow build`
 - `slideflow doctor` runs before long render jobs (`--strict` in CI)
 - provider contract checks enabled where template compatibility guarantees matter (`slideflow validate --provider-contract-check`)
+  - `google_slides`: slide-id + placeholder checks
+  - `google_docs`: section-marker + placeholder checks
 - Secrets managed by platform secret manager (not committed)
 - API quotas/rate limits measured and tuned (`--rps`, `--threads`)
 - Failure notifications wired to orchestration platform

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,8 +5,9 @@
 - Python `3.12+`
 - Google Cloud project with:
   - Google Slides API enabled
+  - Google Docs API enabled (if using `google_docs` provider)
   - Google Drive API enabled
-- A service account with access to your target template deck and Drive folders
+- A service account with access to your target template deck/document and Drive folders
 
 ## Install
 
@@ -30,7 +31,8 @@ source .venv/bin/activate
 SlideFlow accepts credentials via:
 
 1. `provider.config.credentials` in YAML
-2. `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable
+2. `GOOGLE_DOCS_CREDENTIALS` environment variable (for `google_docs`)
+3. `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable
 
 `GOOGLE_SLIDEFLOW_CREDENTIALS` supports either:
 
@@ -45,11 +47,16 @@ export GOOGLE_SLIDEFLOW_CREDENTIALS=/absolute/path/service-account.json
 
 ## Create a template deck
 
-Create a Google Slides template deck with placeholders and target slide layouts.
+Create a template and decide provider mode:
+
+- `google_slides`: Google Slides template deck with placeholder text and target slide IDs.
+- `google_docs`: Google Docs template with explicit section markers (for example `{{SECTION:intro}}`).
+
 You will need:
 
-- `template_id` (presentation ID from URL)
-- slide IDs for each slide you modify
+- `template_id` (presentation/document ID from URL)
+- `google_slides`: slide IDs for each slide you modify
+- `google_docs`: marker ids that match `presentation.slides[].id`
 
 ## Minimal config
 
@@ -64,6 +71,25 @@ presentation:
   name: "My First SlideFlow Deck"
   slides:
     - id: "your_slide_id"
+      replacements:
+        - type: "text"
+          config:
+            placeholder: "{{TITLE}}"
+            replacement: "Hello SlideFlow"
+```
+
+Google Docs variant:
+
+```yaml
+provider:
+  type: "google_docs"
+  config:
+    template_id: "your_google_docs_template_id"
+
+presentation:
+  name: "My First SlideFlow Doc"
+  slides:
+    - id: "intro"
       replacements:
         - type: "text"
           config:
@@ -101,6 +127,7 @@ slideflow build config.yml --params-path params.csv --dry-run
 
 - Run the sample pipeline in [Quickstart](quickstart.md)
 - Configure real template/folder/sharing behavior in [Google Slides Provider](providers/google-slides.md)
+- Configure marker-based doc behavior in [Google Docs Provider](providers/google-docs.md)
 - Choose and harden source systems in [Data Connectors](data-connectors.md)
 - Add reusable preprocessing in [Data Transforms](data-transforms.md)
 - Configure LLM output in [AI Providers](ai-providers.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # SlideFlow
 
-SlideFlow generates Google Slides decks from structured YAML, data sources, and reusable chart/replacement logic.
+SlideFlow generates Google Slides decks and Google Docs documents from structured YAML, data sources, and reusable chart/replacement logic.
 
 ## Core capabilities
 
@@ -15,7 +15,7 @@ SlideFlow generates Google Slides decks from structured YAML, data sources, and 
 
 1. Configure auth and template IDs in [Getting Started](getting-started.md).
 2. Run the full local path in [Quickstart](quickstart.md).
-3. Use [Google Slides Provider](providers/google-slides.md), [Data Connectors](data-connectors.md), [Data Transforms](data-transforms.md), and [AI Providers](ai-providers.md) to harden feature usage.
+3. Use [Google Slides Provider](providers/google-slides.md), [Google Docs Provider](providers/google-docs.md), [Data Connectors](data-connectors.md), [Data Transforms](data-transforms.md), and [AI Providers](ai-providers.md) to harden feature usage.
 4. Use [CLI Reference](cli-reference.md) and [Configuration Reference](config-reference.md) for production configs.
 5. Use [Deployments](deployments.md), [Security & Auth](security.md), [Testing](testing.md), and [Release Process](release-process.md) for operational hardening.
 

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -1,0 +1,133 @@
+# Google Docs Provider
+
+The `google_docs` provider renders SlideFlow output into Google Docs documents
+using section markers (for example `{{SECTION:intro}}`) as logical anchors.
+
+It reuses `presentation.slides[]` from the core schema:
+
+- `slides[].id` maps to a marker id in the document template.
+- replacements/charts scoped to that `slide.id` run inside the matching section.
+
+## Setup Checklist
+
+1. Enable APIs in your Google Cloud project:
+   - Google Docs API
+   - Google Drive API
+2. Create a service account.
+3. Share the template document (and destination Drive folders) with that service account.
+4. Provide credentials via:
+   - `provider.config.credentials` in YAML, or
+   - `GOOGLE_DOCS_CREDENTIALS`, or
+   - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback).
+
+## Template Design for Marker-Based Sections
+
+Use explicit section markers in your document template:
+
+```text
+{{SECTION:intro}}
+{{SECTION:regional_summary}}
+{{SECTION:outlook}}
+```
+
+Rules:
+
+- Marker ids must be unique per document.
+- Marker ids should match `presentation.slides[].id` exactly.
+- Markers should be plain text (do not split token text with inline objects/chips).
+
+## Provider Config
+
+```yaml
+provider:
+  type: "google_docs"
+  config:
+    credentials: "/path/to/service-account.json"
+    template_id: "<google_docs_template_id>"
+    document_folder_id: "<folder_for_output_docs>"
+    drive_folder_id: "<folder_for_chart_images>"
+    section_marker_prefix: "{{SECTION:"
+    section_marker_suffix: "}}"
+    remove_section_markers: false
+    default_chart_width_pt: 300
+    share_with:
+      - "team@example.com"
+    share_role: "reader"
+    requests_per_second: 1.0
+    strict_cleanup: false
+```
+
+Field behavior:
+
+- `template_id`: if set, SlideFlow copies the document template; otherwise creates a blank doc.
+- `document_folder_id`: destination folder for generated docs.
+- `drive_folder_id`: destination folder for uploaded chart images.
+- `section_marker_prefix` / `section_marker_suffix`: marker token format.
+- `share_with` / `share_role`: post-render sharing.
+- `requests_per_second`: API pacing control.
+- `strict_cleanup`: fail run if chart-image cleanup fails.
+
+Current implementation notes:
+
+- `remove_section_markers` is currently reserved and not yet applied at render time.
+- `default_chart_width_pt` is currently reserved and not yet applied at render time.
+
+## Runtime Behavior
+
+- Replacements are section-scoped by marker id.
+- Charts are inserted inline at the matched section anchor.
+- Positional chart fields (`x`, `y`, alignment) are ignored for `google_docs`.
+- The build result `url` points to `https://docs.google.com/document/d/<id>`.
+
+## Contract Validation
+
+Use provider contract checks before build:
+
+```bash
+slideflow validate config.yml --provider-contract-check --params-path variants.csv
+```
+
+Contract checks for `google_docs` validate:
+
+- marker presence for each configured `slide.id`
+- marker uniqueness
+- placeholder presence within the section body
+- template fetch accessibility
+
+Issue types:
+
+- `template_fetch_failed`
+- `missing_section_marker`
+- `duplicate_section_marker`
+- `missing_placeholder`
+
+## Minimal Example
+
+```yaml
+provider:
+  type: "google_docs"
+  config:
+    template_id: "1AbCdEf..."
+
+presentation:
+  name: "Weekly Newsletter"
+  slides:
+    - id: "intro"
+      replacements:
+        - type: "text"
+          config:
+            placeholder: "{{WEEK_LABEL}}"
+            replacement: "Week 09"
+```
+
+## Operational Notes
+
+- Start with conservative concurrency/rate settings and tune gradually.
+- Keep markers stable after config wiring.
+- Validate with `--provider-contract-check` in CI for template safety.
+
+Related references:
+
+- [Configuration Reference](../config-reference.md)
+- [CLI Reference](../cli-reference.md)
+- [Deployments](../deployments.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,10 +2,11 @@
 
 ## Credential sources
 
-For Google Slides provider auth, SlideFlow reads credentials from:
+For Google provider auth, SlideFlow reads credentials from:
 
 1. `provider.config.credentials`
-2. `GOOGLE_SLIDEFLOW_CREDENTIALS`
+2. `GOOGLE_DOCS_CREDENTIALS` (for `google_docs`)
+3. `GOOGLE_SLIDEFLOW_CREDENTIALS`
 
 Credential value can be:
 
@@ -16,9 +17,15 @@ Recommended: use environment variables in CI and avoid storing secrets in repo f
 
 ## Required scopes
 
-Google provider uses:
+Google Slides provider scopes:
 
 - `https://www.googleapis.com/auth/presentations`
+- `https://www.googleapis.com/auth/drive`
+- `https://www.googleapis.com/auth/drive.file`
+
+Google Docs provider scopes:
+
+- `https://www.googleapis.com/auth/documents`
 - `https://www.googleapis.com/auth/drive`
 - `https://www.googleapis.com/auth/drive.file`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,8 +26,8 @@ Common causes:
 
 Common causes:
 
-- missing Google credentials (`provider.config.credentials` or `GOOGLE_SLIDEFLOW_CREDENTIALS`)
-- invalid template ID or slide IDs
+- missing Google credentials (`provider.config.credentials`, `GOOGLE_DOCS_CREDENTIALS`, or `GOOGLE_SLIDEFLOW_CREDENTIALS`)
+- invalid template ID or target IDs (`slide.id` for `google_slides`, section marker ids for `google_docs`)
 - unreadable CSV/JSON input path
 - query/auth issues for Databricks connectors
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: SlideFlow
-site_description: Automated data-driven presentation generation for Google Slides.
+site_description: Automated data-driven generation for Google Slides and Google Docs.
 site_url: https://joe-broadhead.github.io/slideflow/
 repo_url: https://github.com/joe-broadhead/slideflow
 repo_name: slideflow
@@ -104,6 +104,7 @@ nav:
       - Cookbooks: cookbooks.md
       - Troubleshooting: troubleshooting.md
   - How-To:
+      - Google Docs Provider: providers/google-docs.md
       - Google Slides Provider: providers/google-slides.md
       - Data Connectors: data-connectors.md
       - DBT Migration: dbt-migration.md


### PR DESCRIPTION
## Summary
- adds full `google_docs` provider documentation page
- wires Google Docs provider into MkDocs navigation
- updates core docs surfaces (README + docs pages) to reflect dual provider support (`google_slides`, `google_docs`)
- aligns reusable workflow input description for provider contract checks to mention Slides/Docs

## What changed

### New docs page
- `docs/providers/google-docs.md`
  - marker-based section model (`{{SECTION:<id>}}`)
  - provider config fields
  - contract-check behavior and issue taxonomy
  - runtime behavior and current implementation notes

### Updated docs
- `docs/config-reference.md`
  - adds `google_docs` to supported providers
  - documents `provider.config` for `google_docs`
  - clarifies `slides[].id` semantics by provider
  - notes inline chart behavior for docs provider
- `docs/cli-reference.md`
  - provider-contract-check behavior per provider
- `docs/getting-started.md`
  - docs API/setup path and google_docs minimal config variant
- `docs/deployments.md`
  - provider-neutral URL output wording and contract-check notes
- `docs/automation.md`
  - provider-neutral reusable workflow wording/output notes
- `docs/security.md`
  - credential precedence and scope notes for google_docs
- `docs/troubleshooting.md`
  - google_docs-aware credential/target-id troubleshooting note
- `docs/index.md`
  - top-level positioning updated for Slides + Docs
- `mkdocs.yml`
  - adds `Google Docs Provider` nav entry
  - updates site description for Slides + Docs
- `README.md`
  - updates product framing and provider references for docs support

### Workflow text alignment
- `.github/workflows/reusable-slideflow-build.yml`
  - updates `run-provider-contract-check` input description to mention Slides/Docs

## Validation
- `./.venv/bin/python -m mkdocs build --strict`

## Base branch
This PR targets `codex/feature-google-docs-integration` (not `master`).
