### PR TITLE
feat(sheets): add runtime throughput controls to sheets build + reusable workflow

### DIFF
--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -83,12 +83,12 @@ on:
         default: false
         type: boolean
       threads:
-        description: "Optional --threads value"
+        description: "Optional --threads value (presentations + sheets; sheets currently applies 1)"
         required: false
         default: ""
         type: string
       requests-per-second:
-        description: "Optional --rps value"
+        description: "Optional --rps value (presentations + sheets)"
         required: false
         default: ""
         type: string
@@ -328,10 +328,10 @@ jobs:
           if [[ "$artifact_kind" == "presentation" && "${{ inputs.dry-run }}" == "true" ]]; then
             build_cmd+=("--dry-run")
           fi
-          if [[ "$artifact_kind" == "presentation" && -n "${{ inputs.threads }}" ]]; then
+          if [[ -n "${{ inputs.threads }}" ]]; then
             build_cmd+=("--threads" "${{ inputs.threads }}")
           fi
-          if [[ "$artifact_kind" == "presentation" && -n "${{ inputs.requests-per-second }}" ]]; then
+          if [[ -n "${{ inputs.requests-per-second }}" ]]; then
             build_cmd+=("--rps" "${{ inputs.requests-per-second }}")
           fi
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -72,8 +72,10 @@ jobs:
 - `run-provider-contract-check` (optional): Add `--provider-contract-check` to validate for `presentation` builds (`google_slides` and `google_docs`). Ignored for `sheets`. Default `false`.
 - `provider-contract-params-path` (optional): CSV path for validate contract checks; falls back to `params-path` when unset.
 - `dry-run` (optional): Run build with `--dry-run`. Default `false`.
-- `threads` (optional): Value passed to `--threads`.
-- `requests-per-second` (optional): Value passed to `--rps`.
+- `threads` (optional): Value passed to `--threads` for both `presentation`
+  and `sheets` builds. Sheets currently normalizes this to `1`.
+- `requests-per-second` (optional): Value passed to `--rps` for both
+  `presentation` and `sheets` builds.
 - `upload-log-artifact` (optional): Upload logs and discovered URLs. Default `true`.
 - `artifact-name` (optional): Artifact name. Default `slideflow-build-logs`.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -179,14 +179,25 @@ Options:
 | Option | Description |
 | --- | --- |
 | `-r`, `--registry` | One or more Python registry files |
+| `-t`, `--threads` | Workbook worker count (Sheets currently applies `1`) |
+| `--rps`, `--requests-per-second` | Override provider `requests_per_second` for this run |
 | `--output-json` | Write machine-readable build summary JSON |
 
 Examples:
 
 ```bash
 slideflow sheets build workbook.yml
+slideflow sheets build workbook.yml --rps 1.5
+slideflow sheets build workbook.yml --threads 4 --output-json sheets-build.json
 slideflow sheets build workbook.yml --registry registry.py --output-json sheets-build.json
 ```
+
+Notes:
+
+- Sheets builds currently execute sequentially; `--threads` is accepted for
+  workflow parity and normalized to `1`.
+- Build JSON includes a `runtime` block with requested/applied `threads` and
+  `requests_per_second`.
 
 Workbook schema details (tabs, append idempotency, and tab-local AI summaries):
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -71,6 +71,13 @@ jobs:
       requests-per-second: "1.0"
 ```
 
+Runtime control note:
+
+- The reusable workflow forwards `threads` and `requests-per-second` to both
+  `slideflow build` and `slideflow sheets build`.
+- Sheets currently runs sequentially; `threads` is normalized to `1` and
+  reported as requested/applied values in build JSON.
+
 Security notes:
 
 - Prefer pinning reusable workflow refs to a commit SHA.
@@ -224,6 +231,7 @@ Operational notes:
   - `google_slides`: slide-id + placeholder checks
   - `google_docs`: section-marker + placeholder checks
 - Secrets managed by platform secret manager (not committed)
-- API quotas/rate limits measured and tuned (`--rps`, `--threads`)
+- API quotas/rate limits measured and tuned (`--rps`, `--threads`; Sheets
+  currently applies `threads=1`)
 - Failure notifications wired to orchestration platform
 - Build logs and JSON summaries retained for debugging/notifications

--- a/docs/providers/google-sheets.md
+++ b/docs/providers/google-sheets.md
@@ -39,6 +39,7 @@ Field behavior:
 - `drive_folder_id`: destination folder for newly created spreadsheets.
 - `share_with` / `share_role`: optional post-build sharing.
 - `requests_per_second`: Google API pacing for this build.
+  - Can be overridden at runtime via `slideflow sheets build --rps ...`.
 
 ## Workbook Schema
 
@@ -161,8 +162,12 @@ workbook:
 ```bash
 slideflow sheets validate workbook.yml --output-json sheets-validate.json
 slideflow sheets doctor workbook.yml --strict --output-json sheets-doctor.json
