### PR TITLE
test(live): add Google Sheets live E2E suite and workflow

### DIFF
--- a/.github/workflows/live-google-sheets.yml
+++ b/.github/workflows/live-google-sheets.yml
@@ -1,0 +1,53 @@
+name: Live Google Sheets
+
+on:
+  workflow_dispatch:
+
+jobs:
+  live-google-sheets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,ai]"
+
+      - name: Validate required secrets
+        env:
+          GOOGLE_SHEETS_CREDENTIALS: ${{ secrets.GOOGLE_SHEETS_CREDENTIALS || secrets.GOOGLE_SLIDEFLOW_CREDENTIALS }}
+          SLIDEFLOW_LIVE_SHEETS_FOLDER_ID: ${{ secrets.SLIDEFLOW_LIVE_SHEETS_FOLDER_ID || secrets.SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID || secrets.SLIDEFLOW_LIVE_DOCUMENT_FOLDER_ID }}
+        run: |
+          set -euo pipefail
+          [[ -n "${GOOGLE_SHEETS_CREDENTIALS:-}" ]] || {
+            echo "Missing required secret: GOOGLE_SHEETS_CREDENTIALS (or GOOGLE_SLIDEFLOW_CREDENTIALS fallback)"
+            exit 1
+          }
+          [[ -n "${SLIDEFLOW_LIVE_SHEETS_FOLDER_ID:-}" ]] || {
+            echo "Missing required secret: SLIDEFLOW_LIVE_SHEETS_FOLDER_ID (or SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID / SLIDEFLOW_LIVE_DOCUMENT_FOLDER_ID fallback)"
+            exit 1
+          }
+
+      - name: Run live Google Sheets tests
+        env:
+          SLIDEFLOW_RUN_LIVE: "1"
+          GOOGLE_SHEETS_CREDENTIALS: ${{ secrets.GOOGLE_SHEETS_CREDENTIALS || secrets.GOOGLE_SLIDEFLOW_CREDENTIALS }}
+          GOOGLE_SLIDEFLOW_CREDENTIALS: ${{ secrets.GOOGLE_SLIDEFLOW_CREDENTIALS || secrets.GOOGLE_SHEETS_CREDENTIALS }}
+          SLIDEFLOW_LIVE_SHEETS_FOLDER_ID: ${{ secrets.SLIDEFLOW_LIVE_SHEETS_FOLDER_ID || secrets.SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID || secrets.SLIDEFLOW_LIVE_DOCUMENT_FOLDER_ID }}
+          SLIDEFLOW_LIVE_DRIVE_FOLDER_ID: ${{ secrets.SLIDEFLOW_LIVE_DRIVE_FOLDER_ID || secrets.SLIDEFLOW_LIVE_SHEETS_FOLDER_ID || secrets.SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID || secrets.SLIDEFLOW_LIVE_DOCUMENT_FOLDER_ID }}
+          SLIDEFLOW_LIVE_SHARE_EMAIL: ${{ secrets.SLIDEFLOW_LIVE_SHARE_EMAIL }}
+          SLIDEFLOW_LIVE_SHARE_ROLE: "reader"
+          SLIDEFLOW_LIVE_KEEP_ARTIFACTS: "0"
+          SLIDEFLOW_LIVE_RPS: "1.0"
+        run: |
+          python -m pytest -q tests/live_tests -m live_google_sheets -s

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Live Google suite (optional, requires credentials):
 ```bash
 python -m pytest -q tests/live_tests -m live_google
 python -m pytest -q tests/live_tests -m live_google_docs
+python -m pytest -q tests/live_tests -m live_google_sheets
 ```
 
 ## Contribution expectations

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -46,6 +46,14 @@
   - optional secret: `SLIDEFLOW_LIVE_DOC_TEMPLATE_ID` (seed template to copy before test mutation)
   - optional secret: `SLIDEFLOW_LIVE_SHARE_EMAIL` (share rendered doc for manual visual verification)
   - workflow pins `SLIDEFLOW_LIVE_KEEP_ARTIFACTS=0` to avoid leaving artifacts in CI runs
