### PR TITLE
refactor: extract shared Google provider internals

### DIFF
--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -7,7 +7,6 @@ those marker-defined sections.
 
 from __future__ import annotations
 
-import io
 import os
 import re
 import threading
@@ -19,7 +18,6 @@ from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from googleapiclient.http import MediaIoBaseUpload
 from pydantic import Field, field_validator
 
 from slideflow.citations import CitationEntry, format_citation_line
@@ -35,7 +33,12 @@ from slideflow.presentations.providers.google_drive_ownership import (
     transfer_drive_file_ownership,
 )
 from slideflow.utilities.auth import handle_google_credentials
-from slideflow.utilities.exceptions import AuthenticationError, RenderingError
+from slideflow.utilities.exceptions import RenderingError
+from slideflow.utilities.google_api import (
+    build_service_account_credentials,
+    execute_rate_limited_request,
+    upload_png_to_drive,
+)
 from slideflow.utilities.logging import get_logger
 from slideflow.utilities.rate_limiter import RateLimiter
 
@@ -170,14 +173,9 @@ class GoogleDocsProvider(PresentationProvider):
             ],
         )
 
-        try:
-            credentials = Credentials.from_service_account_info(
-                loaded_credentials, scopes=self.SCOPES
-            )
-        except Exception as error_msg:  # pragma: no cover - exercised via tests
-            raise AuthenticationError(
-                f"Credentials authentication failed: {error_msg}"
-            ) from error_msg
+        credentials = build_service_account_credentials(
+            loaded_credentials, self.SCOPES, credentials_cls=Credentials
+        )
 
         self.docs_service = build("docs", "v1", credentials=credentials)
         self.drive_service = build("drive", "v3", credentials=credentials)
@@ -185,8 +183,7 @@ class GoogleDocsProvider(PresentationProvider):
 
     def _execute_request(self, request):
         """Execute Google API request with shared rate limiting."""