-slideflow sheets build workbook.yml --output-json sheets-build.json
+slideflow sheets build workbook.yml --rps 1.2 --output-json sheets-build.json
+slideflow sheets build workbook.yml --threads 3 --output-json sheets-build.json
 ```
+
+`--threads` is accepted for reusable-workflow parity and currently normalizes to
+`1` (sequential workbook execution).
 
 Build JSON includes:
 

--- a/slideflow/cli/commands/sheets.py
+++ b/slideflow/cli/commands/sheets.py
@@ -74,6 +74,46 @@ def _workbook_summary_payload(workbook_config: WorkbookConfig) -> Dict[str, Any]
     }
 
 
+def _runtime_controls_payload(
+    workbook_config: WorkbookConfig,
+    threads: Optional[int],
+    requests_per_second: Optional[float],
+) -> tuple[Dict[str, Any], List[str]]:
+    """Apply CLI runtime overrides and return machine-readable runtime metadata."""
+    warnings: List[str] = []
+    provider_config = workbook_config.provider.config
+
+    requested_threads = threads
+    applied_threads = 1
+    if requested_threads is not None and requested_threads != 1:
+        warnings.append(
+            "Sheets builds currently run sequentially; --threads was normalized "
+            "to 1."
+        )
+
+    requested_rps = requests_per_second
+    if requested_rps is not None:
+        provider_config["requests_per_second"] = requested_rps
+        rps_source = "cli_override"
+    else:
+        rps_source = "provider_config"
+
+    applied_rps = provider_config.get("requests_per_second", 1.0)
+    runtime_payload = {
+        "threads": {
+            "requested": requested_threads,
+            "applied": applied_threads,
+            "supported_values": [1],
+        },
+        "requests_per_second": {
+            "requested": requested_rps,
+            "applied": applied_rps,
+            "source": rps_source,
+        },
+    }
+    return runtime_payload, warnings
+
+
 def sheets_validate_command(
     config_file: Annotated[
         Path, typer.Argument(help="Path to workbook YAML configuration file")
@@ -153,6 +193,24 @@ def sheets_build_command(
             help="Path to Python registry files (can be used multiple times)",
         ),
     ] = None,
+    threads: Annotated[
+        Optional[int],
+        typer.Option(
+            "--threads",
+            "-t",
+            min=1,
+            help="Workbook worker count (Sheets currently supports only 1).",
+        ),
+    ] = None,
+    requests_per_second: Annotated[
+        Optional[float],
+        typer.Option(
+            "--rps",
+            "--requests-per-second",
+            min=0.000001,
+            help="Override provider.config.requests_per_second for this run.",
+        ),
+    ] = None,
     output_json: Annotated[
         Optional[Path],
         typer.Option(
@@ -164,16 +222,23 @@ def sheets_build_command(
     """Build workbook outputs from a workbook configuration."""
     print_validation_header(str(config_file))
     run_started_at = now_iso8601_utc()
+    runtime_controls: Dict[str, Any] = {}
 
     try:
-        _, resolved_registry_paths = _load_workbook_config(
+        workbook_config, resolved_registry_paths = _load_workbook_config(
             config_file=config_file,
             registry_paths=registry_paths,
         )
+        runtime_controls, runtime_warnings = _runtime_controls_payload(
+            workbook_config=workbook_config,
+            threads=threads,
+            requests_per_second=requests_per_second,
+        )
+        for warning in runtime_warnings:
+            typer.echo(f"⚠ {warning}")
 
-        builder = WorkbookBuilder.from_yaml(
-            yaml_path=config_file,
-            registry_paths=resolved_registry_paths,
+        builder = WorkbookBuilder.from_config(
+            config=workbook_config,
         )
         result = builder.build()
         summary = {
@@ -195,6 +260,7 @@ def sheets_build_command(
             "config_file": str(config_file),
             "registry_files": [str(path) for path in resolved_registry_paths],
             "summary": summary,
+            "runtime": runtime_controls,
             "tabs": [tab.model_dump() for tab in result.tab_results],
             "summaries": [
                 summary_result.model_dump() for summary_result in result.summary_results
@@ -242,6 +308,7 @@ def sheets_build_command(
             "started_at": run_started_at,
             "completed_at": now_iso8601_utc(),
             "config_file": str(config_file),
+            "runtime": runtime_controls,
             "error": {"code": error_code, "message": _first_error_line(error)},
         }
         write_output_json(output_json, payload)
@@ -415,6 +482,24 @@ def sheets_build(
             help="Path to Python registry files (can be used multiple times)",
         ),
     ] = None,
+    threads: Annotated[
+        Optional[int],
+        typer.Option(
+            "--threads",
+            "-t",
+            min=1,
+            help="Workbook worker count (Sheets currently supports only 1).",
+        ),
+    ] = None,
+    requests_per_second: Annotated[
+        Optional[float],
+        typer.Option(
+            "--rps",
+            "--requests-per-second",
+            min=0.000001,
+            help="Override provider.config.requests_per_second for this run.",
+        ),
+    ] = None,
     output_json: Annotated[
         Optional[Path],
         typer.Option(
@@ -427,6 +512,8 @@ def sheets_build(
     sheets_build_command(
         config_file=config_file,
         registry_paths=registry_paths,
+        threads=threads,
+        requests_per_second=requests_per_second,
         output_json=output_json,
     )
 

--- a/tests/test_cli_sheets_build.py
+++ b/tests/test_cli_sheets_build.py
@@ -69,7 +69,7 @@ def test_sheets_build_writes_success_json(tmp_path, monkeypatch):
 
     monkeypatch.setattr(
         sheets_command_module.WorkbookBuilder,
-        "from_yaml",
+        "from_config",
         staticmethod(lambda *args, **kwargs: _Builder()),
     )
 
@@ -84,6 +84,11 @@ def test_sheets_build_writes_success_json(tmp_path, monkeypatch):
     )
 
     assert payload["status"] == "success"
+    assert payload["runtime"]["threads"]["requested"] is None
+    assert payload["runtime"]["threads"]["applied"] == 1
+    assert payload["runtime"]["requests_per_second"]["requested"] is None
+    assert payload["runtime"]["requests_per_second"]["applied"] == 1.0
+    assert payload["runtime"]["requests_per_second"]["source"] == "provider_config"
     json_payload = json.loads(output_file.read_text(encoding="utf-8"))
     assert json_payload["command"] == "sheets build"
     assert json_payload["summary"]["workbook_id"] == "sheet_123"
@@ -115,7 +120,7 @@ def test_sheets_build_writes_error_json_and_exits_on_tab_failures(
 
     monkeypatch.setattr(
         sheets_command_module.WorkbookBuilder,
-        "from_yaml",
+        "from_config",
         staticmethod(lambda *args, **kwargs: _Builder()),
     )
 
@@ -171,7 +176,7 @@ def test_sheets_build_writes_error_json_and_exits_on_summary_failures(
 
     monkeypatch.setattr(
         sheets_command_module.WorkbookBuilder,
-        "from_yaml",
+        "from_config",
         staticmethod(lambda *args, **kwargs: _Builder()),
     )
 
@@ -197,7 +202,7 @@ def test_sheets_build_writes_error_json_on_unexpected_failure(tmp_path, monkeypa
     _stub_cli_output(monkeypatch)
     monkeypatch.setattr(
         sheets_command_module.WorkbookBuilder,
-        "from_yaml",
+        "from_config",
         staticmethod(
             lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
         ),
@@ -217,3 +222,105 @@ def test_sheets_build_writes_error_json_on_unexpected_failure(tmp_path, monkeypa
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     assert payload["status"] == "error"
     assert payload["error"]["code"] == "SLIDEFLOW_SHEETS_BUILD_FAILED"
+
+
+def test_sheets_build_runtime_overrides_are_reflected_in_json(tmp_path, monkeypatch):
+    _stub_cli_output(monkeypatch)
+    captured = {}
+
+    class _Builder:
+        def build(self):
+            return WorkbookBuildResult(
+                workbook_id="sheet_123",
+                workbook_url="https://docs.google.com/spreadsheets/d/sheet_123",
+                status="success",
+                tab_results=[],
+                summary_results=[],
+            )
+
+    def _from_config(config):
+        captured["requests_per_second"] = config.provider.config.get(
+            "requests_per_second"
+        )
+        return _Builder()
+
+    monkeypatch.setattr(
+        sheets_command_module.WorkbookBuilder,
+        "from_config",
+        staticmethod(_from_config),
+    )
+
+    config_file = tmp_path / "workbook.yaml"
+    output_file = tmp_path / "sheets-build-runtime.json"
+    _write_minimal_workbook_config(config_file)
+
+    payload = sheets_command_module.sheets_build_command(
+        config_file=config_file,
+        registry_paths=None,
+        threads=1,
+        requests_per_second=2.5,
+        output_json=output_file,
+    )
+
+    assert captured["requests_per_second"] == 2.5
+    assert payload["runtime"]["threads"] == {
+        "requested": 1,
+        "applied": 1,
+        "supported_values": [1],
+    }
+    assert payload["runtime"]["requests_per_second"] == {
+        "requested": 2.5,
+        "applied": 2.5,
+        "source": "cli_override",
+    }
+
+    json_payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert json_payload["runtime"] == payload["runtime"]
+
+
+def test_sheets_build_normalizes_threads_and_emits_warning(tmp_path, monkeypatch):
+    warning_messages = []
+    monkeypatch.setattr(
+        sheets_command_module, "print_validation_header", lambda *a, **k: None
+    )
+    monkeypatch.setattr(sheets_command_module, "print_success", lambda *a, **k: None)
+    monkeypatch.setattr(sheets_command_module, "print_error", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sheets_command_module.typer,
+        "echo",
+        lambda message, *a, **k: warning_messages.append(str(message)),
+    )
+
+    class _Builder:
+        def build(self):
+            return WorkbookBuildResult(
+                workbook_id="sheet_123",
+                workbook_url="https://docs.google.com/spreadsheets/d/sheet_123",
+                status="success",
+                tab_results=[],
+                summary_results=[],
+            )
+
+    monkeypatch.setattr(
+        sheets_command_module.WorkbookBuilder,
+        "from_config",
+        staticmethod(lambda *args, **kwargs: _Builder()),
+    )
+
+    config_file = tmp_path / "workbook.yaml"
+    output_file = tmp_path / "sheets-build-threads.json"
+    _write_minimal_workbook_config(config_file)
+
+    payload = sheets_command_module.sheets_build_command(
+        config_file=config_file,
+        registry_paths=None,
+        threads=4,
+        output_json=output_file,
+    )
+
+    assert payload["runtime"]["threads"] == {
+        "requested": 4,
+        "applied": 1,
+        "supported_values": [1],
+    }
+    assert any("normalized to 1" in msg for msg in warning_messages)


### PR DESCRIPTION
## Summary
- add `--threads` and `--rps/--requests-per-second` to `slideflow sheets build`
- forward reusable workflow `threads` and `requests-per-second` inputs for `artifact-kind: sheets`
- emit applied runtime controls in sheets build JSON output for observability
- document Sheets runtime-control behavior in provider/CLI/deployment docs

## Behavior
- `--rps` overrides `provider.config.requests_per_second` for the current run
- Sheets execution remains sequential for safety; `--threads` is accepted and normalized to `1`
- when `--threads` is set to values other than `1`, CLI emits a warning and reports requested/applied values in JSON

## JSON additions (`slideflow sheets build --output-json`)
- `runtime.threads.requested`
- `runtime.threads.applied`
- `runtime.threads.supported_values`
- `runtime.requests_per_second.requested`
- `runtime.requests_per_second.applied`
- `runtime.requests_per_second.source`

## Tests run
- `./.venv/bin/python -m ruff check slideflow/cli/commands/sheets.py tests/test_cli_sheets_build.py`
- `./.venv/bin/python -m pytest -q tests/test_cli_sheets_build.py`
- `./.venv/bin/python -m pytest -q tests/test_cli_sheets_validate.py`
- `./.venv/bin/python -m mkdocs build --strict`

Closes #183