### PR TITLE
docs: refresh sheets concurrency/runtime references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 - Build JSON output includes citation summary fields and per-result citation payloads.
+- `slideflow sheets build` now executes workbook tabs with bounded parallel workers
+  (`--threads`), capped by tab count.
+- Sheets build runtime JSON now includes richer thread controls metadata:
+  - `runtime.threads.supported_values`
+  - `runtime.threads.effective_workers`
+  - `runtime.threads.workload_size`
 - Build JSON output includes ownership transfer status fields:
   - `ownership_transfer_attempted`
   - `ownership_transfer_succeeded`

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ SlideFlow comes with a simple CLI.
 -   `slideflow sheets validate|build|doctor CONFIG_FILE [OPTIONS]`
     -   workbook configuration workflows (`workbook:` schema)
     -   tab-local AI summaries via `workbook.tabs[].ai.summaries[]` (`type: ai_text`)
+    -   bounded tab concurrency via `--threads` (applied up to tab count)
     -   machine-readable JSON supported via `--output-json`
 
 Examples:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -195,9 +195,15 @@ slideflow sheets build workbook.yml --registry registry.py --output-json sheets-
 Notes:
 
 - Sheets builds execute tabs with a bounded worker pool (`--threads`).
-- Build JSON includes a `runtime` block with requested/applied/effective
-  `threads` and
-  `requests_per_second`.
+- Build JSON includes a `runtime` block with:
+  - `threads.requested`
+  - `threads.applied`
+  - `threads.supported_values`
+  - `threads.effective_workers`
+  - `threads.workload_size`
+  - `requests_per_second.requested`
+  - `requests_per_second.applied`
+  - `requests_per_second.source`
 
 Workbook schema details (tabs, append idempotency, and tab-local AI summaries):
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -76,7 +76,8 @@ Runtime control note:
 - The reusable workflow forwards `threads` and `requests-per-second` to both
   `slideflow build` and `slideflow sheets build`.
 - Sheets runs tab writes with bounded parallelism based on `--threads` and tab
-  count; requested/applied values are reported in build JSON.
+  count; requested/applied/supported/effective/workload values are reported in
+  build JSON.
 
 Security notes:
 

--- a/docs/providers/google-sheets.md
+++ b/docs/providers/google-sheets.md
@@ -175,6 +175,15 @@ slideflow sheets build workbook.yml --threads 3 --output-json sheets-build.json
 
 Build JSON includes:
 
+- runtime controls:
+  - `runtime.threads.requested`
+  - `runtime.threads.applied`
+  - `runtime.threads.supported_values`
+  - `runtime.threads.effective_workers`
+  - `runtime.threads.workload_size`
+  - `runtime.requests_per_second.requested`
+  - `runtime.requests_per_second.applied`
+  - `runtime.requests_per_second.source`
 - workbook-level counters: tabs/summaries succeeded/failed
 - per-tab results (`rows_written`, `rows_skipped`, `run_key`, error)
 - per-summary results (`placement_type`, `target_cell`, `chars_written`, error)


### PR DESCRIPTION
Summary\n- update docs to reflect real Sheets tab concurrency via threads\n- document full Sheets runtime JSON thread fields (supported_values, effective_workers, workload_size)\n- align README and deployments guidance with current behavior\n- add changelog note for the concurrency/runtime metadata change\n\nValidation\n- ./.venv/bin/python -m mkdocs build --strict\n\nFiles\n- README.md\n- CHANGELOG.md\n- docs/cli-reference.md\n- docs/deployments.md\n- docs/providers/google-sheets.md