### PR TITLE
docs(config): fix malformed dbt warehouse YAML fences

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -417,6 +417,7 @@ warehouse:
   project_id: "my-gcp-project"
   location: "US"
   credentials_path: "/path/to/service-account.json"
+```
 
 DuckDB variant example:
 
@@ -436,7 +437,6 @@ warehouse:
   file_search_path:
     - "/tmp/dbt_project"
     - "/tmp/data"
-```
 ```
 
 ### Legacy dbt on Databricks (`databricks_dbt`)


### PR DESCRIPTION
## Summary
- close the BigQuery dbt variant YAML code block in config reference
- remove the extra trailing markdown fence after DuckDB example
- keep example semantics unchanged while restoring valid markdown structure

## Validation
- `./.venv/bin/python -m mkdocs build --strict`

Closes #162