### PR TITLE
feat(google): add restricted chart-image sharing mode and cleanup summary logging

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -61,6 +61,7 @@ Supported values:
 | `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
 | `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
 | `transfer_ownership_strict` | `bool` | no | If `true`, fail build when ownership transfer fails |
+| `chart_image_sharing_mode` | `str` | no | `public` (default) or `restricted` for uploaded chart-image ACL behavior |
 | `requests_per_second` | `float` | no | API rate limit override |
 | `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
 
@@ -82,6 +83,7 @@ For provider setup and operational behavior, see [Google Slides Provider](provid
 | `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
 | `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
 | `transfer_ownership_strict` | `bool` | no | If `true`, fail build when ownership transfer fails |
+| `chart_image_sharing_mode` | `str` | no | `public` (default) or `restricted` for uploaded chart-image ACL behavior |
 | `requests_per_second` | `float` | no | API rate limit override |
 | `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
 

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -58,6 +58,7 @@ provider:
     share_role: "reader"
     transfer_ownership_to: "owner@example.com"
     transfer_ownership_strict: false
+    chart_image_sharing_mode: "public" # public | restricted
     requests_per_second: 1.0
     strict_cleanup: false
 ```
@@ -71,6 +72,9 @@ Field behavior:
 - `share_with` / `share_role`: post-render sharing.
 - `transfer_ownership_to`: optional ownership handoff target after successful render/share.
 - `transfer_ownership_strict`: if `true`, ownership handoff failure fails the run.
+- `chart_image_sharing_mode`: uploaded chart-image ACL mode:
+  - `public` (default): grants `anyone:reader` before insertion.
+  - `restricted`: skips public ACL grant (tighter access; insertion compatibility depends on your Drive permissions model).
 - `requests_per_second`: API pacing control.
 - `strict_cleanup`: fail run if chart-image cleanup fails.
 
@@ -148,6 +152,7 @@ presentation:
 - Start with conservative concurrency/rate settings and tune gradually.
 - Keep markers stable after config wiring.
 - Validate with `--provider-contract-check` in CI for template safety.
+- Cleanup logs include deleted/failed chart-image totals and failed file IDs when applicable.
 
 Related references:
 

--- a/docs/providers/google-slides.md
+++ b/docs/providers/google-slides.md
@@ -49,6 +49,7 @@ provider:
     share_role: "reader"
     transfer_ownership_to: "owner@example.com"
     transfer_ownership_strict: false
+    chart_image_sharing_mode: "public" # public | restricted
     requests_per_second: 1.0
     strict_cleanup: false
 ```
@@ -65,6 +66,9 @@ Field behavior:
 - `share_with` + `share_role`: shares the rendered deck after generation.
 - `transfer_ownership_to`: optional ownership handoff target after successful render/share.
 - `transfer_ownership_strict`: if `true`, ownership handoff failure fails the run.
+- `chart_image_sharing_mode`: uploaded chart-image ACL mode:
+  - `public` (default): grants `anyone:reader` before insertion.
+  - `restricted`: skips public ACL grant (tighter access; insertion compatibility depends on your Drive permissions model).
 - `requests_per_second`: throttles API calls.
 - `strict_cleanup`: if `true`, cleanup failures (chart image trash) fail the render.
 
@@ -88,6 +92,7 @@ After render, SlideFlow attempts to trash those images.
 
 - Default behavior: cleanup issues are logged but do not fail the run.
 - With `strict_cleanup: true`: cleanup failure raises an error and fails the run.
+- Cleanup now emits a summary log with deleted/failed counts and failed file IDs when applicable.
 
 ## Citation Rendering
 

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -1021,6 +1021,23 @@ class Presentation(BaseModel):
                             f"Failed to delete chart image {file_id}: {cleanup_error}"
                         )
 
