### PR TITLE
fix(citations): warn on invalid citation payloads without failing render

### DIFF
--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -664,9 +664,12 @@ class GoogleDocsProvider(PresentationProvider):
 
         lines = ["", "Sources"]
         for citation_payload in citations:
-            try:
-                entry = CitationEntry.model_validate(citation_payload)
-            except Exception:
+            entry = self._validate_citation_payload(
+                citation_payload,
+                scope_id="__document__",
+                location="document_end",
+            )
+            if entry is None:
                 continue
             lines.append(format_citation_line(entry))
         if len(lines) <= 2:
@@ -728,9 +731,12 @@ class GoogleDocsProvider(PresentationProvider):
 
         lines = ["Sources"]
         for citation_payload in citations:
-            try:
-                entry = CitationEntry.model_validate(citation_payload)
-            except Exception:
+            entry = self._validate_citation_payload(
+                citation_payload,
+                scope_id=section_id,
+                location="per_section",
+            )
+            if entry is None:
                 continue
             lines.append(format_citation_line(entry))
         if len(lines) <= 1:
@@ -782,6 +788,36 @@ class GoogleDocsProvider(PresentationProvider):
                 section_id,
                 citations,
             )
+
+    def _validate_citation_payload(
+        self,
+        citation_payload: Dict[str, Any],
+        *,
+        scope_id: str,
+        location: str,
+    ) -> Optional[CitationEntry]:
+        try:
+            return CitationEntry.model_validate(citation_payload)
+        except Exception as error:
+            source_id = (
+                citation_payload.get("source_id", "<missing>")
+                if isinstance(citation_payload, dict)
+                else "<missing>"
+            )
+            provider = (
+                citation_payload.get("provider", "<missing>")
+                if isinstance(citation_payload, dict)
+                else "<missing>"
+            )
+            logger.warning(
+                "Skipping invalid citation for scope '%s' (location=%s, source_id=%s, provider=%s): %s",
+                scope_id,
+                location,
+                source_id,
+                provider,
+                error,
+            )
+            return None
 
     def share_presentation(
         self, presentation_id: str, emails: List[str], role: str = "writer"

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -573,9 +573,12 @@ class GoogleSlidesProvider(PresentationProvider):
             object_id, insertion_index = target
             lines = ["", "Sources"]
             for citation_payload in citations:
-                try:
-                    entry = CitationEntry.model_validate(citation_payload)
-                except Exception:
+                entry = self._validate_citation_payload(
+                    citation_payload,
+                    scope_id=scope_id,
+                    location=location,
+                )
+                if entry is None:
                     continue
                 lines.append(format_citation_line(entry))
             if len(lines) <= 2:
@@ -593,6 +596,36 @@ class GoogleSlidesProvider(PresentationProvider):
 
         if requests:
             self._batch_update(presentation_id, requests)
+
+    def _validate_citation_payload(
+        self,
+        citation_payload: Dict[str, Any],
+        *,
+        scope_id: str,
+        location: str,
+    ) -> Optional[CitationEntry]:
+        try:
+            return CitationEntry.model_validate(citation_payload)
+        except Exception as error:
+            source_id = (
+                citation_payload.get("source_id", "<missing>")
+                if isinstance(citation_payload, dict)
+                else "<missing>"
+            )
+            provider = (
+                citation_payload.get("provider", "<missing>")
+                if isinstance(citation_payload, dict)
+                else "<missing>"
+            )
+            logger.warning(
+                "Skipping invalid citation for scope '%s' (location=%s, source_id=%s, provider=%s): %s",
+                scope_id,
+                location,
+                source_id,
+                provider,
+                error,
+            )
+            return None
 
     def share_presentation(
         self,

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -865,3 +865,45 @@ def test_render_citations_per_section_routes_to_footnotes(monkeypatch):
             [{"source_id": "src-2", "provider": "csv", "display_name": "Two"}],
         ),
     ]