-        self.rate_limiter.wait()
-        return request.execute(num_retries=3)
+        return execute_rate_limited_request(request, self.rate_limiter, num_retries=3)
 
     def run_preflight_checks(self) -> List[Tuple[str, bool, str]]:
         has_credentials = bool(self.config.credentials) or bool(
@@ -929,37 +926,22 @@ class GoogleDocsProvider(PresentationProvider):
     def _upload_image_to_drive(
         self, image_bytes: bytes, filename: str
     ) -> Tuple[str, str]:
-        file_metadata: Dict[str, Any] = {"name": filename}
-        if self.config.drive_folder_id:
-            file_metadata["parents"] = [self.config.drive_folder_id]
-
-        media = MediaIoBaseUpload(io.BytesIO(image_bytes), mimetype="image/png")
-        uploaded_file = self._execute_request(
-            self.drive_service.files().create(
-                body=file_metadata,
-                media_body=media,
-                fields="id",
-                supportsAllDrives=True,
-            )
-        )
-
-        file_id = uploaded_file.get("id")
         sharing_mode = getattr(self.config, "chart_image_sharing_mode", "public")
-        if sharing_mode == "public":
-            self._execute_request(
-                self.drive_service.permissions().create(
-                    fileId=file_id,
-                    body={"role": "reader", "type": "anyone"},
-                    supportsAllDrives=True,
+        return upload_png_to_drive(
+            drive_service=self.drive_service,
+            execute_request=self._execute_request,
+            image_bytes=image_bytes,
+            filename=filename,
+            destination_folder_id=self.config.drive_folder_id,
+            sharing_mode=sharing_mode,
+            permission_delay_seconds=Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S,
+            resumable=False,
+            sleep_fn=time.sleep,
+            on_restricted_file=(
+                lambda resolved_file_id: logger.info(
+                    "Chart image sharing mode is restricted; skipping public Drive permission "
+                    "(file_id=%s).",
+                    resolved_file_id,
                 )
-            )
-            if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
-                time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
-        else:
-            logger.info(
-                "Chart image sharing mode is restricted; skipping public Drive permission "
-                "(file_id=%s).",
-                file_id,
-            )
-        public_url = f"https://drive.google.com/uc?id={file_id}"
-        return public_url, file_id
+            ),
+        )

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -65,7 +65,6 @@ Example:
     >>> print(f"View presentation: {url}")
 """
 
-import io
 import os
 import threading
 import time
@@ -74,7 +73,6 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from googleapiclient.http import MediaIoBaseUpload
 from pydantic import Field, field_validator
 
 from slideflow.citations import CitationEntry, format_citation_line
@@ -91,7 +89,11 @@ from slideflow.presentations.providers.google_drive_ownership import (
 )
 from slideflow.presentations.rate_limiter import get_google_api_rate_limiter
 from slideflow.utilities.auth import handle_google_credentials
-from slideflow.utilities.exceptions import AuthenticationError
+from slideflow.utilities.google_api import (
+    build_service_account_credentials,
+    execute_rate_limited_request,
+    upload_png_to_drive,
+)
 from slideflow.utilities.logging import get_logger, log_api_operation
 from slideflow.utilities.rate_limiter import RateLimiter
 
@@ -259,14 +261,9 @@ class GoogleSlidesProvider(PresentationProvider):
         # Initialize Google API services
         loaded_credentials = handle_google_credentials(config.credentials)
 
-        try:
-            credentials = Credentials.from_service_account_info(
-                loaded_credentials, scopes=self.SCOPES
-            )
-        except Exception as error_msg:
-            raise AuthenticationError(
-                f"Credentials authentication failed: {error_msg}"
-            ) from error_msg
+        credentials = build_service_account_credentials(
+            loaded_credentials, self.SCOPES, credentials_cls=Credentials
+        )
 
         self.slides_service = build("slides", "v1", credentials=credentials)
         self.drive_service = build("drive", "v3", credentials=credentials)
@@ -275,8 +272,7 @@ class GoogleSlidesProvider(PresentationProvider):
 
     def _execute_request(self, request):
         """Execute a Google API request with rate limiting."""
-        self.rate_limiter.wait()
-        return request.execute(num_retries=3)
+        return execute_rate_limited_request(request, self.rate_limiter, num_retries=3)
 
     @staticmethod
     def _dimension_to_points(dimension: Optional[Dict[str, Any]]) -> Optional[int]:
@@ -907,44 +903,25 @@ class GoogleSlidesProvider(PresentationProvider):
                 self.config.drive_folder_id or self._get_or_create_destination_folder()
             )
 
-            file_metadata: Dict[str, Any] = {"name": filename}
-            if destination_folder_id:
-                file_metadata["parents"] = [destination_folder_id]
-
-            media = MediaIoBaseUpload(
-                io.BytesIO(image_bytes), mimetype="image/png", resumable=True
-            )
-
-            uploaded_file = self._execute_request(
-                self.drive_service.files().create(
-                    body=file_metadata,
-                    media_body=media,
-                    fields="id",
-                    supportsAllDrives=True,
-                )
-            )
-
-            file_id = uploaded_file.get("id")
-
             sharing_mode = getattr(self.config, "chart_image_sharing_mode", "public")
-            if sharing_mode == "public":
-                self._execute_request(
-                    self.drive_service.permissions().create(
-                        fileId=file_id,
-                        body={"role": "reader", "type": "anyone"},
-                        supportsAllDrives=True,
+            public_url, file_id = upload_png_to_drive(
+                drive_service=self.drive_service,
+                execute_request=self._execute_request,
+                image_bytes=image_bytes,
+                filename=filename,
+                destination_folder_id=destination_folder_id,
+                sharing_mode=sharing_mode,
+                permission_delay_seconds=Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S,
+                resumable=True,
+                sleep_fn=time.sleep,
+                on_restricted_file=(
+                    lambda resolved_file_id: logger.info(
+                        "Chart image sharing mode is restricted; skipping public Drive permission "
+                        "(file_id=%s).",
+                        resolved_file_id,
                     )
-                )
-                if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
-                    time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
-            else:
-                logger.info(
-                    "Chart image sharing mode is restricted; skipping public Drive permission "
-                    "(file_id=%s).",
-                    file_id,
-                )
-
-            public_url = f"https://drive.google.com/uc?id={file_id}"
+                ),
+            )
             duration = time.time() - start_time
             log_api_operation(
                 "google_drive",

--- a/slideflow/utilities/google_api.py
+++ b/slideflow/utilities/google_api.py
@@ -1,0 +1,87 @@
+"""Shared Google API utility helpers for providers."""
+
+from __future__ import annotations
+
+import io
+import time
+from typing import Any, Callable, Dict, Optional, Tuple, Type
+
+from google.oauth2.service_account import Credentials
+from googleapiclient.http import MediaIoBaseUpload
+
+from slideflow.utilities.exceptions import AuthenticationError
+from slideflow.utilities.rate_limiter import RateLimiter
+
+
+def build_service_account_credentials(
+    loaded_credentials: Dict[str, Any],
+    scopes: list[str],
+    credentials_cls: Type[Credentials] = Credentials,
+) -> Credentials:
+    """Construct Google service-account credentials with consistent errors."""
+    try:
+        return credentials_cls.from_service_account_info(
+            loaded_credentials, scopes=scopes
+        )
+    except Exception as error_msg:
+        raise AuthenticationError(
+            f"Credentials authentication failed: {error_msg}"
+        ) from error_msg
+
+
+def execute_rate_limited_request(
+    request: Any, rate_limiter: RateLimiter, num_retries: int = 3
+) -> Any:
+    """Execute a Google API request through a shared rate-limited wrapper."""
+    rate_limiter.wait()
+    return request.execute(num_retries=num_retries)
+
+
+def upload_png_to_drive(
+    *,
+    drive_service: Any,
+    execute_request: Callable[[Any], Any],
+    image_bytes: bytes,
+    filename: str,
+    destination_folder_id: Optional[str],
+    sharing_mode: str,
+    permission_delay_seconds: float,
+    resumable: bool,
+    on_restricted_file: Optional[Callable[[str], None]] = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> Tuple[str, str]:
+    """Upload PNG bytes to Drive and return (public_url, file_id)."""
+    file_metadata: Dict[str, Any] = {"name": filename}
+    if destination_folder_id:
+        file_metadata["parents"] = [destination_folder_id]
+
+    media = MediaIoBaseUpload(
+        io.BytesIO(image_bytes),
+        mimetype="image/png",
+        resumable=resumable,
+    )
+
+    uploaded_file = execute_request(
+        drive_service.files().create(
+            body=file_metadata,
+            media_body=media,
+            fields="id",
+            supportsAllDrives=True,
+        )
+    )
+    file_id = uploaded_file.get("id")
+
+    if sharing_mode == "public":
+        execute_request(
+            drive_service.permissions().create(
+                fileId=file_id,
+                body={"role": "reader", "type": "anyone"},
+                supportsAllDrives=True,
+            )
+        )
+        if permission_delay_seconds > 0:
+            sleep_fn(permission_delay_seconds)
+    elif on_restricted_file is not None:
+        on_restricted_file(file_id)
+
+    return f"https://drive.google.com/uc?id={file_id}", file_id

--- a/slideflow/workbooks/providers/google_sheets.py
+++ b/slideflow/workbooks/providers/google_sheets.py
@@ -14,7 +14,11 @@ from pydantic import Field
 
 from slideflow.constants import Environment, GoogleSlides
 from slideflow.utilities.auth import handle_google_credentials
-from slideflow.utilities.exceptions import AuthenticationError, RenderingError
+from slideflow.utilities.exceptions import RenderingError
+from slideflow.utilities.google_api import (
+    build_service_account_credentials,
+    execute_rate_limited_request,
+)
 from slideflow.utilities.logging import get_logger
 from slideflow.utilities.rate_limiter import RateLimiter
 from slideflow.workbooks.config import RESERVED_METADATA_TAB
@@ -88,14 +92,9 @@ class GoogleSheetsProvider(WorkbookProvider):
             ],
         )
 
-        try:
-            credentials = Credentials.from_service_account_info(
-                loaded_credentials, scopes=self.SCOPES
-            )
-        except Exception as error_msg:  # pragma: no cover - exercised via tests
-            raise AuthenticationError(
-                f"Credentials authentication failed: {error_msg}"
-            ) from error_msg
+        credentials = build_service_account_credentials(
+            loaded_credentials, self.SCOPES, credentials_cls=Credentials
+        )
 
         self.sheets_service = build("sheets", "v4", credentials=credentials)
         self.drive_service = build("drive", "v3", credentials=credentials)
@@ -104,8 +103,7 @@ class GoogleSheetsProvider(WorkbookProvider):
 
     def _execute_request(self, request):
         """Execute Google API request with shared rate limiting."""
-        self.rate_limiter.wait()
-        return request.execute(num_retries=3)
+        return execute_rate_limited_request(request, self.rate_limiter, num_retries=3)
 
     def run_preflight_checks(self) -> List[Tuple[str, bool, str]]:
         has_credentials = bool(self.config.credentials) or bool(


### PR DESCRIPTION
Summary\n- adds shared Google API utility module at slideflow/utilities/google_api.py\n- centralizes service-account credential construction with consistent AuthenticationError chaining\n- centralizes rate-limited request execution wrapper used by Google Slides/Docs/Sheets providers\n- centralizes shared Drive PNG upload + optional public permission grant primitive\n- rewires google_slides, google_docs, and google_sheets providers to use the shared utilities while preserving provider interfaces and behavior\n\nWhy\nImplements #169 by reducing duplicated provider internals (auth/request/upload paths) without changing public provider APIs.\n\nValidation\n- uv run ruff check on changed files\n- uv run black --check on changed files\n- uv run pytest tests/test_google_slides_provider_coverage.py\n- uv run pytest tests/test_google_docs_provider_coverage.py\n- uv run pytest tests/test_google_sheets_workbook_provider.py\n- uv run pytest tests/test_connectors_and_providers_unit.py -k google_provider_execute_request_and_batch_update or google_provider_upload_image_uses_configured_propagation_delay\n\nCloses #169