### PR TITLE
docs: complete Google Docs docs coverage sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /local_testing
 /**/__pycache__
 /slideflow.egg-info
+*.egg-info/
 .env*
 .venv
 .coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ Live Google suite (optional, requires credentials):
 
 ```bash
 python -m pytest -q tests/live_tests -m live_google
+python -m pytest -q tests/live_tests -m live_google_docs
 ```
 
 ## Contribution expectations

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -117,6 +117,19 @@ jobs:
 - `google_docs` provider can use `GOOGLE_SLIDEFLOW_CREDENTIALS` in this workflow (or `provider.config.credentials`).
 - Prefer pinning reusable workflow references to a commit SHA in production.
 
+If your caller repo stores Google Docs credentials under `GOOGLE_DOCS_CREDENTIALS`,
+map it into the reusable workflow's expected secret name:
+
+```yaml
+jobs:
+  build:
+    uses: joe-broadhead/slideflow/.github/workflows/reusable-slideflow-build.yml@<pinned_sha>
+    secrets:
+      GOOGLE_SLIDEFLOW_CREDENTIALS: ${{ secrets.GOOGLE_DOCS_CREDENTIALS }}
+    with:
+      config-file: config/google-docs-report.yml
+```
+
 Example `dbt` source for a private dbt repo:
 
 ```yaml

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -153,7 +153,7 @@ Common positioning fields in chart config:
 
 Provider note:
 
-- `google_docs` inserts charts inline and ignores positional fields (`x`, `y`, alignment).
+- `google_docs` inserts charts inline and ignores positional fields (`x`, `y`, alignment); non-zero positional values emit a warning.
 
 ### `plotly_go`
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -80,6 +80,18 @@ Supported reusable-workflow secret mappings:
 For `google_docs` provider runs with the reusable workflow, use `GOOGLE_SLIDEFLOW_CREDENTIALS`
 as the credentials secret mapping (or set `provider.config.credentials` directly in config).
 
+If your caller repo secret is named `GOOGLE_DOCS_CREDENTIALS`, map it explicitly:
+
+```yaml
+jobs:
+  build:
+    uses: joe-broadhead/slideflow/.github/workflows/reusable-slideflow-build.yml@<pinned_sha>
+    secrets:
+      GOOGLE_SLIDEFLOW_CREDENTIALS: ${{ secrets.GOOGLE_DOCS_CREDENTIALS }}
+    with:
+      config-file: config/google-docs-report.yml
+```
+
 ### Passing machine-readable outputs to downstream jobs
 
 The reusable workflow exposes:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ SlideFlow accepts credentials via:
 2. `GOOGLE_DOCS_CREDENTIALS` environment variable (for `google_docs`)
 3. `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable
 
-`GOOGLE_SLIDEFLOW_CREDENTIALS` supports either:
+Environment credential values support either:
 
 - Path to service-account JSON file
 - Raw JSON string content
@@ -43,6 +43,7 @@ Example:
 
 ```bash
 export GOOGLE_SLIDEFLOW_CREDENTIALS=/absolute/path/service-account.json
+export GOOGLE_DOCS_CREDENTIALS=/absolute/path/service-account.json
 ```
 
 ## Create a template deck
@@ -105,6 +106,12 @@ slideflow build config.yml
 ```
 
 Validation should be treated as mandatory in CI and release workflows.
+
+For provider contract checks (recommended in CI):
+
+```bash
+slideflow validate config.yml --provider-contract-check
+```
 
 To discover built-in chart templates:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,7 +42,28 @@ Expected outcome:
 - Slide 1 gets `{{MONTH}}` replacement and a bar chart from `docs/quickstart/data.csv`
 - Slide 2 gets a template chart from the built-in `bars/bar_basic` template
 
-## 3. Batch mode (multi-deck)
+## 3. Switch to a real Google Docs build
+
+Use a config with `provider.type: google_docs`, then set:
+
+- `provider.config.template_id`
+- `provider.config.credentials` (or `GOOGLE_DOCS_CREDENTIALS` / `GOOGLE_SLIDEFLOW_CREDENTIALS`)
+- section markers in your template (for example `{{SECTION:intro}}`) that match `presentation.slides[*].id`
+
+Then run:
+
+```bash
+slideflow validate path/to/google-docs-config.yml --provider-contract-check
+slideflow build path/to/google-docs-config.yml
+```
+
+Expected outcome:
+
+- A new document is copied from your template
+- Replacements run inside matched section-marker blocks
+- Charts are inserted inline in those same sections
+
+## 4. Batch mode (multi-deck)
 
 Create `variants.csv`:
 
@@ -66,7 +87,7 @@ Rules:
 - Empty CSV rows are rejected at runtime
 - Use `--dry-run` to validate all variants without building
 
-## 4. Control concurrency and rate limits
+## 5. Control concurrency and rate limits
 
 ```bash
 slideflow build docs/quickstart/config.yml \
@@ -77,7 +98,7 @@ slideflow build docs/quickstart/config.yml \
 
 Use conservative `--threads` and `--rps` when Google API quotas are tight.
 
-## 5. Troubleshoot fast
+## 6. Troubleshoot fast
 
 If anything fails:
 
@@ -87,7 +108,7 @@ If anything fails:
 - verify connector credentials for your runtime target
 - check [Troubleshooting](troubleshooting.md)
 
-## 6. CI-parity local gate (recommended before PR)
+## 7. CI-parity local gate (recommended before PR)
 
 ```bash
 source .venv/bin/activate


### PR DESCRIPTION
## Summary
- complete a docs sweep for Google Docs coverage across README and MkDocs pages
- add explicit reusable workflow credential mapping guidance for callers that store docs credentials as GOOGLE_DOCS_CREDENTIALS
- add a dedicated Google Docs quickstart path including provider contract validation
- clarify chart positional warning behavior for google_docs
- ignore generated *.egg-info directories in git

## Files Updated
- .gitignore
- CONTRIBUTING.md
- docs/getting-started.md
- docs/quickstart.md
- docs/automation.md
- docs/deployments.md
- docs/config-reference.md

## Validation
- uv run mkdocs build --strict