### PR TITLE
fix(slides): resolve malformed FieldMask in citations notes lookup

### DIFF
--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -472,7 +472,7 @@ class GoogleSlidesProvider(PresentationProvider):
                     "pageElements(objectId,shape(text(textElements(endIndex))))),"
                     "notesPage(notesProperties(speakerNotesObjectId),"
                     "pageElements(objectId,shape(text(textElements(endIndex)))))"
-                    ")"
+                    "))"
                 ),
             )
         )

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -542,8 +542,10 @@ def test_get_speaker_notes_targets_reads_slide_properties_notes_page():
 
     targets = provider._get_speaker_notes_targets("pres-1")
 
+    fields_mask = captured_get_kwargs["fields"]
     assert targets == {"slide-1": ("notes-1", 14)}
-    assert "slideProperties(notesPage(" in captured_get_kwargs["fields"]
+    assert "slideProperties(notesPage(" in fields_mask
+    assert fields_mask.count("(") == fields_mask.count(")")
 
 
 def test_get_speaker_notes_targets_falls_back_to_legacy_top_level_notes_page():


### PR DESCRIPTION
## Summary
- fix malformed Google Slides `fields` selector in `_get_speaker_notes_targets`
- balance parentheses in the `presentations.get(..., fields=...)` FieldMask
- harden tests by asserting the generated FieldMask is balanced

Closes #154

## Details
The previous selector ended with one missing closing `)` and could produce API 400 errors (`Invalid FieldMask`).

Updated from:
- `..."pageElements(...)))" ")"`

To:
- `..."pageElements(...)))" "))"`

## Validation
- `./.venv/bin/python -m black slideflow/presentations/providers/google_slides.py tests/test_google_slides_provider_coverage.py`
- `./.venv/bin/python -m ruff check slideflow/presentations/providers/google_slides.py tests/test_google_slides_provider_coverage.py`
- `./.venv/bin/python -m pytest -q tests/test_google_slides_provider_coverage.py`