+- `Live Google Sheets` (`.github/workflows/live-google-sheets.yml`)
+  - runs on manual dispatch (`workflow_dispatch`) only
+  - executes `pytest -q tests/live_tests -m live_google_sheets`
+  - uses dedicated secrets/folders to create real workbook artifacts
+  - validates replace + append idempotency behavior against Google Sheets APIs
+  - requires secrets: `GOOGLE_SHEETS_CREDENTIALS` (or `GOOGLE_SLIDEFLOW_CREDENTIALS` fallback), `SLIDEFLOW_LIVE_SHEETS_FOLDER_ID` (or presentation/document folder fallback)
+  - optional secret: `SLIDEFLOW_LIVE_SHARE_EMAIL` (share rendered workbook for manual verification)
+  - workflow pins `SLIDEFLOW_LIVE_KEEP_ARTIFACTS=0` to avoid leaving artifacts in CI runs
 
 ## Required local checks before PR
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,6 +37,12 @@
    - validates inline chart insertion in rendered docs
    - validates deterministic AI and table replacement behavior
    - trashes created files on teardown
+6. Live Google Sheets tests (`@pytest.mark.live_google_sheets`, `tests/live_tests/`)
+   - creates a real workbook via Google Sheets API
+   - validates replace-mode writes for current snapshot tabs
+   - validates append-mode idempotency using `_slideflow_meta` run-key tracking
+   - verifies rerun skip behavior prevents duplicate appended rows
+   - trashes created files on teardown
 
 ## Local commands
 
