### PR TITLE
feat: add opt-in ownership transfer for Google Slides/Docs

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -56,6 +56,8 @@ Supported values:
 | `new_folder_name_fn` | `callable` | no | Dynamic folder-name generator |
 | `share_with` | `list[str]` | no | Emails to share generated deck with |
 | `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
+| `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
+| `transfer_ownership_strict` | `bool` | no | If `true`, fail build when ownership transfer fails |
 | `requests_per_second` | `float` | no | API rate limit override |
 | `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
 
@@ -75,6 +77,8 @@ For provider setup and operational behavior, see [Google Slides Provider](provid
 | `default_chart_width_pt` | `float` | no | Reserved config field; currently not applied at render time |
 | `share_with` | `list[str]` | no | Emails to share generated document with |
 | `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
+| `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
+| `transfer_ownership_strict` | `bool` | no | If `true`, fail build when ownership transfer fails |
 | `requests_per_second` | `float` | no | API rate limit override |
 | `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
 

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -53,6 +53,8 @@ provider:
     share_with:
       - "team@example.com"
     share_role: "reader"
+    transfer_ownership_to: "owner@example.com"
+    transfer_ownership_strict: false
     requests_per_second: 1.0
     strict_cleanup: false
 ```
@@ -64,6 +66,8 @@ Field behavior:
 - `drive_folder_id`: destination folder for uploaded chart images.
 - `section_marker_prefix` / `section_marker_suffix`: marker token format.
 - `share_with` / `share_role`: post-render sharing.
+- `transfer_ownership_to`: optional ownership handoff target after successful render/share.
+- `transfer_ownership_strict`: if `true`, ownership handoff failure fails the run.
 - `requests_per_second`: API pacing control.
 - `strict_cleanup`: fail run if chart-image cleanup fails.
 
@@ -78,6 +82,7 @@ Current implementation notes:
 - Charts are inserted inline at the matched section anchor.
 - Positional chart fields (`x`, `y`, alignment) are ignored for `google_docs` and log a warning when non-zero positional values are provided.
 - The build result `url` points to `https://docs.google.com/document/d/<id>`.
+- Ownership transfer is explicit opt-in and only supported for files in **My Drive** (not Shared Drives).
 
 ## Contract Validation
 

--- a/docs/providers/google-slides.md
+++ b/docs/providers/google-slides.md
@@ -44,6 +44,8 @@ provider:
     share_with:
       - "team@example.com"
     share_role: "reader"
