### PR TITLE
feat(google-docs): finalize render by removing section markers

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -71,7 +71,7 @@ For provider setup and operational behavior, see [Google Slides Provider](provid
 | `drive_folder_id` | `str` | no | Folder for uploaded chart images |
 | `section_marker_prefix` | `str` | no | Marker prefix (default `{{SECTION:`) |
 | `section_marker_suffix` | `str` | no | Marker suffix (default `}}`) |
-| `remove_section_markers` | `bool` | no | Reserved config field; currently not applied at render time |
+| `remove_section_markers` | `bool` | no | Remove `{{SECTION:...}}` markers after render finalization |
 | `default_chart_width_pt` | `float` | no | Reserved config field; currently not applied at render time |
 | `share_with` | `list[str]` | no | Emails to share generated document with |
 | `share_role` | `str` | no | `reader`, `writer`, or `commenter` |

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -69,7 +69,7 @@ Field behavior:
 
 Current implementation notes:
 
-- `remove_section_markers` is currently reserved and not yet applied at render time.
+- `remove_section_markers` runs after render finalization and deletes section-marker tokens.
 - `default_chart_width_pt` is currently reserved and not yet applied at render time.
 
 ## Runtime Behavior

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -696,6 +696,12 @@ class Presentation(BaseModel):
                         # Continue with other replacements rather than failing entirely
                         continue
 
+            finalize_presentation = getattr(
+                self.provider, "finalize_presentation", None
+            )
+            if callable(finalize_presentation):
+                finalize_presentation(presentation_id)
+
             # Share presentation if configured
             if hasattr(self.provider, "config") and hasattr(
                 self.provider.config, "share_with"

--- a/slideflow/presentations/providers/base.py
+++ b/slideflow/presentations/providers/base.py
@@ -215,6 +215,17 @@ class PresentationProvider(ABC):
         """
         return []
 
+    def finalize_presentation(self, presentation_id: str) -> None:
+        """Run provider-specific finalization after slide operations complete.
+
+        Providers can override this hook for post-render actions that must happen
+        once (for example, marker cleanup) after chart/replacement work is done.
+
+        Args:
+            presentation_id: Unique identifier of the rendered presentation.
+        """
+        del presentation_id
+
     @abstractmethod
     def create_presentation(self, name: str, template_id: Optional[str] = None) -> str:
         """Create a new presentation on the platform.

--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -259,6 +259,17 @@ class GoogleDocsProvider(PresentationProvider):
             )
         )
 
+    def finalize_presentation(self, presentation_id: str) -> None:
+        if not self.config.remove_section_markers:
+            return
+        removed = self._remove_section_markers(presentation_id)
+        if removed > 0:
+            logger.info(
+                "Removed %s section marker(s) from rendered document %s",
+                removed,
+                presentation_id,
+            )
+
     def _get_document_content(self, document_id: str) -> List[Dict[str, Any]]:
         document = self._execute_request(
             self.docs_service.documents().get(documentId=document_id)
@@ -491,6 +502,37 @@ class GoogleDocsProvider(PresentationProvider):
                 )
 
         return segments
+
+    def _remove_section_markers(self, document_id: str) -> int:
+        content = self._get_document_content(document_id)
+        marker_pattern = self._marker_regex()
+        marker_ranges: List[Tuple[int, int]] = []
+
+        for segment in self._iter_text_segments(content):
+            for marker_match in marker_pattern.finditer(segment.text):
+                marker_start = segment.boundaries[marker_match.start()]
+                marker_end = segment.boundaries[marker_match.end()]
+                if marker_end > marker_start:
+                    marker_ranges.append((marker_start, marker_end))
+
+        if not marker_ranges:
+            return 0
+
+        requests = [
+            {
+                "deleteContentRange": {
+                    "range": {"startIndex": start_index, "endIndex": end_index}
+                }
+            }
+            for start_index, end_index in sorted(marker_ranges, reverse=True)
+        ]
+        self._execute_request(
+            self.docs_service.documents().batchUpdate(
+                documentId=document_id,
+                body={"requests": requests},
+            )
+        )
+        return len(marker_ranges)
 
     def replace_text_in_slide(
         self, presentation_id: str, slide_id: str, placeholder: str, replacement: str

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -24,6 +24,7 @@ def _attach_default_docs_config(provider: GoogleDocsProvider) -> None:
     provider.config = SimpleNamespace(
         section_marker_prefix="{{SECTION:",
         section_marker_suffix="}}",
+        remove_section_markers=False,
         strict_cleanup=False,
     )
 
@@ -430,6 +431,75 @@ def test_marker_resolution_ignores_table_of_contents_copies():
         "doc-toc", "section-1", "{{PLACEHOLDER}}", "VALUE"
     )
     assert replaced == 1