@@ -111,6 +117,24 @@ export SLIDEFLOW_LIVE_KEEP_ARTIFACTS=1
 pytest -q tests/live_tests -m live_google_docs
 ```
 
+Run live Google Sheets tests locally:
+
+```bash
+export SLIDEFLOW_RUN_LIVE=1
+export GOOGLE_SHEETS_CREDENTIALS=/absolute/path/to/service-account.json
+export SLIDEFLOW_LIVE_SHEETS_FOLDER_ID=<drive-folder-id>
+# optional override:
+export SLIDEFLOW_LIVE_DRIVE_FOLDER_ID=<drive-folder-id>
+# optional comma-separated emails to share rendered workbook with:
+export SLIDEFLOW_LIVE_SHARE_EMAIL=<you@example.com>
+# optional permission role for shared workbook (reader|writer|commenter):
+export SLIDEFLOW_LIVE_SHARE_ROLE=reader
+# optional retention toggle; defaults to 1 when sharing is enabled:
+export SLIDEFLOW_LIVE_KEEP_ARTIFACTS=1
+
+pytest -q tests/live_tests -m live_google_sheets
+```
+
 ## CI quality gates
 
 - CI enforces version consistency checks.
@@ -120,6 +144,7 @@ pytest -q tests/live_tests -m live_google_docs
 - Distribution artifacts are built for every CI run.
 - Live Google Slides tests run in a separate workflow (`Live Google Slides`) so PR CI remains deterministic.
 - Live Google Docs tests run in a separate workflow (`Live Google Docs`) so PR CI remains deterministic.
+- Live Google Sheets tests run in a separate workflow (`Live Google Sheets`) so PR CI remains deterministic.
 
 ## Orchestrated runtime note
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,4 +90,5 @@ markers = [
     "e2e: end-to-end workflow tests",
     "live_google: live Google Slides API tests that create real presentations",
     "live_google_docs: live Google Docs API tests that create real documents",
+    "live_google_sheets: live Google Sheets API tests that create real workbooks",
 ]

--- a/tests/live_tests/test_live_google_sheets_workbooks.py
+++ b/tests/live_tests/test_live_google_sheets_workbooks.py
@@ -1,0 +1,242 @@
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from slideflow.workbooks.builder import WorkbookBuilder
+from slideflow.workbooks.providers.google_sheets import (
+    GoogleSheetsProvider,
+    GoogleSheetsProviderConfig,
+)
+
+pytestmark = pytest.mark.live_google_sheets
+
+
+def _require_first_env(var_names: Iterable[str], reason: str) -> str:
+    for var_name in var_names:
+        value = os.getenv(var_name)
+        if value:
+            return value
+    pytest.skip(reason)
+
+
+def _parse_optional_email_list(var_name: str) -> List[str]:
+    raw = os.getenv(var_name, "")
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _is_truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@pytest.fixture(scope="session")
+def live_provider() -> GoogleSheetsProvider:
+    if os.getenv("SLIDEFLOW_RUN_LIVE") != "1":
+        pytest.skip("SLIDEFLOW_RUN_LIVE != 1; skipping live Google Sheets tests.")
+
+    credentials = _require_first_env(
+        ["GOOGLE_SHEETS_CREDENTIALS", "GOOGLE_SLIDEFLOW_CREDENTIALS"],
+        "GOOGLE_SHEETS_CREDENTIALS/GOOGLE_SLIDEFLOW_CREDENTIALS is not set.",
+    )
+    workbook_folder_id = _require_first_env(
+        [
+            "SLIDEFLOW_LIVE_SHEETS_FOLDER_ID",
+            "SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID",
+            "SLIDEFLOW_LIVE_DOCUMENT_FOLDER_ID",
+        ],
+        "SLIDEFLOW_LIVE_SHEETS_FOLDER_ID is not set.",
+    )
+    drive_folder_id = os.getenv("SLIDEFLOW_LIVE_DRIVE_FOLDER_ID", workbook_folder_id)
+    requests_per_second = float(os.getenv("SLIDEFLOW_LIVE_RPS", "1.0"))
+
+    config = GoogleSheetsProviderConfig(
+        credentials=credentials,
+        drive_folder_id=drive_folder_id,
+        requests_per_second=requests_per_second,
+    )
+    return GoogleSheetsProvider(config)
+
+
+def _trash_files(provider: GoogleSheetsProvider, file_ids: Iterable[str]) -> None:
+    for file_id in file_ids:
+        if not file_id:
+            continue
+        try:
+            provider._execute_request(
+                provider.drive_service.files().update(
+                    fileId=file_id,
+                    body={"trashed": True},
+                    supportsAllDrives=True,
+                )
+            )
+        except Exception:
+            # Best-effort cleanup for live tests.
+            pass
+
+
+def _tab_result(result, tab_name: str):
+    for tab in result.tab_results:
+        if tab.tab_name == tab_name:
+            return tab
+    raise AssertionError(f"Expected tab result for '{tab_name}'")
+
+
+def _read_values(
+    provider: GoogleSheetsProvider, workbook_id: str, a1_range: str
+) -> List[List[Any]]:
+    response = provider._execute_request(
+        provider.sheets_service.spreadsheets()
+        .values()
+        .get(
+            spreadsheetId=workbook_id,
+            range=a1_range,
+        )
+    )
+    return response.get("values", []) if isinstance(response, dict) else []
+
+
+def _write_config(config_path: Path, payload: Dict[str, Any]) -> None:
+    config_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.live_google_sheets
+def test_live_google_sheets_replace_and_append_idempotent(
+    live_provider: GoogleSheetsProvider, tmp_path: Path
+):
+    created_file_ids: List[str] = []
+    share_with = _parse_optional_email_list("SLIDEFLOW_LIVE_SHARE_EMAIL")
+    keep_artifacts = _is_truthy(
+        os.getenv("SLIDEFLOW_LIVE_KEEP_ARTIFACTS", "1" if share_with else "0")
+    )
+    share_role = os.getenv("SLIDEFLOW_LIVE_SHARE_ROLE", "reader")
+
+    replace_data = tmp_path / "replace_data.csv"
+    replace_data.write_text("month,value\nJan,10\nFeb,20\n", encoding="utf-8")
+    append_data = tmp_path / "append_data.csv"
+    append_data.write_text("month,value\nMar,30\nApr,40\n", encoding="utf-8")
+
+    workbook_title = f"slideflow live sheets {uuid.uuid4().hex[:8]}"
+    run_key = "week_2026_09"
+
+    provider_config: Dict[str, Any] = {
+        "credentials": live_provider.config.credentials,
+        "drive_folder_id": live_provider.config.drive_folder_id,
+    }
+    if share_with:
+        provider_config["share_with"] = share_with
+        provider_config["share_role"] = share_role
+
+    config_payload: Dict[str, Any] = {
+        "provider": {
+            "type": "google_sheets",
+            "config": provider_config,
+        },
+        "workbook": {
+            "title": workbook_title,
+            "tabs": [
+                {
+                    "name": "kpi_current",
+                    "mode": "replace",
+                    "start_cell": "A1",
+                    "include_header": True,
+                    "data_source": {
+                        "type": "csv",
+                        "name": "replace_source",
+                        "file_path": str(replace_data),
+                    },
+                },
+                {
+                    "name": "kpi_history",
+                    "mode": "append",
+                    "start_cell": "A1",
+                    "include_header": False,
+                    "idempotency_key": run_key,
+                    "data_source": {
+                        "type": "csv",
+                        "name": "append_source",
+                        "file_path": str(append_data),
+                    },
+                },
+            ],
+        },
+    }
+
+    config_path = tmp_path / "live_google_sheets.yml"
+    _write_config(config_path, config_payload)
+    first_result = WorkbookBuilder.from_yaml(config_path).build()
+
+    workbook_id = first_result.workbook_id
+    created_file_ids.append(workbook_id)
+
+    assert first_result.status == "success"
+    assert first_result.tabs_total == 2
+    assert first_result.tabs_failed == 0
+    assert first_result.workbook_url.endswith(workbook_id)
+
+    first_append = _tab_result(first_result, "kpi_history")
+    assert first_append.status == "success"
+    assert first_append.rows_written == 2
+    assert first_append.rows_skipped == 0
+    assert first_append.run_key == run_key
+
+    # Second run targets the same workbook to verify append idempotency.
+    second_provider_config = dict(provider_config)
+    second_provider_config["spreadsheet_id"] = workbook_id
+    second_payload = dict(config_payload)
+    second_payload["provider"] = {
+        "type": "google_sheets",
+        "config": second_provider_config,
+    }
+    second_config_path = tmp_path / "live_google_sheets_rerun.yml"
+    _write_config(second_config_path, second_payload)
+    second_result = WorkbookBuilder.from_yaml(second_config_path).build()
+
+    assert second_result.status == "success"
+    second_append = _tab_result(second_result, "kpi_history")
+    assert second_append.rows_written == 0
+    assert second_append.rows_skipped == 2
+
+    current_values = _read_values(live_provider, workbook_id, "'kpi_current'!A1:B3")
+    assert current_values[0] == ["month", "value"]
+    assert ["Jan", "10"] in current_values
+    assert ["Feb", "20"] in current_values
+
+    history_values = _read_values(live_provider, workbook_id, "'kpi_history'!A1:B4")
+    assert ["Mar", "30"] in history_values
+    assert ["Apr", "40"] in history_values
+    assert len(history_values) == 2
+
+    metadata_values = _read_values(
+        live_provider,
+        workbook_id,
+        "'_slideflow_meta'!A1:D20",
+    )
+    assert metadata_values and metadata_values[0][:2] == ["tab_name", "run_key"]
+    matching_metadata = [
+        row
+        for row in metadata_values[1:]
+        if len(row) >= 2 and row[0] == "kpi_history" and row[1] == run_key
+    ]
+    assert len(matching_metadata) == 1
+
+    if share_with:
+        print(
+            "Shared rendered workbook with "
+            f"{', '.join(share_with)} ({share_role}): {first_result.workbook_url}"
+        )
+
+    if not keep_artifacts:
+        _trash_files(live_provider, created_file_ids)
+    else:
+        print(
+            "Retaining live test artifacts (set SLIDEFLOW_LIVE_KEEP_ARTIFACTS=0 "
+            "for auto-cleanup)."
+        )


### PR DESCRIPTION
## Summary
- add a new live Google Sheets end-to-end test: `tests/live_tests/test_live_google_sheets_workbooks.py`
- validate replace + append workbook behavior against real Google APIs
- validate append idempotency on rerun using `_slideflow_meta` run-key tracking
- add a manual workflow: `.github/workflows/live-google-sheets.yml`
- document the new live marker/workflow in `docs/testing.md`, `docs/ci-quality.md`, and `CONTRIBUTING.md`
- register new pytest marker: `live_google_sheets`

## Why
This closes the remaining operational validation gap for the sheets feature by providing a live E2E path similar to existing Slides/Docs live suites.

## Validation
- `./.venv/bin/python -m ruff check tests/live_tests/test_live_google_sheets_workbooks.py`
- `./.venv/bin/python -m pytest -q tests/live_tests -m live_google_sheets --collect-only`
- `./.venv/bin/python -m pytest -q tests/test_workbook_builder.py tests/test_workbook_config.py tests/test_cli_sheets_doctor.py tests/test_cli_sheets_build.py tests/test_cli_sheets_validate.py`
- `python` YAML parse check for `.github/workflows/live-google-sheets.yml`