### PR TITLE
ci: add optional connector extras coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,43 @@ jobs:
           path: coverage.xml
           if-no-files-found: ignore
 
+  optional-connectors:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install optional connector dependencies (locked)
+        run: |
+          uv lock --check
+          uv sync --extra dev --extra ai --extra bigquery --extra duckdb --locked
+
+      - name: Validate dependency resolution
+        run: |
+          uv pip check
+
+      - name: Run optional connector tests
+        run: |
+          uv run python -m pytest -q \
+            tests/test_bigquery_connector.py \
+            tests/test_duckdb_connector.py
+
   build-dist:
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - test
+      - optional-connectors
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- add a dedicated `optional-connectors` CI job on Python 3.12
- enforce locked install for optional connector extras:
  - `uv sync --extra dev --extra ai --extra bigquery --extra duckdb --locked`
- add dependency validation with `uv pip check`
- run focused connector tests in that job:
  - `tests/test_bigquery_connector.py`
  - `tests/test_duckdb_connector.py`
- gate `build-dist` on both `test` and `optional-connectors`

## Validation
- `python - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml') ... PY`
- `./.venv/bin/python -m pytest -q tests/test_bigquery_connector.py tests/test_duckdb_connector.py`

Closes #163