### PR TITLE
fix(sheets): normalize non-finite Decimal workbook cell values

### DIFF
--- a/slideflow/workbooks/builder.py
+++ b/slideflow/workbooks/builder.py
@@ -31,7 +31,10 @@ def _normalize_cell_value(value: Any) -> Any:
         return None
     if isinstance(value, Decimal):
         # Google Sheets API payloads must be JSON serializable scalars.
-        return float(value)
+        try:
+            value = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return str(value)
     if isinstance(value, float):
         if math.isnan(value) or math.isinf(value):
             return None

--- a/tests/test_workbook_builder.py
+++ b/tests/test_workbook_builder.py
@@ -147,6 +147,22 @@ def test_dataframe_to_sheet_rows_normalizes_decimal_values():
     assert rows[1] == ["WEUR", 123.45]
 
 
+def test_dataframe_to_sheet_rows_normalizes_non_finite_decimal_values():
+    df = pd.DataFrame(
+        {
+            "region": ["A", "B", "C"],
+            "gmv": [Decimal("NaN"), Decimal("Infinity"), Decimal("-Infinity")],
+        }
+    )
+
+    rows = dataframe_to_sheet_rows(df, include_header=True)
+
+    assert rows[0] == ["region", "gmv"]
+    assert rows[1] == ["A", None]
+    assert rows[2] == ["B", None]
+    assert rows[3] == ["C", None]
+
+
 def test_workbook_builder_build_success(tmp_path, monkeypatch):
     csv_path = tmp_path / "kpi.csv"
     csv_path.write_text("month,value\nJan,10\nFeb,20\n", encoding="utf-8")


### PR DESCRIPTION
Summary:\n- Normalize Decimal cell values through the existing float non-finite guard in workbook row conversion.\n- Map Decimal NaN and Decimal plus/minus Infinity to None to avoid non-standard JSON tokens in Sheets payloads.\n- Add a regression test covering non-finite Decimal values.\n\nWhy:\n- _normalize_cell_value previously returned early for Decimal, so non-finite values bypassed float normalization and could leak nan/inf downstream.\n\nValidation:\n- ./.venv/bin/python -m pytest -q tests/test_workbook_builder.py\n- ./.venv/bin/python -m ruff check slideflow/workbooks/builder.py tests/test_workbook_builder.py\n- ./.venv/bin/python -m mypy slideflow/workbooks/builder.py\n- ./.venv/bin/python -m pytest -q