+    transfer_ownership_to: "owner@example.com"
+    transfer_ownership_strict: false
     requests_per_second: 1.0
     strict_cleanup: false
 ```
@@ -58,6 +60,8 @@ Field behavior:
   - If omitted, SlideFlow falls back to the presentation destination folder logic.
 - `new_folder_name` + `new_folder_name_fn`: optional dynamic subfolder under `presentation_folder_id`.
 - `share_with` + `share_role`: shares the rendered deck after generation.
+- `transfer_ownership_to`: optional ownership handoff target after successful render/share.
+- `transfer_ownership_strict`: if `true`, ownership handoff failure fails the run.
 - `requests_per_second`: throttles API calls.
 - `strict_cleanup`: if `true`, cleanup failures (chart image trash) fail the render.
 
@@ -68,6 +72,8 @@ Sharing is performed by the service account, not your personal user.
 - Ensure the service account has permission to share files in the target drive/folder.
 - `share_role` supports `reader`, `writer`, and `commenter`.
 - Google may send notification emails when sharing is executed.
+- Ownership transfer is explicit opt-in and only works for files in **My Drive** (not Shared Drives).
+- Transfer uses Google Drive ownership APIs and may notify the target owner.
 
 ## Cleanup Semantics
 

--- a/slideflow/cli/commands/build.py
+++ b/slideflow/cli/commands/build.py
@@ -386,6 +386,18 @@ def build_command(
                     result_dict = returned_params.copy()
                     result_dict["url"] = result.presentation_url
                     result_dict["presentation_name"] = name
+                    result_dict["ownership_transfer_attempted"] = getattr(
+                        result, "ownership_transfer_attempted", False
+                    )
+                    result_dict["ownership_transfer_succeeded"] = getattr(
+                        result, "ownership_transfer_succeeded", None
+                    )
+                    result_dict["ownership_transfer_target"] = getattr(
+                        result, "ownership_transfer_target", None
+                    )
+                    result_dict["ownership_transfer_error"] = getattr(
+                        result, "ownership_transfer_error", None
+                    )
                     results.append(result_dict)
 
                     completed_count += 1

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -66,6 +66,7 @@ from slideflow.constants import GoogleSlides, Timing
 from slideflow.presentations.positioning import compute_chart_dimensions
 from slideflow.presentations.providers.base import PresentationProvider
 from slideflow.replacements.base import BaseReplacement
+from slideflow.utilities.error_messages import safe_error_line
 from slideflow.utilities.exceptions import RenderingError
 from slideflow.utilities.logging import get_logger
 
@@ -129,6 +130,34 @@ class PresentationResult(BaseModel):
         Field(
             default_factory=datetime.now,
             description="Timestamp when presentation was created",
+        ),
+    ]
+    ownership_transfer_attempted: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Whether ownership transfer was explicitly requested and attempted",
+        ),
+    ]
+    ownership_transfer_succeeded: Annotated[
+        Optional[bool],
+        Field(
+            default=None,
+            description="Ownership transfer result when attempted, otherwise null",
+        ),
+    ]
+    ownership_transfer_target: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Ownership transfer target email when configured",
+        ),
+    ]
+    ownership_transfer_error: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Single-line transfer error when ownership transfer fails",
         ),
     ]
 
@@ -541,6 +570,10 @@ class Presentation(BaseModel):
             getattr(getattr(self.provider, "config", None), "strict_cleanup", False)
         )
         failed_cleanup_ids: List[str] = []
+        ownership_transfer_attempted = False
+        ownership_transfer_succeeded: Optional[bool] = None
+        ownership_transfer_target: Optional[str] = None
+        ownership_transfer_error: Optional[str] = None
 
         try:
             # Pre-fetch all data sources (uses caching)
@@ -713,6 +746,55 @@ class Presentation(BaseModel):
                         getattr(self.provider.config, "share_role", "writer"),
                     )
 
+            transfer_owner = getattr(
+                getattr(self.provider, "config", None),
+                "transfer_ownership_to",
+                None,
+            )
+            if transfer_owner:
+                ownership_transfer_attempted = True
+                ownership_transfer_target = transfer_owner
+                transfer_strict = bool(
+                    getattr(
+                        getattr(self.provider, "config", None),
+                        "transfer_ownership_strict",
+                        False,
+                    )
+                )
+                transfer_method = getattr(
+                    self.provider, "transfer_presentation_ownership", None
+                )
+
+                if not callable(transfer_method):
+                    ownership_transfer_succeeded = False
+                    ownership_transfer_error = (
+                        "Ownership transfer is not supported by provider "
+                        f"'{type(self.provider).__name__}'"
+                    )
+                    logger.warning(ownership_transfer_error)
+                    if transfer_strict:
+                        raise RenderingError(ownership_transfer_error)
+                else:
+                    try:
+                        transfer_method(presentation_id, transfer_owner)
+                        ownership_transfer_succeeded = True
+                    except (
+                        Exception
+                    ) as transfer_error:  # pragma: no cover - guarded via tests
+                        ownership_transfer_succeeded = False
+                        ownership_transfer_error = safe_error_line(transfer_error)
+                        logger.error(
+                            "Ownership transfer failed for '%s' -> '%s': %s",
+                            presentation_id,
+                            transfer_owner,
+                            ownership_transfer_error,
+                        )
+                        if transfer_strict:
+                            raise RenderingError(
+                                "Ownership transfer failed: "
+                                f"{ownership_transfer_error}"
+                            ) from transfer_error
+
             render_time = time.time() - start_time
 
             return PresentationResult(
@@ -722,6 +804,10 @@ class Presentation(BaseModel):
                 replacements_made=total_replacements,
                 render_time=render_time,
                 created_at=datetime.now(),
+                ownership_transfer_attempted=ownership_transfer_attempted,
+                ownership_transfer_succeeded=ownership_transfer_succeeded,
+                ownership_transfer_target=ownership_transfer_target,
+                ownership_transfer_error=ownership_transfer_error,
             )
         except Exception as e:
             original_error = e

--- a/slideflow/presentations/providers/base.py
+++ b/slideflow/presentations/providers/base.py
@@ -423,6 +423,27 @@ class PresentationProvider(ABC):
         """
         pass
 
+    def transfer_presentation_ownership(
+        self, presentation_id: str, new_owner_email: str
+    ) -> None:
+        """Transfer ownership of a presentation/document to another user.
+
+        This is an optional hook used by providers that support ownership
+        transfer semantics (for example, Google Drive-backed providers).
+
+        Args:
+            presentation_id: Unique identifier of the artifact.
+            new_owner_email: Target user email that should become owner.
+
+        Raises:
+            NotImplementedError: If the provider does not support ownership
+                transfer operations.
+        """
+        del presentation_id, new_owner_email
+        raise NotImplementedError(
+            f"Provider '{type(self).__name__}' does not support ownership transfer"
+        )
+
     @abstractmethod
     def get_presentation_url(self, presentation_id: str) -> str:
         """Get the public URL for accessing a presentation.

--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -20,12 +20,18 @@ from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseUpload
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from slideflow.constants import Environment, GoogleSlides, Timing
 from slideflow.presentations.providers.base import (
     PresentationProvider,
     PresentationProviderConfig,
+)
+from slideflow.presentations.providers.google_drive_ownership import (
+    append_transfer_owner_preflight_check,
+    is_shared_drive_file,
+    normalize_transfer_owner_email,
+    transfer_drive_file_ownership,
 )
 from slideflow.utilities.auth import handle_google_credentials
 from slideflow.utilities.exceptions import AuthenticationError, RenderingError
@@ -102,6 +108,19 @@ class GoogleDocsProviderConfig(PresentationProviderConfig):
         False,
         description="If true, fail rendering when chart image cleanup fails.",
     )
+    transfer_ownership_to: Optional[str] = Field(
+        None,
+        description="Optional email address that should become the owner after rendering completes.",
+    )
+    transfer_ownership_strict: bool = Field(
+        False,
+        description="If true, fail rendering when ownership transfer fails.",
+    )
+
+    @field_validator("transfer_ownership_to")
+    @classmethod
+    def _validate_transfer_ownership_to(cls, value: Optional[str]) -> Optional[str]:
+        return normalize_transfer_owner_email(value)
 
 
 class GoogleDocsProvider(PresentationProvider):
@@ -164,7 +183,6 @@ class GoogleDocsProvider(PresentationProvider):
             os.getenv(Environment.GOOGLE_DOCS_CREDENTIALS)
             or os.getenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS)
         )
-
         checks: List[Tuple[str, bool, str]] = [
             (
                 "google_docs_credentials_present",
@@ -203,6 +221,11 @@ class GoogleDocsProvider(PresentationProvider):
                 ),
             ),
         ]
+
+        append_transfer_owner_preflight_check(
+            checks,
+            getattr(self.config, "transfer_ownership_to", None),
+        )
         return checks
 
     def create_presentation(self, name: str, template_id: Optional[str] = None) -> str:
@@ -629,6 +652,35 @@ class GoogleDocsProvider(PresentationProvider):
                     supportsAllDrives=True,
                 )
             )
+
+    def _is_shared_drive_file(self, file_id: str) -> bool:
+        """Return True when the file is backed by a Shared Drive."""
+        return is_shared_drive_file(
+            execute_request=self._execute_request,
+            drive_service=self.drive_service,
+            file_id=file_id,
+        )
+
+    def transfer_presentation_ownership(
+        self, presentation_id: str, new_owner_email: str
+    ) -> None:
+        """Transfer ownership of a generated document to another user."""
+        if self._is_shared_drive_file(presentation_id):
+            raise ValueError(
+                "Ownership transfer is not supported for files in Shared Drives"
+            )
+
+        transfer_drive_file_ownership(
+            execute_request=self._execute_request,
+            drive_service=self.drive_service,
+            file_id=presentation_id,
+            new_owner_email=new_owner_email,
+        )
+        logger.info(
+            "Transferred document ownership to %s (document_id=%s)",
+            new_owner_email,
+            presentation_id,
+        )
 
     def get_presentation_url(self, presentation_id: str) -> str:
         return f"https://docs.google.com/document/d/{presentation_id}"

--- a/slideflow/presentations/providers/google_drive_ownership.py
+++ b/slideflow/presentations/providers/google_drive_ownership.py
@@ -1,0 +1,82 @@
+"""Shared ownership-transfer helpers for Google Drive-backed providers."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+def normalize_transfer_owner_email(value: Optional[str]) -> Optional[str]:
+    """Normalize and validate an optional ownership-transfer target email."""
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    if not normalized:
+        return None
+
+    if "@" not in normalized or "." not in normalized.rsplit("@", 1)[-1]:
+        raise ValueError("transfer_ownership_to must be a valid email address")
+
+    return normalized
+
+
+def append_transfer_owner_preflight_check(
+    checks: List[Tuple[str, bool, str]],
+    transfer_owner: Optional[str],
+) -> None:
+    """Append a standardized transfer-target check when configured."""
+    owner = (transfer_owner or "").strip()
+    if not owner:
+        return
+
+    target_valid = "@" in owner and "." in owner.rsplit("@", 1)[-1]
+    checks.append(
+        (
+            "ownership_transfer_target_valid",
+            target_valid,
+            (
+                f"Ownership transfer target '{owner}' looks valid"
+                if target_valid
+                else "transfer_ownership_to must be a valid email address"
+            ),
+        )
+    )
+
+
+def is_shared_drive_file(
+    execute_request: Callable[[Any], Dict[str, Any]],
+    drive_service: Any,
+    file_id: str,
+) -> bool:
+    """Return True when a Drive file is backed by a Shared Drive."""
+    metadata = execute_request(
+        drive_service.files().get(
+            fileId=file_id,
+            fields="id,driveId",
+            supportsAllDrives=True,
+        )
+    )
+    return bool(metadata.get("driveId"))
+
+
+def transfer_drive_file_ownership(
+    execute_request: Callable[[Any], Dict[str, Any]],
+    drive_service: Any,
+    file_id: str,
+    new_owner_email: str,
+) -> None:
+    """Transfer ownership of a Drive file to a user."""
+    permission = {
+        "type": "user",
+        "role": "owner",
+        "emailAddress": new_owner_email,
+    }
+    execute_request(
+        drive_service.permissions().create(
+            fileId=file_id,
+            body=permission,
+            transferOwnership=True,
+            sendNotificationEmail=True,
+            supportsAllDrives=False,
+        )
+    )

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -75,12 +75,18 @@ from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseUpload
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from slideflow.constants import Environment, GoogleSlides, Timing
 from slideflow.presentations.providers.base import (
     PresentationProvider,
     PresentationProviderConfig,
+)
+from slideflow.presentations.providers.google_drive_ownership import (
+    append_transfer_owner_preflight_check,
+    is_shared_drive_file,
+    normalize_transfer_owner_email,
+    transfer_drive_file_ownership,
 )
 from slideflow.utilities.auth import handle_google_credentials
 from slideflow.utilities.exceptions import AuthenticationError
@@ -167,6 +173,19 @@ class GoogleSlidesProviderConfig(PresentationProviderConfig):
         False,
         description="If true, fail rendering when uploaded chart images cannot be cleaned up.",
     )
+    transfer_ownership_to: Optional[str] = Field(
+        None,
+        description="Optional email address that should become the owner after rendering completes.",
+    )
+    transfer_ownership_strict: bool = Field(
+        False,
+        description="If true, fail rendering when ownership transfer fails.",
+    )
+
+    @field_validator("transfer_ownership_to")
+    @classmethod
+    def _validate_transfer_ownership_to(cls, value: Optional[str]) -> Optional[str]:
+        return normalize_transfer_owner_email(value)
 
 
 class GoogleSlidesProvider(PresentationProvider):
@@ -283,7 +302,6 @@ class GoogleSlidesProvider(PresentationProvider):
         has_credentials = bool(self.config.credentials) or bool(
             os.getenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS)
         )
-
         checks: List[Tuple[str, bool, str]] = [
             (
                 "google_credentials_present",
@@ -322,6 +340,11 @@ class GoogleSlidesProvider(PresentationProvider):
                 ),
             ),
         ]
+
+        append_transfer_owner_preflight_check(
+            checks,
+            getattr(self.config, "transfer_ownership_to", None),
+        )
 
         return checks
 
@@ -464,6 +487,38 @@ class GoogleSlidesProvider(PresentationProvider):
             except HttpError as error:
                 logger.error(f"Error sharing presentation: {error}")
                 raise
+
+    def _is_shared_drive_file(self, file_id: str) -> bool:
+        """Return True when the file is backed by a Shared Drive."""
+        return is_shared_drive_file(
+            execute_request=self._execute_request,
+            drive_service=self.drive_service,
+            file_id=file_id,
+        )
+
+    def transfer_presentation_ownership(
+        self, presentation_id: str, new_owner_email: str
+    ) -> None:
+        """Transfer ownership of a generated presentation to another user.
+
+        Ownership transfer is only supported for files in My Drive.
+        """
+        if self._is_shared_drive_file(presentation_id):
+            raise ValueError(
+                "Ownership transfer is not supported for files in Shared Drives"
+            )
+
+        transfer_drive_file_ownership(
+            execute_request=self._execute_request,
+            drive_service=self.drive_service,
+            file_id=presentation_id,
+            new_owner_email=new_owner_email,
+        )
+        logger.info(
+            "Transferred presentation ownership to %s (presentation_id=%s)",
+            new_owner_email,
+            presentation_id,
+        )
 
     def get_presentation_url(self, presentation_id: str) -> str:
         """Get the public URL for a Google Slides presentation.

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -183,6 +183,14 @@ def test_google_docs_provider_init_authentication_failure(monkeypatch):
         GoogleDocsProvider(GoogleDocsProviderConfig(credentials='{"invalid":true}'))
 
 
+def test_google_docs_config_validates_transfer_ownership_target():
+    with pytest.raises(ValueError, match="transfer_ownership_to"):
+        GoogleDocsProviderConfig(transfer_ownership_to="not-an-email")
+
+    config = GoogleDocsProviderConfig(transfer_ownership_to=" owner@example.com ")
+    assert config.transfer_ownership_to == "owner@example.com"
+
+
 def test_google_docs_provider_factory_registration():
     config = ProviderConfig(
         type="google_docs",
@@ -214,6 +222,25 @@ def test_run_preflight_checks_without_credentials(monkeypatch):
     assert check_map["rate_limiter_initialized"] is False
 
 
+def test_run_preflight_checks_validates_transfer_target(monkeypatch):
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace(
+        credentials=None,
+        requests_per_second=1.0,
+        transfer_ownership_to="bad-target",
+    )
+    provider.docs_service = object()
+    provider.drive_service = object()
+    provider.rate_limiter = object()
+    monkeypatch.delenv(Environment.GOOGLE_DOCS_CREDENTIALS, raising=False)
+    monkeypatch.delenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS, raising=False)
+
+    checks = provider.run_preflight_checks()
+    check_map = {name: ok for name, ok, _ in checks}
+
+    assert check_map["ownership_transfer_target_valid"] is False
+
+
 def test_create_presentation_template_and_plain(monkeypatch):
     provider = _provider_without_init()
     provider.config = SimpleNamespace(template_id="template-1")
@@ -236,6 +263,53 @@ def test_create_presentation_template_and_plain(monkeypatch):
     provider.config = SimpleNamespace(template_id=None)
     assert provider.create_presentation("Doc C") == "created"
     assert create_calls == ["Doc C"]
+
+
+def test_transfer_presentation_ownership_success_and_shared_drive_guard():
+    provider = _provider_without_init()
+    created_permissions: List[Dict[str, Any]] = []
+
+    class _Files:
+        def get(self, **kwargs):
+            return ("files-get", kwargs)
+
+    class _Permissions:
+        def create(self, **kwargs):
+            created_permissions.append(kwargs)
+            return ("permissions-create", kwargs)
+
+    provider.drive_service = SimpleNamespace(
+        files=lambda: _Files(),
+        permissions=lambda: _Permissions(),
+    )
+
+    def _exec(request):
+        if request[0] == "files-get":
+            return {"id": "doc-1"}
+        return {}
+
+    provider._execute_request = _exec
+    provider.transfer_presentation_ownership("doc-1", "owner@example.com")
+
+    assert created_permissions == [
+        {
+            "fileId": "doc-1",
+            "body": {
+                "type": "user",
+                "role": "owner",
+                "emailAddress": "owner@example.com",
+            },
+            "transferOwnership": True,
+            "sendNotificationEmail": True,
+            "supportsAllDrives": False,
+        }
+    ]
+
+    provider._execute_request = lambda request: (
+        {"id": "doc-2", "driveId": "drive-123"} if request[0] == "files-get" else {}
+    )
+    with pytest.raises(ValueError, match="Shared Drives"):
+        provider.transfer_presentation_ownership("doc-2", "owner@example.com")
 
 
 def test_insert_chart_and_replace_text_requests():

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -80,6 +80,14 @@ def test_google_provider_init_authentication_failure(monkeypatch):
         GoogleSlidesProvider(GoogleSlidesProviderConfig(credentials='{"invalid":true}'))
 
 
+def test_google_slides_config_validates_transfer_ownership_target():
+    with pytest.raises(ValueError, match="transfer_ownership_to"):
+        GoogleSlidesProviderConfig(transfer_ownership_to="not-an-email")
+
+    config = GoogleSlidesProviderConfig(transfer_ownership_to=" owner@example.com ")
+    assert config.transfer_ownership_to == "owner@example.com"
+
+
 @pytest.mark.parametrize(
     ("dimension", "expected"),
     [
@@ -115,6 +123,24 @@ def test_run_preflight_checks_without_credentials(monkeypatch):
     assert check_map["rate_limiter_initialized"] is False
 
 
+def test_run_preflight_checks_validates_transfer_target(monkeypatch):
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace(
+        credentials=None,
+        requests_per_second=1.0,
+        transfer_ownership_to="not-an-email",
+    )
+    provider.slides_service = object()
+    provider.drive_service = object()
+    provider.rate_limiter = object()
+    monkeypatch.delenv("GOOGLE_SLIDEFLOW_CREDENTIALS", raising=False)
+
+    checks = provider.run_preflight_checks()
+    check_map = {name: ok for name, ok, _ in checks}
+
+    assert check_map["ownership_transfer_target_valid"] is False
+
+
 def test_share_presentation_success_and_error(monkeypatch):
     provider = _provider_without_init()
     requests: List[Any] = []
@@ -147,6 +173,53 @@ def test_share_presentation_success_and_error(monkeypatch):
 
     with pytest.raises(google_provider_module.HttpError):
         provider.share_presentation("pres-2", ["x@example.com"], role="writer")
+
+
+def test_transfer_presentation_ownership_success_and_shared_drive_guard():
+    provider = _provider_without_init()
+    created_permissions: List[Dict[str, Any]] = []
+
+    class _Files:
+        def get(self, **kwargs):
+            return ("files-get", kwargs)
+
+    class _Permissions:
+        def create(self, **kwargs):
+            created_permissions.append(kwargs)
+            return ("permissions-create", kwargs)
+
+    provider.drive_service = SimpleNamespace(
+        files=lambda: _Files(),
+        permissions=lambda: _Permissions(),
+    )
+
+    def _exec(request):
+        if request[0] == "files-get":
+            return {"id": "pres-1"}
+        return {}
+
+    provider._execute_request = _exec
+    provider.transfer_presentation_ownership("pres-1", "owner@example.com")
+
+    assert created_permissions == [
+        {
+            "fileId": "pres-1",
+            "body": {
+                "type": "user",
+                "role": "owner",
+                "emailAddress": "owner@example.com",
+            },
+            "transferOwnership": True,
+            "sendNotificationEmail": True,
+            "supportsAllDrives": False,
+        }
+    ]
+
+    provider._execute_request = lambda request: (
+        {"id": "pres-2", "driveId": "drive-123"} if request[0] == "files-get" else {}
+    )
+    with pytest.raises(ValueError, match="Shared Drives"):
+        provider.transfer_presentation_ownership("pres-2", "owner@example.com")
 
 
 def test_get_presentation_page_size_logs_failure_on_exception(monkeypatch):

--- a/tests/test_presentation_render.py
+++ b/tests/test_presentation_render.py
@@ -152,3 +152,72 @@ def test_render_fails_fast_when_provider_preflight_fails():
 
     with pytest.raises(RenderingError, match="Provider preflight checks failed"):
         presentation.render()
+
+
+def test_render_transfers_ownership_when_configured():
+    class TransferProvider(FakeProvider):
+        def __init__(self):
+            super().__init__(strict_cleanup=False, fail_cleanup=False)
+            self.config.share_with = ["team@example.com"]
+            self.config.share_role = "writer"
+            self.config.transfer_ownership_to = "owner@example.com"
+            self.config.transfer_ownership_strict = False
+            self.share_calls = []
+            self.transfer_calls = []
+
+        def share_presentation(self, presentation_id, emails, role="writer"):
+            self.share_calls.append((presentation_id, tuple(emails), role))
+
+        def transfer_presentation_ownership(self, presentation_id, new_owner_email):
+            self.transfer_calls.append((presentation_id, new_owner_email))
+
+    provider = TransferProvider()
+    presentation, _chart = _build_presentation(provider)
+
+    result = presentation.render()
+
+    assert provider.share_calls == [("presentation-1", ("team@example.com",), "writer")]
+    assert provider.transfer_calls == [("presentation-1", "owner@example.com")]
+    assert result.ownership_transfer_attempted is True
+    assert result.ownership_transfer_succeeded is True
+    assert result.ownership_transfer_target == "owner@example.com"
+    assert result.ownership_transfer_error is None
+
+
+def test_render_records_non_strict_transfer_failure():
+    class TransferProvider(FakeProvider):
+        def __init__(self):
+            super().__init__(strict_cleanup=False, fail_cleanup=False)
+            self.config.transfer_ownership_to = "owner@example.com"
+            self.config.transfer_ownership_strict = False
+
+        def transfer_presentation_ownership(self, presentation_id, new_owner_email):
+            del presentation_id, new_owner_email
+            raise RuntimeError()
+
+    provider = TransferProvider()
+    presentation, _chart = _build_presentation(provider)
+
+    result = presentation.render()
+
+    assert result.ownership_transfer_attempted is True
+    assert result.ownership_transfer_succeeded is False
+    assert result.ownership_transfer_error == "RuntimeError"
+
+
+def test_render_raises_when_strict_transfer_fails():
+    class TransferProvider(FakeProvider):
+        def __init__(self):
+            super().__init__(strict_cleanup=False, fail_cleanup=False)
+            self.config.transfer_ownership_to = "owner@example.com"
+            self.config.transfer_ownership_strict = True
+
+        def transfer_presentation_ownership(self, presentation_id, new_owner_email):
+            del presentation_id, new_owner_email
+            raise RuntimeError("transfer denied")
+
+    provider = TransferProvider()
+    presentation, _chart = _build_presentation(provider)
+
+    with pytest.raises(RenderingError, match="Ownership transfer failed"):
+        presentation.render()

--- a/tests/test_runtime_workflows_phase4.py
+++ b/tests/test_runtime_workflows_phase4.py
@@ -166,6 +166,54 @@ def test_build_command_non_dry_run_processes_results_and_sorts(tmp_path, monkeyp
         "https://example.com/z",
     ]
     assert sorted(row["region"] for row in result) == ["eu", "us"]
+    assert all(row["ownership_transfer_attempted"] is False for row in result)
+    assert all(row["ownership_transfer_succeeded"] is None for row in result)
+
+
+def test_build_command_includes_ownership_transfer_metadata(tmp_path, monkeypatch):
+    _stub_build_cli_output(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        build_command_module,
+        "build_single_presentation",
+        lambda *_args, **_kwargs: (
+            "Deck",
+            SimpleNamespace(
+                presentation_url="https://example.com/deck",
+                ownership_transfer_attempted=True,
+                ownership_transfer_succeeded=False,
+                ownership_transfer_target="owner@example.com",
+                ownership_transfer_error="transfer denied",
+            ),
+            1,
+            {},
+        ),
+    )
+
+    result = build_command_module.build_command(
+        config_file=config_file,
+        registry_files=None,
+        params_path=None,
+        dry_run=False,
+        threads=1,
+    )
+
+    assert result[0]["ownership_transfer_attempted"] is True
+    assert result[0]["ownership_transfer_succeeded"] is False
+    assert result[0]["ownership_transfer_target"] == "owner@example.com"
+    assert result[0]["ownership_transfer_error"] == "transfer denied"
 
 
 def test_build_command_non_dry_run_worker_failure_exits(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add optional ownership transfer support for `google_slides` and `google_docs`
- run transfer only when `provider.config.transfer_ownership_to` is configured
- add strict mode (`transfer_ownership_strict`) to fail builds on transfer errors
- keep default behavior unchanged (share-only)

## Implementation
- add provider hook: `transfer_presentation_ownership(...)`
- wire transfer execution into render flow after sharing
- capture transfer result metadata in `PresentationResult`
- include transfer metadata in `slideflow build --output-json` per-result entries
- add shared helper module for Drive ownership transfer logic to avoid duplication:
  - email normalization/validation
  - preflight transfer-target check
  - shared-drive guard
  - transfer API request payload

## Provider behavior
- Google providers now support:
  - `transfer_ownership_to`
  - `transfer_ownership_strict`
- transfer is blocked for Shared Drive-backed files with explicit error

## Docs
- update config reference and provider docs with new ownership-transfer settings and constraints

## Tests
- add/extend tests for:
  - transfer config validation
  - preflight checks
  - transfer success/failure + shared drive guard
  - render behavior in strict and non-strict modes
  - build output JSON transfer metadata

## Validation run
- `ruff check` (changed files)
- `black --check` (changed files)
- `mypy` (changed source files)
- `pytest -q tests/test_presentation_render.py tests/test_google_slides_provider_coverage.py tests/test_google_docs_provider_coverage.py tests/test_runtime_workflows_phase4.py tests/test_cli_commands.py tests/test_cli_doctor.py tests/test_integration_cli_workflows.py`
  - result: `101 passed`

Closes #135