+
+
+def test_remove_section_markers_deletes_body_markers_only():
+    provider = _provider_without_init()
+    _attach_default_docs_config(provider)
+    provider.docs_service = SimpleNamespace(
+        documents=lambda: SimpleNamespace(
+            batchUpdate=lambda **kwargs: ("batch-update", kwargs),
+            get=lambda **kwargs: ("doc-get", kwargs),
+        )
+    )
+    mock_document = _document_from_paragraph_texts(
+        "{{SECTION:section-1}} Intro\n",
+        "{{SECTION:section-2}} Details\n",
+    )
+    _append_toc_copy(mock_document, "{{SECTION:section-1}}")
+
+    requests: List[Any] = []
+
+    def _exec(request: Any) -> Any:
+        requests.append(request)
+        if request[0] == "doc-get":
+            return mock_document
+        return {}
+
+    provider._execute_request = _exec
+
+    removed = provider._remove_section_markers("doc-remove")
+
+    assert removed == 2
+    assert requests[0][0] == "doc-get"
+    assert requests[1][0] == "batch-update"
+    delete_requests = requests[1][1]["body"]["requests"]
+    assert len(delete_requests) == 2
+    first_range = delete_requests[0]["deleteContentRange"]["range"]
+    second_range = delete_requests[1]["deleteContentRange"]["range"]
+    assert first_range["startIndex"] > second_range["startIndex"]
+
+
+def test_finalize_presentation_skips_marker_cleanup_when_disabled(monkeypatch):
+    provider = _provider_without_init()
+    _attach_default_docs_config(provider)
+    provider.config.remove_section_markers = False
+
+    calls: List[str] = []
+    monkeypatch.setattr(
+        provider,
+        "_remove_section_markers",
+        lambda document_id: calls.append(document_id) or 0,
+    )
+
+    provider.finalize_presentation("doc-no-cleanup")
+    assert calls == []
+
+
+def test_finalize_presentation_runs_marker_cleanup_when_enabled(monkeypatch):
+    provider = _provider_without_init()
+    _attach_default_docs_config(provider)
+    provider.config.remove_section_markers = True
+
+    calls: List[str] = []
+    monkeypatch.setattr(
+        provider,
+        "_remove_section_markers",
+        lambda document_id: calls.append(document_id) or 2,
+    )
+
+    provider.finalize_presentation("doc-cleanup")
+    assert calls == ["doc-cleanup"]
 
 
 def test_upload_share_and_delete_paths():

--- a/tests/test_presentation_render.py
+++ b/tests/test_presentation_render.py
@@ -38,6 +38,7 @@ class FakeProvider:
         self.insert_calls = []
         self.page_size = None
         self.preflight_checks = []
+        self.finalize_calls = []
 
     def create_presentation(self, _name):
         return "presentation-1"
@@ -87,6 +88,9 @@ class FakeProvider:
     def run_preflight_checks(self):
         return self.preflight_checks
 
+    def finalize_presentation(self, presentation_id):
+        self.finalize_calls.append(presentation_id)
+
 
 def _build_presentation(provider):
     chart = FakeChart()
@@ -110,6 +114,7 @@ def test_render_passes_empty_dataframe_to_static_chart():
 
     assert isinstance(chart.generated_with, pd.DataFrame)
     assert result.charts_generated == 1
+    assert provider.finalize_calls == ["presentation-1"]
 
 
 def test_render_raises_when_strict_cleanup_enabled_and_delete_fails():


### PR DESCRIPTION
## Summary
- add a provider lifecycle hook (`finalize_presentation`) to support post-render provider actions
- wire presentation render flow to call provider finalization when available
- implement `google_docs` marker cleanup when `provider.config.remove_section_markers=true`
- update docs to reflect that `remove_section_markers` is now active behavior

## Why
Issue #104 called out optional marker cleanup after render. The docs provider supported marker-based targeting but did not actually remove section markers at the end of a successful render. This closes that functional gap.

## Behavior
- default behavior unchanged (`remove_section_markers=false`): no marker deletion
- when enabled:
  - all section markers matching configured prefix/suffix are removed after chart/replacement processing
  - cleanup runs once per render (post-slide operations)
  - marker removal ignores TOC-copied markers (same non-TOC traversal used for section anchoring)

## Validation
- `./.venv/bin/python -m ruff check slideflow/presentations/providers/base.py slideflow/presentations/base.py slideflow/presentations/providers/google_docs.py tests/test_google_docs_provider_coverage.py tests/test_presentation_render.py`
- `./.venv/bin/python -m black --check slideflow/presentations/providers/base.py slideflow/presentations/base.py slideflow/presentations/providers/google_docs.py tests/test_google_docs_provider_coverage.py tests/test_presentation_render.py`
- `./.venv/bin/python -m pytest -q tests/test_google_docs_provider_coverage.py tests/test_presentation_render.py`
- `./.venv/bin/python -m pytest -q tests/test_cli_commands.py -k google_docs`
- `./.venv/bin/python -m mkdocs build --strict`

## Notes
- render finalization call is duck-typed (`callable(getattr(..., "finalize_presentation", None))`) to preserve compatibility with existing test fakes and custom providers.