+
+
+def test_render_document_end_citations_logs_warning_for_invalid_payload(monkeypatch):
+    provider = _provider_without_init()
+    provider._get_document_content = lambda _document_id: [{"endIndex": 6}]
+    provider.docs_service = SimpleNamespace(
+        documents=lambda: SimpleNamespace(
+            batchUpdate=lambda **kwargs: ("batch-update", kwargs)
+        )
+    )
+
+    calls: List[Any] = []
+    provider._execute_request = lambda request: calls.append(request) or {}
+
+    warnings: List[str] = []
+    monkeypatch.setattr(
+        google_docs_module.logger,
+        "warning",
+        lambda message, *args: warnings.append(message % args),
+    )
+
+    provider._render_document_end_citations(
+        "doc-3",
+        [
+            {"source_id": "src-invalid", "provider": "csv"},
+            {
+                "source_id": "src-valid",
+                "provider": "csv",
+                "display_name": "Valid Source",
+            },
+        ],
+    )
+
+    assert calls
+    request = calls[0][1]
+    inserted_text = request["body"]["requests"][0]["insertText"]["text"]
+    assert "Valid Source" in inserted_text
+    assert "src-invalid" not in inserted_text
+
+    assert warnings
+    assert "location=document_end" in warnings[0]
+    assert "src-invalid" in warnings[0]

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -551,6 +551,49 @@ def test_render_citations_document_end_uses_first_slide_notes():
     assert "Two" in insert_request["text"]
 
 
+def test_render_citations_logs_warning_for_invalid_payload_and_continues(monkeypatch):
+    provider = _provider_without_init()
+    provider._get_speaker_notes_targets = lambda _presentation_id: {
+        "slide-1": ("notes-1", 3)
+    }
+    captured_requests: List[Dict[str, Any]] = []
+    provider._batch_update = (
+        lambda _presentation_id, requests: captured_requests.extend(requests) or {}
+    )
+
+    warnings: List[str] = []
+    monkeypatch.setattr(
+        google_provider_module.logger,
+        "warning",
+        lambda message, *args: warnings.append(message % args),
+    )
+
+    provider.render_citations(
+        "pres-1",
+        {
+            "slide-1": [
+                {"source_id": "src-invalid", "provider": "csv"},
+                {
+                    "source_id": "src-valid",
+                    "provider": "csv",
+                    "display_name": "Valid Source",
+                },
+            ]
+        },
+        location="per_slide",
+    )
+
+    assert len(captured_requests) == 1
+    rendered_text = captured_requests[0]["insertText"]["text"]
+    assert "Valid Source" in rendered_text
+    assert "src-invalid" not in rendered_text
+
+    assert warnings
+    assert "slide-1" in warnings[0]
+    assert "src-invalid" in warnings[0]
+    assert "location=per_slide" in warnings[0]
+
+
 def test_get_speaker_notes_targets_reads_slide_properties_notes_page():
     provider = _provider_without_init()
     captured_get_kwargs: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- replace silent citation validation drops with warning logs in Google Slides and Google Docs providers
- include actionable context in each warning (`scope`, `location`, `source_id`, `provider`)
- keep render resilient by skipping malformed citation payloads and continuing with valid entries
- add provider coverage tests for malformed citation payload behavior and warning emission

## Why
Implements #166 from the roadmap epic (#159): citation validation failures should be observable without turning malformed entries into full render failures.

## Validation
- `./.venv/bin/python -m ruff check slideflow/presentations/providers/google_slides.py slideflow/presentations/providers/google_docs.py tests/test_google_slides_provider_coverage.py tests/test_google_docs_provider_coverage.py`
- `./.venv/bin/python -m black --check slideflow/presentations/providers/google_slides.py slideflow/presentations/providers/google_docs.py tests/test_google_slides_provider_coverage.py tests/test_google_docs_provider_coverage.py`
- `./.venv/bin/python -m pytest -q tests/test_google_slides_provider_coverage.py tests/test_google_docs_provider_coverage.py`

Closes #166