### PR TITLE
refactor: remove charts->google_slides rate-limiter coupling

### DIFF
--- a/slideflow/presentations/charts.py
+++ b/slideflow/presentations/charts.py
@@ -71,7 +71,9 @@ from slideflow.builtins.template_engine import get_template_engine
 from slideflow.constants import FileExtensions, GoogleSlides, Timing
 from slideflow.data.connectors.base import BaseSourceConfig as DataSourceConfig
 from slideflow.presentations.positioning import safe_eval_expression
-from slideflow.presentations.providers.google_slides import _get_rate_limiter
+from slideflow.presentations.rate_limiter import (
+    get_google_api_rate_limiter as _get_rate_limiter,
+)
 from slideflow.utilities.data_transforms import apply_data_transforms
 from slideflow.utilities.exceptions import ChartGenerationError
 

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -89,6 +89,7 @@ from slideflow.presentations.providers.google_drive_ownership import (
     normalize_transfer_owner_email,
     transfer_drive_file_ownership,
 )
+from slideflow.presentations.rate_limiter import get_google_api_rate_limiter
 from slideflow.utilities.auth import handle_google_credentials
 from slideflow.utilities.exceptions import AuthenticationError
 from slideflow.utilities.logging import get_logger, log_api_operation
@@ -97,19 +98,11 @@ from slideflow.utilities.rate_limiter import RateLimiter
 logger = get_logger(__name__)
 _folder_creation_lock = threading.Lock()
 _folder_id_cache: Dict[Tuple[str, str], str] = {}
-_api_rate_limiter: Optional[RateLimiter] = None
-_rate_limiter_lock = threading.Lock()
 
 
 def _get_rate_limiter(rps: float, force_update: bool = False) -> RateLimiter:
     """Get or create the global rate limiter."""
-    global _api_rate_limiter
-    with _rate_limiter_lock:
-        if _api_rate_limiter is None:
-            _api_rate_limiter = RateLimiter(rps)
-        elif force_update:
-            _api_rate_limiter.set_rate(rps)
-        return _api_rate_limiter
+    return get_google_api_rate_limiter(rps, force_update=force_update)
 
 
 class GoogleSlidesProviderConfig(PresentationProviderConfig):

--- a/slideflow/presentations/rate_limiter.py
+++ b/slideflow/presentations/rate_limiter.py
@@ -1,0 +1,31 @@
+"""Shared presentation-layer rate limiter helpers.
+
+This module hosts provider-agnostic rate limiter singletons used across
+presentation runtime components to avoid cross-layer imports.
+"""
+
+import threading
+from typing import Optional
+
+from slideflow.utilities.rate_limiter import RateLimiter
+
+_google_api_rate_limiter: Optional[RateLimiter] = None
+_google_api_rate_limiter_lock = threading.Lock()
+
+
+def get_google_api_rate_limiter(rps: float, force_update: bool = False) -> RateLimiter:
+    """Get or create the shared Google API rate limiter."""
+    global _google_api_rate_limiter
+    with _google_api_rate_limiter_lock:
+        if _google_api_rate_limiter is None:
+            _google_api_rate_limiter = RateLimiter(rps)
+        elif force_update:
+            _google_api_rate_limiter.set_rate(rps)
+        return _google_api_rate_limiter
+
+
+def reset_google_api_rate_limiter() -> None:
+    """Reset shared Google API limiter for deterministic tests."""
+    global _google_api_rate_limiter
+    with _google_api_rate_limiter_lock:
+        _google_api_rate_limiter = None

--- a/tests/test_connectors_and_providers_unit.py
+++ b/tests/test_connectors_and_providers_unit.py
@@ -11,6 +11,7 @@ import slideflow.data.connectors.base as base_connectors_module
 import slideflow.data.connectors.databricks as databricks_module
 import slideflow.presentations.providers.factory as provider_factory_module
 import slideflow.presentations.providers.google_slides as google_provider_module
+import slideflow.presentations.rate_limiter as presentation_rate_limiter_module
 from slideflow.constants import Defaults
 from slideflow.presentations.config import ProviderConfig
 from slideflow.presentations.providers.base import (
@@ -597,8 +598,8 @@ def test_google_provider_upload_image_uses_configured_propagation_delay(monkeypa
     assert len(executed) == 2
 
 
-def test_google_rate_limiter_singleton_update(monkeypatch):
-    monkeypatch.setattr(google_provider_module, "_api_rate_limiter", None)
+def test_google_rate_limiter_singleton_update():
+    presentation_rate_limiter_module.reset_google_api_rate_limiter()
     rl1 = google_provider_module._get_rate_limiter(1.0)
     rl2 = google_provider_module._get_rate_limiter(5.0)
     rl3 = google_provider_module._get_rate_limiter(5.0, force_update=True)

--- a/tests/test_runtime_utilities.py
+++ b/tests/test_runtime_utilities.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 import slideflow.data.cache as data_cache_module
+import slideflow.presentations.rate_limiter as presentation_rate_limiter_module
 import slideflow.utilities.rate_limiter as rate_limiter_module
 from slideflow.constants import Environment
 from slideflow.data.cache import DataSourceCache, get_data_cache
@@ -358,3 +359,16 @@ def test_rate_limiter_wait_sleeps_only_when_needed(monkeypatch):
     limiter.wait()  # no sleep
 
     assert sleep_calls == [0.5, 0.4]
+
+
+def test_google_api_rate_limiter_shared_singleton_update():
+    presentation_rate_limiter_module.reset_google_api_rate_limiter()
+
+    rl1 = presentation_rate_limiter_module.get_google_api_rate_limiter(1.0)
+    rl2 = presentation_rate_limiter_module.get_google_api_rate_limiter(3.0)
+    rl3 = presentation_rate_limiter_module.get_google_api_rate_limiter(
+        3.0, force_update=True
+    )
+
+    assert rl1 is rl2 is rl3
+    assert rl3.rate == 3.0


### PR DESCRIPTION
Summary\n- adds a neutral presentation-layer rate limiter helper in slideflow/presentations/rate_limiter.py\n- updates charts.py to use the neutral helper instead of importing from google_slides\n- keeps google_slides._get_rate_limiter() as a compatibility wrapper over the shared helper\n- updates tests to assert shared singleton behavior through the neutral helper\n\nWhy\nImplements #168 by removing cross-layer coupling from chart runtime to a specific provider module while preserving existing rate-limit behavior and defaults.\n\nValidation\n- uv run ruff check on changed files\n- uv run black --check on changed files\n- targeted pytest for google rate limiter singleton\n- targeted pytest for runtime rate limiter behavior\n- targeted pytest for charts upload path\n\nCloses #168