### PR TITLE
fix: restore Google Slides citation rendering to speaker notes

### DIFF
--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -468,6 +468,8 @@ class GoogleSlidesProvider(PresentationProvider):
                 presentationId=presentation_id,
                 fields=(
                     "slides(objectId,"
+                    "slideProperties(notesPage(notesProperties(speakerNotesObjectId),"
+                    "pageElements(objectId,shape(text(textElements(endIndex))))),"
                     "notesPage(notesProperties(speakerNotesObjectId),"
                     "pageElements(objectId,shape(text(textElements(endIndex)))))"
                     ")"
@@ -480,7 +482,15 @@ class GoogleSlidesProvider(PresentationProvider):
             if not isinstance(slide, dict):
                 continue
             slide_id = slide.get("objectId")
-            notes_page = slide.get("notesPage", {})
+            slide_properties = slide.get("slideProperties", {})
+            if not isinstance(slide_properties, dict):
+                slide_properties = {}
+            notes_page = slide_properties.get("notesPage")
+            if not isinstance(notes_page, dict):
+                legacy_notes_page = slide.get("notesPage", {})
+                notes_page = (
+                    legacy_notes_page if isinstance(legacy_notes_page, dict) else {}
+                )
             if not isinstance(notes_page, dict) or not slide_id:
                 continue
 

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -503,3 +503,71 @@ def test_render_citations_document_end_uses_first_slide_notes():
     assert insert_request["objectId"] == "notes-a"
     assert "One" in insert_request["text"]
     assert "Two" in insert_request["text"]
+
+
+def test_get_speaker_notes_targets_reads_slide_properties_notes_page():
+    provider = _provider_without_init()
+    captured_get_kwargs: Dict[str, Any] = {}
+
+    provider.slides_service = SimpleNamespace(
+        presentations=lambda: SimpleNamespace(
+            get=lambda **kwargs: captured_get_kwargs.update(kwargs) or ("get", kwargs)
+        )
+    )
+    provider._execute_request = lambda _request: {
+        "slides": [
+            {
+                "objectId": "slide-1",
+                "slideProperties": {
+                    "notesPage": {
+                        "notesProperties": {"speakerNotesObjectId": "notes-1"},
+                        "pageElements": [
+                            {
+                                "objectId": "notes-1",
+                                "shape": {
+                                    "text": {
+                                        "textElements": [
+                                            {"endIndex": 4},
+                                            {"endIndex": 15},
+                                        ]
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                },
+            }
+        ]
+    }
+
+    targets = provider._get_speaker_notes_targets("pres-1")
+
+    assert targets == {"slide-1": ("notes-1", 14)}
+    assert "slideProperties(notesPage(" in captured_get_kwargs["fields"]
+
+
+def test_get_speaker_notes_targets_falls_back_to_legacy_top_level_notes_page():
+    provider = _provider_without_init()
+    provider.slides_service = SimpleNamespace(
+        presentations=lambda: SimpleNamespace(get=lambda **kwargs: ("get", kwargs))
+    )
+    provider._execute_request = lambda _request: {
+        "slides": [
+            {
+                "objectId": "slide-legacy",
+                "notesPage": {
+                    "notesProperties": {"speakerNotesObjectId": "notes-legacy"},
+                    "pageElements": [
+                        {
+                            "objectId": "notes-legacy",
+                            "shape": {"text": {"textElements": [{"endIndex": 6}]}},
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+    targets = provider._get_speaker_notes_targets("pres-legacy")
+
+    assert targets == {"slide-legacy": ("notes-legacy", 5)}


### PR DESCRIPTION
## Summary
- fix Google Slides speaker-notes target extraction to read from `slideProperties.notesPage`
- keep backward-compatible fallback to top-level `notesPage` payloads
- add regression tests for both modern and legacy response shapes

Closes #149

## Changes
- `GoogleSlidesProvider._get_speaker_notes_targets` now requests and reads:
  - `slides[].slideProperties.notesPage.notesProperties.speakerNotesObjectId`
  - `slides[].slideProperties.notesPage.pageElements`
- fallback remains in place for legacy/mocked payloads that expose `slides[].notesPage`

## Tests
- `./.venv/bin/python -m ruff check slideflow/presentations/providers/google_slides.py tests/test_google_slides_provider_coverage.py`
- `./.venv/bin/python -m pytest -q tests/test_google_slides_provider_coverage.py`
  - includes new tests:
    - `test_get_speaker_notes_targets_reads_slide_properties_notes_page`
    - `test_get_speaker_notes_targets_falls_back_to_legacy_top_level_notes_page`