+                deleted_cleanup_count = len(uploaded_file_ids) - len(failed_cleanup_ids)
+                if failed_cleanup_ids:
+                    logger.warning(
+                        "Chart image cleanup completed with %d failure(s): deleted %d/%d. "
+                        "Failed IDs: %s",
+                        len(failed_cleanup_ids),
+                        deleted_cleanup_count,
+                        len(uploaded_file_ids),
+                        failed_cleanup_ids,
+                    )
+                else:
+                    logger.info(
+                        "Chart image cleanup completed: deleted %d/%d chart image(s).",
+                        deleted_cleanup_count,
+                        len(uploaded_file_ids),
+                    )
+
             if strict_cleanup and failed_cleanup_ids and original_error is None:
                 raise RenderingError(
                     f"Strict cleanup enabled and {len(failed_cleanup_ids)} chart image(s) "

--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -109,6 +109,13 @@ class GoogleDocsProviderConfig(PresentationProviderConfig):
         False,
         description="If true, fail rendering when chart image cleanup fails.",
     )
+    chart_image_sharing_mode: Literal["public", "restricted"] = Field(
+        "public",
+        description=(
+            "Chart image sharing mode. 'public' grants anyone:reader (default); "
+            "'restricted' skips public sharing for tighter access control."
+        ),
+    )
     transfer_ownership_to: Optional[str] = Field(
         None,
         description="Optional email address that should become the owner after rendering completes.",
@@ -901,14 +908,22 @@ class GoogleDocsProvider(PresentationProvider):
         )
 
         file_id = uploaded_file.get("id")
-        self._execute_request(
-            self.drive_service.permissions().create(
-                fileId=file_id,
-                body={"role": "reader", "type": "anyone"},
-                supportsAllDrives=True,
+        sharing_mode = getattr(self.config, "chart_image_sharing_mode", "public")
+        if sharing_mode == "public":
+            self._execute_request(
+                self.drive_service.permissions().create(
+                    fileId=file_id,
+                    body={"role": "reader", "type": "anyone"},
+                    supportsAllDrives=True,
+                )
             )
-        )
-        if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
-            time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
+            if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
+                time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
+        else:
+            logger.info(
+                "Chart image sharing mode is restricted; skipping public Drive permission "
+                "(file_id=%s).",
+                file_id,
+            )
         public_url = f"https://drive.google.com/uc?id={file_id}"
         return public_url, file_id

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -174,6 +174,13 @@ class GoogleSlidesProviderConfig(PresentationProviderConfig):
         False,
         description="If true, fail rendering when uploaded chart images cannot be cleaned up.",
     )
