### PR TITLE
ci(release): align release dependency install with locked CI resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Validate release branch
         id: branch
@@ -33,41 +37,46 @@ jobs:
           VERSION=$(python scripts/ci/validate_release_branch.py "${GITHUB_REF_NAME}")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Install project and release dependencies
+      - name: Install project and release dependencies (locked)
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,ai]" build
+          uv lock --check
+          uv sync --extra dev --extra ai --locked
+
+      - name: Validate dependency resolution
+        run: |
+          uv pip check
 
       - name: Check NumPy/Pandas binary compatibility
         run: |
-          python scripts/ci/check_numpy_binary_compatibility.py
+          uv run python scripts/ci/check_numpy_binary_compatibility.py
 
       - name: Validate version consistency
         run: |
-          python scripts/ci/check_version_consistency.py "${GITHUB_REF_NAME}"
+          uv run python scripts/ci/check_version_consistency.py "${GITHUB_REF_NAME}"
 
       - name: Check code formatting
         run: |
-          python -m black --check slideflow tests scripts
+          uv run python -m black --check slideflow tests scripts
 
       - name: Run lint checks
         run: |
-          python -m ruff check slideflow tests scripts
+          uv run python -m ruff check slideflow tests scripts
 
       - name: Run type checks
         run: |
-          python -m mypy slideflow
+          uv run python -m mypy slideflow
 
       - name: Run release test suite
         run: |
-          python -m pytest -q \
+          uv run python -m pytest -q \
             --cov=slideflow \
             --cov-report=term \
             --cov-fail-under=80
 
       - name: Build distribution artifacts
         run: |
-          python -m build
+          uv pip install build
+          uv run python -m build
 
       - name: Smoke test built wheel
         run: |


### PR DESCRIPTION
## Summary
- switch release workflow from editable pip install to locked uv resolution
- add `uv lock --check` + `uv sync --extra dev --extra ai --locked`
- run release quality gates through `uv run` for CI/release parity
- add `uv pip check` dependency validation in release workflow

## Why
This removes dependency drift between CI and release jobs and completes #161.

## Notes
- build artifact step now installs `build` via `uv pip install build` before `uv run python -m build`

Closes #161