### PR TITLE
fix(google-docs): warn when positional chart fields are ignored

### DIFF
--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -76,7 +76,7 @@ Current implementation notes:
 
 - Replacements are section-scoped by marker id.
 - Charts are inserted inline at the matched section anchor.
-- Positional chart fields (`x`, `y`, alignment) are ignored for `google_docs`.
+- Positional chart fields (`x`, `y`, alignment) are ignored for `google_docs` and log a warning when non-zero positional values are provided.
 - The build result `url` points to `https://docs.google.com/document/d/<id>`.
 
 ## Contract Validation

--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -235,6 +235,14 @@ class GoogleDocsProvider(PresentationProvider):
         compatibility and ignored because Google Docs only supports inline
         image insertion in this provider.
         """
+        if x != 0 or y != 0:
+            logger.warning(
+                "google_docs provider ignores chart positioning values (x=%s, y=%s) "
+                "and inserts charts inline at section '%s'.",
+                x,
+                y,
+                slide_id,
+            )
         del x, y
 
         anchor, _ = self._resolve_section_anchor(

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -284,6 +284,43 @@ def test_insert_chart_and_replace_text_requests():
     assert delete_range["startIndex"] < section_two_start
 
 
+def test_insert_chart_warns_when_position_values_are_ignored(monkeypatch):
+    provider = _provider_without_init()
+    _attach_default_docs_config(provider)
+    provider.docs_service = SimpleNamespace(
+        documents=lambda: SimpleNamespace(
+            batchUpdate=lambda **kwargs: ("batch-update", kwargs),
+            get=lambda **kwargs: ("doc-get", kwargs),
+        )
+    )
+
+    requests: List[Any] = []
+
+    def _exec(request: Any) -> Any:
+        requests.append(request)
+        if request[0] == "doc-get":
+            return _document_from_paragraph_texts("{{SECTION:section-1}} Alpha\n")
+        return {}
+
+    warning_messages: List[str] = []
+    monkeypatch.setattr(
+        google_docs_module.logger,
+        "warning",
+        lambda message, *args: warning_messages.append(message % args),
+    )
+
+    provider._execute_request = _exec
+    provider.insert_chart_to_slide(
+        "doc-1", "section-1", "https://img.example/chart.png", 10, 20, 300, 200
+    )
+
+    assert requests[0][0] == "doc-get"
+    assert requests[1][0] == "batch-update"
+    assert len(warning_messages) == 1
+    assert "ignores chart positioning values" in warning_messages[0]
+    assert "section-1" in warning_messages[0]
+
+
 def test_insert_chart_raises_when_marker_missing():
     provider = _provider_without_init()
     _attach_default_docs_config(provider)


### PR DESCRIPTION
## Summary
- add a runtime warning in `google_docs` provider when non-zero `x`/`y` values are passed to chart insertion
- add unit coverage to assert warning behavior and preserve insertion flow
- update docs to state ignored positional values now emit warnings

## Why
Issue #104 expects positional chart fields to be ignored *with warnings* for the docs provider. We already ignored positioning; this patch adds the explicit warning behavior and test coverage.

## Validation
- `./.venv/bin/python -m ruff check slideflow/presentations/providers/google_docs.py tests/test_google_docs_provider_coverage.py`
- `./.venv/bin/python -m black --check slideflow/presentations/providers/google_docs.py tests/test_google_docs_provider_coverage.py`
- `./.venv/bin/python -m pytest -q tests/test_google_docs_provider_coverage.py -k "warns_when_position_values_are_ignored or insert_chart_and_replace_text_requests"`
- `./.venv/bin/python -m mkdocs build --strict`