+    chart_image_sharing_mode: Literal["public", "restricted"] = Field(
+        "public",
+        description=(
+            "Chart image sharing mode. 'public' grants anyone:reader (default); "
+            "'restricted' skips public sharing for tighter access control."
+        ),
+    )
     transfer_ownership_to: Optional[str] = Field(
         None,
         description="Optional email address that should become the owner after rendering completes.",
@@ -893,17 +900,23 @@ class GoogleSlidesProvider(PresentationProvider):
 
             file_id = uploaded_file.get("id")
 
-            # Make public
-            self._execute_request(
-                self.drive_service.permissions().create(
-                    fileId=file_id,
-                    body={"role": "reader", "type": "anyone"},
-                    supportsAllDrives=True,
+            sharing_mode = getattr(self.config, "chart_image_sharing_mode", "public")
+            if sharing_mode == "public":
+                self._execute_request(
+                    self.drive_service.permissions().create(
+                        fileId=file_id,
+                        body={"role": "reader", "type": "anyone"},
+                        supportsAllDrives=True,
+                    )
                 )
-            )
-
-            if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
-                time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
+                if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
+                    time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
+            else:
+                logger.info(
+                    "Chart image sharing mode is restricted; skipping public Drive permission "
+                    "(file_id=%s).",
+                    file_id,
+                )
 
             public_url = f"https://drive.google.com/uc?id={file_id}"
             duration = time.time() - start_time

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -650,7 +650,11 @@ def test_finalize_presentation_runs_marker_cleanup_when_enabled(monkeypatch):
 
 def test_upload_share_and_delete_paths():
     provider = _provider_without_init()
-    provider.config = SimpleNamespace(drive_folder_id="folder-1", strict_cleanup=False)
+    provider.config = SimpleNamespace(
+        drive_folder_id="folder-1",
+        strict_cleanup=False,
+        chart_image_sharing_mode="public",
+    )
 
     provider.drive_service = SimpleNamespace(
         files=lambda: SimpleNamespace(
@@ -703,7 +707,11 @@ def test_upload_share_and_delete_paths():
 
 def test_upload_chart_image_waits_for_drive_acl_propagation(monkeypatch):
     provider = _provider_without_init()
-    provider.config = SimpleNamespace(drive_folder_id="folder-1", strict_cleanup=False)
+    provider.config = SimpleNamespace(
+        drive_folder_id="folder-1",
+        strict_cleanup=False,
+        chart_image_sharing_mode="public",
+    )
     provider.drive_service = SimpleNamespace(
         files=lambda: SimpleNamespace(create=lambda **kwargs: ("files-create", kwargs)),
         permissions=lambda: SimpleNamespace(
@@ -735,6 +743,47 @@ def test_upload_chart_image_waits_for_drive_acl_propagation(monkeypatch):
     assert url == "https://drive.google.com/uc?id=file-1"
     assert file_id == "file-1"
     assert sleep_calls == [1.5]
+
+
+def test_upload_chart_image_restricted_mode_skips_public_permission(monkeypatch):
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace(
+        drive_folder_id="folder-1",
+        strict_cleanup=False,
+        chart_image_sharing_mode="restricted",
+    )
+    provider.drive_service = SimpleNamespace(
+        files=lambda: SimpleNamespace(create=lambda **kwargs: ("files-create", kwargs)),
+        permissions=lambda: SimpleNamespace(
+            create=lambda **kwargs: ("perm-create", kwargs)
+        ),
+    )
+
+    calls: List[Any] = []
+
+    def _exec(request):
+        calls.append(request)
+        if request[0] == "files-create":
+            return {"id": "file-1"}
+        return {}
+
+    sleep_calls: List[float] = []
+    monkeypatch.setattr(
+        google_docs_module, "time", SimpleNamespace(sleep=sleep_calls.append)
+    )
+    monkeypatch.setattr(
+        google_docs_module.Timing,
+        "GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S",
+        1.5,
+    )
+
+    provider._execute_request = _exec
+
+    url, file_id = provider.upload_chart_image("doc-1", b"bytes", "chart.png")
+    assert url == "https://drive.google.com/uc?id=file-1"
+    assert file_id == "file-1"
+    assert [call for call in calls if call[0] == "perm-create"] == []
+    assert sleep_calls == []
 
 
 def test_delete_chart_image_raises_when_strict_cleanup_enabled():

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -375,7 +375,9 @@ def test_copy_template_success_and_error():
 
 def test_upload_image_to_drive_success_and_error(monkeypatch):
     provider = _provider_without_init()
-    provider.config = SimpleNamespace(drive_folder_id=None)
+    provider.config = SimpleNamespace(
+        drive_folder_id=None, chart_image_sharing_mode="public"
+    )
     provider._get_or_create_destination_folder = lambda: "folder-1"
 
     provider.drive_service = SimpleNamespace(
@@ -391,12 +393,17 @@ def test_upload_image_to_drive_success_and_error(monkeypatch):
     )
     monkeypatch.setattr(google_provider_module.time, "sleep", lambda _seconds: None)
 
-    provider._execute_request = lambda request: (
-        {"id": "file-123"} if request[0] == "files-create" else {}
-    )
+    calls: List[Any] = []
+
+    def _exec(request):
+        calls.append(request)
+        return {"id": "file-123"} if request[0] == "files-create" else {}
+
+    provider._execute_request = _exec
     public_url, file_id = provider._upload_image_to_drive(b"png-bytes", "chart.png")
     assert public_url == "https://drive.google.com/uc?id=file-123"
     assert file_id == "file-123"
+    assert len([call for call in calls if call[0] == "perm-create"]) == 1
     assert logs[-1][0][2] is True
 
     provider._execute_request = lambda _request: (_ for _ in ()).throw(
@@ -404,6 +411,41 @@ def test_upload_image_to_drive_success_and_error(monkeypatch):
     )
     with pytest.raises(google_provider_module.HttpError):
         provider._upload_image_to_drive(b"png-bytes", "chart.png")
+
+
+def test_upload_image_to_drive_restricted_mode_skips_public_permission(monkeypatch):
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace(
+        drive_folder_id=None, chart_image_sharing_mode="restricted"
+    )
+    provider._get_or_create_destination_folder = lambda: "folder-1"
+    provider.drive_service = SimpleNamespace(
+        files=lambda: SimpleNamespace(create=lambda **kwargs: ("files-create", kwargs)),
+        permissions=lambda: SimpleNamespace(
+            create=lambda **kwargs: ("perm-create", kwargs)
+        ),
+    )
+
+    sleep_calls: List[float] = []
+    monkeypatch.setattr(
+        google_provider_module.time,
+        "sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
+
+    calls: List[Any] = []
+
+    def _exec(request):
+        calls.append(request)
+        return {"id": "file-123"} if request[0] == "files-create" else {}
+
+    provider._execute_request = _exec
+
+    public_url, file_id = provider._upload_image_to_drive(b"png-bytes", "chart.png")
+    assert public_url == "https://drive.google.com/uc?id=file-123"
+    assert file_id == "file-123"
+    assert [call for call in calls if call[0] == "perm-create"] == []
+    assert sleep_calls == []
 
 
 def test_batch_update_error_logs_and_raises(monkeypatch):

--- a/tests/test_presentation_render.py
+++ b/tests/test_presentation_render.py
@@ -1,3 +1,5 @@
+import logging
+
 import pandas as pd
 import pytest
 
@@ -125,6 +127,29 @@ def test_render_raises_when_strict_cleanup_enabled_and_delete_fails():
 
     with pytest.raises(RenderingError, match="Strict cleanup enabled"):
         presentation.render()
+
+
+def test_render_logs_cleanup_summary_on_success(caplog):
+    provider = FakeProvider(strict_cleanup=False, fail_cleanup=False)
+    presentation, _chart = _build_presentation(provider)
+
+    with caplog.at_level(logging.INFO):
+        presentation.render()
+
+    assert "Chart image cleanup completed: deleted 1/1 chart image(s)." in caplog.text
+
+
+def test_render_logs_cleanup_summary_on_failure(caplog):
+    provider = FakeProvider(strict_cleanup=False, fail_cleanup=True)
+    presentation, _chart = _build_presentation(provider)
+
+    with caplog.at_level(logging.WARNING):
+        presentation.render()
+
+    assert (
+        "Chart image cleanup completed with 1 failure(s): deleted 0/1." in caplog.text
+    )
+    assert "Failed IDs: ['file-1']" in caplog.text
 
 
 def test_render_uses_provider_page_dimensions_for_relative_chart():


### PR DESCRIPTION
## Summary
- add `chart_image_sharing_mode` to Google Slides/Docs provider configs:
  - `public` (default): current behavior (`anyone:reader` ACL)
  - `restricted`: skip public ACL grant for uploaded chart images
- keep default behavior non-breaking for existing workflows
- add explicit cleanup summary logs in `Presentation.render()`:
  - success summary with deleted count
  - failure summary with deleted/failed counts and failed IDs
- update provider + config docs for sharing mode and cleanup reporting
- add tests for both providers covering restricted mode behavior and cleanup summary logging

## Why
Implements #165 by making secure chart-image sharing available via config while preserving compatibility defaults, and improves cleanup observability.

## Validation
- `./.venv/bin/python -m ruff check slideflow/presentations/base.py slideflow/presentations/providers/google_docs.py slideflow/presentations/providers/google_slides.py tests/test_google_docs_provider_coverage.py tests/test_google_slides_provider_coverage.py tests/test_presentation_render.py`
- `./.venv/bin/python -m pytest -q tests/test_google_docs_provider_coverage.py tests/test_google_slides_provider_coverage.py tests/test_presentation_render.py`
- `./.venv/bin/python -m mkdocs build --strict`

Closes #165