### PR TITLE
Production-ready hardening milestone

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -27,25 +27,33 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: pip
 
-      - name: Install dependencies for audit
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install locked audit environment
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,ai]"
-          python -m pip install pip-audit
+          uv lock --check
+          uv sync \
+            --extra dev \
+            --extra ai \
+            --extra databricks \
+            --extra dbt \
+            --extra bigquery \
+            --extra duckdb \
+            --locked
 
       - name: Run pip-audit
         id: pip_audit
-        # Advisory security scans: emit warnings + artifacts without blocking CI.
-        continue-on-error: true
         run: |
-          pip-audit --format=json --output pip-audit.json
+          uv run pip-audit --format=json --output pip-audit.json
 
       - name: Warn on vulnerabilities
         if: always() && steps.pip_audit.outcome == 'failure'
         run: |
-          echo "::warning::pip-audit detected vulnerable dependencies. See artifact pip-audit-report."
+          echo "::error::pip-audit detected vulnerable dependencies. See artifact pip-audit-report."
 
       - name: Upload pip-audit report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,28 @@ permissions:
   contents: read
 
 jobs:
+  workflow-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Lint GitHub workflows
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          "$(go env GOPATH)/bin/actionlint"
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,9 @@ jobs:
         run: |
           python -m venv .venv-smoke
           . .venv-smoke/bin/activate
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip twine
           python -m pip install dist/*.whl
-          bash scripts/ci/run_quickstart_smoke.sh
+          bash scripts/ci/smoke_installed_wheel.sh dist docs/quickstart/smoke
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
       - "README.md"
       - "CONTRIBUTING.md"
       - "CHANGELOG.md"
+      - "pyproject.toml"
+      - "uv.lock"
   push:
     branches:
       - master
@@ -18,6 +20,8 @@ on:
       - "README.md"
       - "CONTRIBUTING.md"
       - "CHANGELOG.md"
+      - "pyproject.toml"
+      - "uv.lock"
   workflow_dispatch:
 
 permissions:
@@ -37,20 +41,20 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: pip
 
-      - name: Install docs dependencies
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install locked docs environment
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
-            mkdocs>=1.6 \
-            mkdocs-material>=9.5 \
-            mkdocs-minify-plugin>=0.8 \
-            pymdown-extensions>=10.0
+          uv lock --check
+          uv sync --extra docs --locked
 
       - name: Build MkDocs site (strict)
         run: |
-          mkdocs build --strict
+          uv run mkdocs build --strict
 
       - name: Configure GitHub Pages
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,255 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
+  workflow-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Lint GitHub workflows
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          "$(go env GOPATH)/bin/actionlint"
+
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install project and test dependencies (locked)
+        run: |
+          uv lock --check
+          uv sync --extra dev --extra ai --locked
+
+      - name: Validate dependency resolution
+        run: |
+          uv pip check
+
+      - name: Run pre-commit hooks
+        if: matrix.python-version == '3.12'
+        run: |
+          uv run pre-commit run --all-files
+
+      - name: Check NumPy/Pandas binary compatibility
+        run: |
+          uv run python scripts/ci/check_numpy_binary_compatibility.py
+
+      - name: Validate version consistency
+        run: |
+          uv run python scripts/ci/check_version_consistency.py "${GITHUB_REF_NAME}"
+
+      - name: Check code formatting
+        run: |
+          uvx --from black==26.3.1 black --check slideflow tests scripts
+
+      - name: Run lint checks
+        run: |
+          uv run python -m ruff check slideflow tests scripts
+
+      - name: Run type checks
+        run: |
+          uv run python -m mypy slideflow
+
+      - name: Run unit tests with coverage
+        run: |
+          uv run python -m pytest -q \
+            -m "not integration and not e2e" \
+            --cov=slideflow \
+            --cov-branch \
+            --cov-report=term \
+            --cov-report=xml \
+            --cov-fail-under=82
+
+      - name: Run integration tests
+        run: |
+          uv run python -m pytest -q -m integration
+
+      - name: Run e2e tests
+        run: |
+          uv run python -m pytest -q -m e2e
+
+  optional-connectors:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install optional connector dependencies (locked)
+        run: |
+          uv lock --check
+          uv sync --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --locked
+
+      - name: Validate dependency resolution
+        run: |
+          uv pip check
+
+      - name: Verify optional connector extras importability
+        run: |
+          uv run python - <<'PY'
+          import dbt.cli.main  # noqa: F401
+          import databricks.sql  # noqa: F401
+          import git  # noqa: F401
+          import google.cloud.bigquery  # noqa: F401
+          import duckdb  # noqa: F401
+          print("Optional connector extras importability check passed.")
+          PY
+
+      - name: Run optional connector functional tests
+        run: |
+          uv run python -m pytest -q \
+            tests/test_bigquery_connector.py \
+            tests/test_duckdb_connector.py \
+            tests/test_connectors_and_providers_unit.py \
+            tests/test_dbt_sanitization.py
+
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install locked docs environment
+        run: |
+          uv lock --check
+          uv sync --extra docs --locked
+
+      - name: Build MkDocs site (strict)
+        run: |
+          uv run mkdocs build --strict
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install locked audit environment
+        run: |
+          uv lock --check
+          uv sync \
+            --extra dev \
+            --extra ai \
+            --extra databricks \
+            --extra dbt \
+            --extra bigquery \
+            --extra duckdb \
+            --locked
+
+      - name: Run pip-audit
+        run: |
+          uv run pip-audit --progress-spinner off
+
+  live-google-validation:
+    runs-on: ubuntu-latest
+    environment: google-live-validation
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate live Google workflow evidence
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLIDES_RUN_ID: ${{ vars.SLIDEFLOW_LIVE_GOOGLE_SLIDES_RUN_ID }}
+          DOCS_RUN_ID: ${{ vars.SLIDEFLOW_LIVE_GOOGLE_DOCS_RUN_ID }}
+          SHEETS_RUN_ID: ${{ vars.SLIDEFLOW_LIVE_GOOGLE_SHEETS_RUN_ID }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SLIDES_RUN_ID}" || -z "${DOCS_RUN_ID}" || -z "${SHEETS_RUN_ID}" ]]; then
+            echo "::error::Set SLIDEFLOW_LIVE_GOOGLE_SLIDES_RUN_ID, SLIDEFLOW_LIVE_GOOGLE_DOCS_RUN_ID, and SLIDEFLOW_LIVE_GOOGLE_SHEETS_RUN_ID on the google-live-validation environment."
+            exit 1
+          fi
+
+          python scripts/ci/check_live_validation_evidence.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            --expected-sha "${GITHUB_SHA}" \
+            --slides-run-id "${SLIDES_RUN_ID}" \
+            --docs-run-id "${DOCS_RUN_ID}" \
+            --sheets-run-id "${SHEETS_RUN_ID}" | tee -a "$GITHUB_STEP_SUMMARY"
+
   release:
     runs-on: ubuntu-latest
+    needs:
+      - workflow-lint
+      - test
+      - optional-connectors
+      - docs
+      - dependency-audit
+      - live-google-validation
     environment: pypi
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -46,45 +288,22 @@ jobs:
         run: |
           uv pip check
 
-      - name: Check NumPy/Pandas binary compatibility
-        run: |
-          uv run python scripts/ci/check_numpy_binary_compatibility.py
-
       - name: Validate version consistency
         run: |
           uv run python scripts/ci/check_version_consistency.py "${GITHUB_REF_NAME}"
 
-      - name: Check code formatting
-        run: |
-          uvx --from black==26.3.1 black --check slideflow tests scripts
-
-      - name: Run lint checks
-        run: |
-          uv run python -m ruff check slideflow tests scripts
-
-      - name: Run type checks
-        run: |
-          uv run python -m mypy slideflow
-
-      - name: Run release test suite
-        run: |
-          uv run python -m pytest -q \
-            --cov=slideflow \
-            --cov-report=term \
-            --cov-fail-under=80
-
       - name: Build distribution artifacts
         run: |
-          uv pip install build
+          uv pip install build twine
           uv run python -m build
 
       - name: Smoke test built wheel
         run: |
           python -m venv .venv-smoke
           . .venv-smoke/bin/activate
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip twine
           python -m pip install dist/*.whl
-          bash scripts/ci/run_quickstart_smoke.sh
+          bash scripts/ci/smoke_installed_wheel.sh dist docs/quickstart/smoke
 
       - name: Verify distribution package identity
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,63 +328,16 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          python - <<'PY'
-          import os
-          import subprocess
-          import urllib.error
-          import urllib.request
-
-
-          def url_exists(url: str, headers: dict[str, str] | None = None) -> bool:
-              request = urllib.request.Request(url, headers=headers or {})
-              try:
-                  with urllib.request.urlopen(request, timeout=15) as response:
-                      return response.status == 200
-              except urllib.error.HTTPError as error:
-                  if error.code == 404:
-                      return False
-                  raise
-
-
-          version = os.environ["VERSION"]
-          repository = os.environ["REPOSITORY"]
-          tag = f"v{version}"
-
-          package_exists = url_exists(
-              f"https://pypi.org/pypi/slideflow-presentations/{version}/json"
-          )
-          tag_exists = (
-              subprocess.run(
-                  ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"],
-                  check=False,
-                  capture_output=True,
-                  text=True,
-              ).returncode
-              == 0
-          )
-          release_exists = url_exists(
-              f"https://api.github.com/repos/{repository}/releases/tags/{tag}",
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
-              },
-          )
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_file:
-              output_file.write(f"package_exists={str(package_exists).lower()}\n")
-              output_file.write(f"tag_exists={str(tag_exists).lower()}\n")
-              output_file.write(f"release_exists={str(release_exists).lower()}\n")
-          PY
+          uv run python scripts/ci/check_release_artifact_state.py \
+            --version "${VERSION}" \
+            --expected-commit "${GITHUB_SHA}" \
+            --repository "${REPOSITORY}"
 
       - name: Release idempotency summary
         run: |
           echo "PyPI version exists: ${{ steps.release_state.outputs.package_exists }}"
           echo "Git tag exists: ${{ steps.release_state.outputs.tag_exists }}"
           echo "GitHub release exists: ${{ steps.release_state.outputs.release_exists }}"
-
-      - name: Publish package to PyPI
-        if: ${{ steps.release_state.outputs.package_exists != 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create and push release tag
         if: ${{ steps.release_state.outputs.tag_exists != 'true' }}
@@ -397,6 +350,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "${TAG}"
           git push origin "${TAG}"
+
+      - name: Publish package to PyPI
+        if: ${{ steps.release_state.outputs.package_exists != 'true' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub release
         if: ${{ steps.release_state.outputs.release_exists != 'true' }}

--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -389,13 +389,17 @@ jobs:
             extracted_urls=""
           fi
           if [[ "${{ inputs.artifact-kind }}" == "sheets" ]]; then
-            echo "presentation_urls=" >> "$GITHUB_OUTPUT"
-            echo "workbook_urls=$extracted_urls" >> "$GITHUB_OUTPUT"
-            echo "artifact_urls=$extracted_urls" >> "$GITHUB_OUTPUT"
+            {
+              echo "presentation_urls="
+              echo "workbook_urls=$extracted_urls"
+              echo "artifact_urls=$extracted_urls"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "presentation_urls=$extracted_urls" >> "$GITHUB_OUTPUT"
-            echo "workbook_urls=" >> "$GITHUB_OUTPUT"
-            echo "artifact_urls=$extracted_urls" >> "$GITHUB_OUTPUT"
+            {
+              echo "presentation_urls=$extracted_urls"
+              echo "workbook_urls="
+              echo "artifact_urls=$extracted_urls"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract JSON outputs
@@ -411,13 +415,15 @@ jobs:
           emit_json_output() {
             local key="$1"
             local file="$2"
-            echo "${key}<<EOF" >> "$GITHUB_OUTPUT"
-            if [[ -s "$file" ]]; then
-              cat "$file" >> "$GITHUB_OUTPUT"
-            else
-              echo "{}" >> "$GITHUB_OUTPUT"
-            fi
-            echo "EOF" >> "$GITHUB_OUTPUT"
+            {
+              echo "${key}<<EOF"
+              if [[ -s "$file" ]]; then
+                cat "$file"
+              else
+                echo "{}"
+              fi
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           }
 
           emit_json_output "doctor_result_json" "$DOCTOR_JSON_FILE"

--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -78,7 +78,7 @@ on:
         default: ""
         type: string
       dry-run:
-        description: "Run build with --dry-run"
+        description: "Run presentation build with --dry-run; unsupported for sheets"
         required: false
         default: false
         type: boolean
@@ -254,6 +254,10 @@ jobs:
           artifact_kind="${{ inputs.artifact-kind }}"
           if [[ "$artifact_kind" != "presentation" && "$artifact_kind" != "sheets" ]]; then
             echo "Unsupported artifact-kind: '$artifact_kind' (expected 'presentation' or 'sheets')" >&2
+            exit 1
+          fi
+          if [[ "$artifact_kind" == "sheets" && "${{ inputs.dry-run }}" == "true" ]]; then
+            echo "dry-run is only supported for presentation artifacts; slideflow sheets build has no dry-run mode." >&2
             exit 1
           fi
           : > "$LOG_FILE"

--- a/.github/workflows/reusable-slideflow-build.yml
+++ b/.github/workflows/reusable-slideflow-build.yml
@@ -415,10 +415,121 @@ jobs:
           emit_json_output() {
             local key="$1"
             local file="$2"
+            local summary_file="${RUNNER_TEMP}/${key}-summary.json"
+
+            if ! python - "$file" > "$summary_file" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          REDACTION_HELPER_AVAILABLE = True
+          try:
+              from slideflow.utilities.redaction import redact_value
+          except Exception:
+              REDACTION_HELPER_AVAILABLE = False
+
+              def redact_value(value):
+                  return value
+
+          SAFE_SUMMARY_KEYS = {
+              "append_tabs",
+              "charts",
+              "failed_errors",
+              "failed_warnings",
+              "idempotent_skips",
+              "passed",
+              "provider_type",
+              "replace_tabs",
+              "replacements",
+              "slides",
+              "summaries",
+              "summaries_failed",
+              "summaries_succeeded",
+              "summaries_total",
+              "tabs",
+              "tabs_failed",
+              "tabs_succeeded",
+              "tabs_total",
+              "total",
+          }
+          TOP_LEVEL_KEYS = {
+              "chart_image_cleanup_failed_count",
+              "citations_emitted_sources",
+              "citations_enabled",
+              "citations_total_sources",
+              "citations_truncated",
+              "command",
+              "dry_run",
+              "generated_presentations",
+              "status",
+              "strict",
+              "total_presentations",
+          }
+
+          path = Path(sys.argv[1])
+          if not path.is_file() or path.stat().st_size == 0:
+              payload = {}
+          else:
+              payload = json.loads(path.read_text(encoding="utf-8"))
+
+          summary = {key: payload[key] for key in TOP_LEVEL_KEYS if key in payload}
+
+          source_summary = payload.get("summary")
+          if isinstance(source_summary, dict):
+              summary["summary"] = {
+                  key: source_summary[key]
+                  for key in SAFE_SUMMARY_KEYS
+                  if key in source_summary
+              }
+
+          runtime = payload.get("runtime")
+          if isinstance(runtime, dict):
+              summary["runtime"] = {
+                  key: runtime[key]
+                  for key in ("threads", "requests_per_second")
+                  if key in runtime
+              }
+
+          error = payload.get("error")
+          if isinstance(error, dict):
+              error_summary = {key: error[key] for key in ("code",) if key in error}
+              if REDACTION_HELPER_AVAILABLE and isinstance(error.get("message"), str):
+                  error_summary["message"] = error["message"]
+              elif "message" in error:
+                  error_summary["message"] = (
+                      "Redacted because the Slideflow redaction helper is unavailable."
+                  )
+              summary["error"] = error_summary
+
+          provider_contract = payload.get("provider_contract")
+          if isinstance(provider_contract, dict):
+              provider_contract_summary = {
+                  key: provider_contract[key]
+                  for key in ("status", "slides_checked")
+                  if key in provider_contract
+              }
+              for key in ("missing_slides", "missing_placeholders"):
+                  value = provider_contract.get(key)
+                  if isinstance(value, list):
+                      provider_contract_summary[f"{key}_count"] = len(value)
+              summary["provider_contract"] = provider_contract_summary
+
+          print(
+              json.dumps(
+                  redact_value(summary),
+                  sort_keys=True,
+                  separators=(",", ":"),
+              )
+          )
+          PY
+            then
+              printf '{}\n' > "$summary_file"
+            fi
+
             {
               echo "${key}<<EOF"
-              if [[ -s "$file" ]]; then
-                cat "$file"
+              if [[ -s "$summary_file" ]]; then
+                cat "$summary_file"
               else
                 echo "{}"
               fi
@@ -438,7 +549,7 @@ jobs:
           path: |
             ${{ runner.temp }}/slideflow-build.log
             ${{ runner.temp }}/slideflow-presentation-urls.txt
-            ${{ runner.temp }}/slideflow-doctor-result.json
-            ${{ runner.temp }}/slideflow-validate-result.json
-            ${{ runner.temp }}/slideflow-build-result.json
+            ${{ runner.temp }}/doctor_result_json-summary.json
+            ${{ runner.temp }}/validate_result_json-summary.json
+            ${{ runner.temp }}/build_result_json-summary.json
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@ build/*
 dist/*
 sa.json
 # Local credential/key material
+credentials/
+secrets/
+client_secret*.json
+*client-secret*.json
+*refresh-token*.json
+*.secret.json
+google-application-credentials.json
+*service-account*.json
 *.pem
 *.key
 *.p12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: local
+    hooks:
+      - id: slideflow-secret-hygiene
+        name: SlideFlow secret hygiene
+        entry: python scripts/ci/check_secret_hygiene.py
+        language: system
+        pass_filenames: false
+
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Google provider contract validation now fails closed when read-only auth
   initialization fails. Pass `--provider-contract-full-auth-fallback` only when
   validation is allowed to instantiate providers with full build scopes.
+- Presentation builds now resolve chart templates with a build-scoped
+  `TemplateEngine`, so concurrent builds with different `template_paths` do not
+  mutate shared template state.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Credential hygiene docs now require secret-manager or environment-backed
   credentials, document GitHub secret scanning/push-protection status, and add a
   SlideFlow-specific secret hygiene check to pre-commit/CI.
+- Workflow and configuration docs now clarify presentation-only dry-run
+  behavior, release/docs workflow triggers, credential handling, and reserved
+  Google Docs chart-width configuration.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Data-source cache reads now return isolated `DataFrame` copies, table
+  formatting avoids mutating shared source frames, and cache `clear()`/`disable()`
+  wake in-flight waiters without allowing stale loads to refill the cache.
 - Release provenance checks now keep version metadata, changelog release headers,
   tag ancestry, and existing PyPI artifacts aligned with the artifact-producing
   commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Presentation builds now resolve chart templates with a build-scoped
   `TemplateEngine`, so concurrent builds with different `template_paths` do not
   mutate shared template state.
+- Security and release docs now spell out how hardening PRs reconcile
+  Dependabot alerts and superseded dependency-update PRs after the patched
+  lockfile reaches the default branch.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Data-source cache reads now return isolated `DataFrame` copies, table
   formatting avoids mutating shared source frames, and cache `clear()`/`disable()`
   wake in-flight waiters without allowing stale loads to refill the cache.
+- Plotly chart export timeouts now terminate only the timed-out export worker,
+  so one build cannot reset another build's in-flight chart export.
 - Release provenance checks now keep version metadata, changelog release headers,
   tag ancestry, and existing PyPI artifacts aligned with the artifact-producing
   commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Security and release docs now spell out how hardening PRs reconcile
   Dependabot alerts and superseded dependency-update PRs after the patched
   lockfile reaches the default branch.
+- Credential hygiene docs now require secret-manager or environment-backed
+  credentials, document GitHub secret scanning/push-protection status, and add a
+  SlideFlow-specific secret hygiene check to pre-commit/CI.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- Google Slides and Google Docs generated-artifact sharing now defaults to
+  `share_role: reader`. Set `provider.config.share_role: writer` explicitly
+  if recipients need edit access.
+- Google provider contract validation now fails closed when read-only auth
+  initialization fails. Pass `--provider-contract-full-auth-fallback` only when
+  validation is allowed to instantiate providers with full build scopes.
+
+### Fixed
+
+- Release provenance checks now keep version metadata, changelog release headers,
+  tag ancestry, and existing PyPI artifacts aligned with the artifact-producing
+  commit.
+
 ## [0.0.7] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - `provider.config.transfer_ownership_to`
   - `provider.config.transfer_ownership_strict`
 - Chart image sharing-mode controls for Google Slides/Docs:
-  - `provider.config.chart_image_sharing_mode` (`public` | `restricted`)
+  - `provider.config.chart_image_sharing_mode` (`restricted` by default, explicit `public` opt-in)
+  - cleanup failure counts and file IDs in build results/output JSON
 - Shared Google API utility layer for provider internals:
   - shared credential construction
   - shared rate-limited request execution helper

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ To create your first output, you\'ll need:
 3.  **A YAML Configuration File:** This is where you\'ll define your output artifact. See the [Configuration](#-configuration) section for more details.
 4.  **Google Cloud Credentials:** You'll need a Google Cloud service account with access to the required Google APIs (Slides/Docs/Sheets + Drive as needed). Provide credentials with one of:
 
-    -   Set the `credentials` field in your `config.yml` to the path of your JSON credentials file.
-    -   Set the `credentials` field in your `config.yml` to the JSON content of your credentials file as a string.
-    -   Set `GOOGLE_DOCS_CREDENTIALS` (for `google_docs`), `GOOGLE_SHEETS_CREDENTIALS` (for `google_sheets`), or `GOOGLE_SLIDEFLOW_CREDENTIALS` (shared fallback) to a path/raw JSON.
+    -   Set the `credentials` field in your `config.yml` to the path of an untracked JSON credentials file.
+    -   Set `GOOGLE_DOCS_CREDENTIALS` (for `google_docs`), `GOOGLE_SHEETS_CREDENTIALS` (for `google_sheets`), or `GOOGLE_SLIDEFLOW_CREDENTIALS` (shared fallback) to a path or secret-manager-injected raw JSON.
+
+    Do not commit raw service-account JSON, OAuth client secrets, refresh tokens, or `.env` files.
 
 Once you have these, you can run the `build` command:
 
@@ -190,7 +191,7 @@ presentation:
 provider:
   type: "google_slides" # or "google_docs"
   config:
-    credentials: "/path/to/your/credentials.json"
+    credentials: null # set GOOGLE_SLIDEFLOW_CREDENTIALS or use an untracked local path
     template_id: "your_google_slides_template_id"
 
 citations: # optional

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -84,9 +84,13 @@ jobs:
 - `presentation-urls`: Comma-separated URLs for `presentation` builds.
 - `workbook-urls`: Comma-separated URLs for `sheets` builds.
 - `artifact-urls`: Comma-separated URLs for whichever artifact-kind was built.
-- `doctor-result-json`: JSON summary emitted by doctor command (`slideflow doctor` or `slideflow sheets doctor`).
-- `validate-result-json`: JSON summary emitted by validate command (`slideflow validate` or `slideflow sheets validate`).
-- `build-result-json`: JSON summary emitted by build command (`slideflow build` or `slideflow sheets build`).
+- `doctor-result-json`: redacted, non-sensitive JSON summary emitted by doctor command (`slideflow doctor` or `slideflow sheets doctor`).
+- `validate-result-json`: redacted, non-sensitive JSON summary emitted by validate command (`slideflow validate` or `slideflow sheets validate`).
+- `build-result-json`: redacted, non-sensitive JSON summary emitted by build command (`slideflow build` or `slideflow sheets build`).
+
+Workflow JSON outputs intentionally omit full result rows, raw params, check
+details, workbook/document IDs, and URLs. Use `artifact-urls` for the generated
+artifact links and keep downstream handling scoped to trusted jobs.
 
 Example downstream usage:
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -71,7 +71,9 @@ jobs:
 - `run-validate` (optional): Run validate before build (`slideflow validate` for `presentation`, `slideflow sheets validate` for `sheets`). Default `true`.
 - `run-provider-contract-check` (optional): Add `--provider-contract-check` to validate for `presentation` builds (`google_slides` and `google_docs`). Ignored for `sheets`. Default `false`.
 - `provider-contract-params-path` (optional): CSV path for validate contract checks; falls back to `params-path` when unset.
-- `dry-run` (optional): Run build with `--dry-run`. Default `false`.
+- `dry-run` (optional): Run presentation builds with `--dry-run`. Default
+  `false`. Unsupported for `artifact-kind: sheets`; the workflow fails fast
+  rather than performing a real Sheets write after a caller requested dry-run.
 - `threads` (optional): Value passed to `--threads` for both `presentation`
   and `sheets` builds.
 - `requests-per-second` (optional): Value passed to `--rps` for both

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -17,6 +17,8 @@
   - builds wheel/sdist artifacts and verifies distribution identity (`slideflow-presentations`)
   - installs built wheel and runs quickstart smoke validation (`validate` + `build --dry-run`)
 - `Docs` (`.github/workflows/docs.yml`)
+  - builds docs on pull requests that touch docs, README, changelog, package
+    metadata, or docs dependencies
   - installs locked docs dependencies with `uv sync --extra docs --locked`
   - runs `uv run mkdocs build --strict`
   - deploys to GitHub Pages on `master`/`main`

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -7,6 +7,8 @@
   - enforces lock freshness with `uv lock --check`
   - installs project + dev deps with locked resolution (`uv sync --extra dev --extra ai --locked`)
   - runs `uv pip check`
+  - runs pre-commit on Python 3.12, including `detect-secrets` and
+    `scripts/ci/check_secret_hygiene.py`
   - runs NumPy/Pandas ABI compatibility check (`scripts/ci/check_numpy_binary_compatibility.py`)
   - runs pinned `black --check` via `uvx --from black==26.3.1`, plus `ruff check` and `mypy`
   - runs unit tests with coverage gate (`-m "not integration and not e2e"`)
@@ -79,6 +81,7 @@ uv sync --extra docs --extra dev --extra ai --extra databricks --extra dbt --ext
 source .venv/bin/activate
 uv lock --check
 uv pip check
+uv run python scripts/ci/check_secret_hygiene.py
 uv run pip-audit
 actionlint
 uv run python scripts/ci/check_numpy_binary_compatibility.py

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -25,7 +25,8 @@
   - publishes to PyPI first
   - creates tag + GitHub release only after publish succeeds
 - `Audit` (`.github/workflows/audit.yml`)
-  - runs `pip-audit`
+  - installs the locked project environment with `dev`, `ai`, `databricks`, `dbt`, `bigquery`, and `duckdb` extras
+  - runs blocking `pip-audit` from that locked environment
   - runs `bandit`
   - uploads audit reports as artifacts
 - `Live Google Slides` (`.github/workflows/live-google-slides.yml`)
@@ -72,10 +73,11 @@
 ## Required local checks before PR
 
 ```bash
-uv sync --extra docs --extra dev --extra ai --locked
+uv sync --extra docs --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --locked
 source .venv/bin/activate
 uv lock --check
 uv pip check
+uv run pip-audit
 uv run python scripts/ci/check_numpy_binary_compatibility.py
 uvx --from black==26.3.1 black --check slideflow tests scripts
 uv run python -m ruff check slideflow tests scripts

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -112,6 +112,12 @@ uv run bash scripts/ci/run_quickstart_smoke.sh
 - Patch/minor updates are grouped to reduce review load.
 - Major updates are reviewed separately and merged deliberately.
 - Auto-merge is disabled by default; every dependency PR must pass full CI and maintainer review.
+- Security dependency fixes can land through either a focused Dependabot PR or a
+  broader hardening PR, but alerts are not treated as closed until the fixed
+  lockfile is on the default branch and GitHub reports no related open alert.
+- When a hardening PR supersedes open Dependabot PRs, capture the affected PR
+  numbers in the hardening PR description and close the superseded PRs after the
+  default-branch alert check passes.
 
 ## Branching policy
 

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -3,6 +3,7 @@
 ## Workflows
 
 - `CI` (`.github/workflows/ci.yml`)
+  - runs blocking GitHub workflow linting with `actionlint`
   - enforces lock freshness with `uv lock --check`
   - installs project + dev deps with locked resolution (`uv sync --extra dev --extra ai --locked`)
   - runs `uv pip check`
@@ -14,7 +15,8 @@
   - builds wheel/sdist artifacts and verifies distribution identity (`slideflow-presentations`)
   - installs built wheel and runs quickstart smoke validation (`validate` + `build --dry-run`)
 - `Docs` (`.github/workflows/docs.yml`)
-  - runs `mkdocs build --strict`
+  - installs locked docs dependencies with `uv sync --extra docs --locked`
+  - runs `uv run mkdocs build --strict`
   - deploys to GitHub Pages on `master`/`main`
 - `Release` (`.github/workflows/release.yml`)
   - runs on `release/vX.Y.Z`
@@ -78,6 +80,7 @@ source .venv/bin/activate
 uv lock --check
 uv pip check
 uv run pip-audit
+actionlint
 uv run python scripts/ci/check_numpy_binary_compatibility.py
 uvx --from black==26.3.1 black --check slideflow tests scripts
 uv run python -m ruff check slideflow tests scripts

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -76,6 +76,11 @@ Options:
 | `--rps` | Override provider requests/second |
 | `--output-json` | Write machine-readable build summary JSON |
 
+Build JSON omits batch params by default. Secret-like keys and values are
+redacted recursively before JSON is written, including token/key/secret fields,
+Google credential fields, authorization headers, bearer/basic tokens, URL
+userinfo, and sensitive URL query parameters.
+
 Build JSON highlights (`--output-json`):
 
 - top-level:
@@ -85,6 +90,9 @@ Build JSON highlights (`--output-json`):
   - `citations_emitted_sources`
   - `citations_truncated`
 - per-result:
+  - `variant_index`
+  - `url`
+  - `presentation_name`
   - `ownership_transfer_attempted`
   - `ownership_transfer_succeeded`
   - `ownership_transfer_target`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,6 +35,7 @@ Options:
 | `-r`, `--registry` | One or more Python registry files |
 | `-f`, `--params-path` | Optional CSV used for provider contract checks (`template_id` column) |
 | `--provider-contract-check` | Validate provider template contracts (`google_slides`: slide IDs/placeholders, `google_docs`: section markers/placeholders) |
+| `--provider-contract-full-auth-fallback` | Allow contract validation to instantiate the full Google provider if read-only auth initialization fails; omitted by default |
 | `--output-json` | Write machine-readable validation summary JSON |
 
 Registry resolution order:
@@ -58,6 +59,9 @@ Provider contract behavior:
 
 - `google_slides`: validates slide IDs and placeholders in template decks.
 - `google_docs`: validates section markers and placeholders in template docs.
+- Contract checks use Google read-only scopes by default and fail closed on
+  read-only auth initialization errors unless
+  `--provider-contract-full-auth-fallback` is explicitly passed.
 
 ## `slideflow build`
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -66,7 +66,7 @@ Supported values:
 | `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
 | `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
 | `transfer_ownership_strict` | `bool` | no | If `true`, fail build when ownership transfer fails |
-| `chart_image_sharing_mode` | `str` | no | `public` (default) or `restricted` for uploaded chart-image ACL behavior |
+| `chart_image_sharing_mode` | `str` | no | `restricted` (default) or explicit `public` for uploaded chart-image ACL behavior |
 | `requests_per_second` | `float` | no | API rate limit override |
 | `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
 
@@ -88,7 +88,7 @@ For provider setup and operational behavior, see [Google Slides Provider](provid
 | `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
 | `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
 | `transfer_ownership_strict` | `bool` | no | If `true`, fail build when ownership transfer fails |
-| `chart_image_sharing_mode` | `str` | no | `public` (default) or `restricted` for uploaded chart-image ACL behavior |
+| `chart_image_sharing_mode` | `str` | no | `restricted` (default) or explicit `public` for uploaded chart-image ACL behavior |
 | `requests_per_second` | `float` | no | API rate limit override |
 | `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -63,7 +63,7 @@ Supported values:
 | `new_folder_name` | `str` | no | Create/use subfolder under `presentation_folder_id` |
 | `new_folder_name_fn` | `callable` | no | Dynamic folder-name generator |
 | `share_with` | `list[str]` | no | Emails to share generated deck with |
-| `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
+| `share_role` | `str` | no | `reader` (default), `writer`, or `commenter` |
 | `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
 | `transfer_ownership_strict` | `bool` | no | If `true`, fail build when ownership transfer fails |
 | `chart_image_sharing_mode` | `str` | no | `restricted` (default) or explicit `public` for uploaded chart-image ACL behavior |
@@ -85,7 +85,7 @@ For provider setup and operational behavior, see [Google Slides Provider](provid
 | `remove_section_markers` | `bool` | no | Remove `{{SECTION:...}}` markers after render finalization |
 | `default_chart_width_pt` | `float` | no | Reserved config field; currently not applied at render time |
 | `share_with` | `list[str]` | no | Emails to share generated document with |
-| `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
+| `share_role` | `str` | no | `reader` (default), `writer`, or `commenter` |
 | `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
 | `transfer_ownership_strict` | `bool` | no | If `true`, fail build when ownership transfer fails |
 | `chart_image_sharing_mode` | `str` | no | `restricted` (default) or explicit `public` for uploaded chart-image ACL behavior |
@@ -108,7 +108,7 @@ For provider setup and marker behavior, see [Google Docs Provider](providers/goo
 | `spreadsheet_id` | `str` | no | Reuse an existing spreadsheet instead of creating one |
 | `drive_folder_id` | `str` | no | Destination folder for newly created spreadsheets |
 | `share_with` | `list[str]` | no | Emails to share generated spreadsheet with |
-| `share_role` | `str` | no | `reader`, `writer`, or `commenter` |
+| `share_role` | `str` | no | `reader` (default), `writer`, or `commenter` |
 | `requests_per_second` | `float` | no | API rate limit override |
 
 Credential precedence for `google_sheets`:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -56,7 +56,7 @@ Supported values:
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `credentials` | `str` | conditionally | Path or raw JSON; can also come from env |
+| `credentials` | `str` | conditionally | Path to an untracked file, or secret-manager/env injected raw JSON; can also come from env |
 | `template_id` | `str` | recommended | Source template deck ID |
 | `drive_folder_id` | `str` | no | Folder for uploaded chart images |
 | `presentation_folder_id` | `str` | no | Folder for generated decks |
@@ -76,14 +76,14 @@ For provider setup and operational behavior, see [Google Slides Provider](provid
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `credentials` | `str` | conditionally | Path/raw JSON; can also come from env |
+| `credentials` | `str` | conditionally | Path to an untracked file, or secret-manager/env injected raw JSON; can also come from env |
 | `template_id` | `str` | recommended | Source template document ID |
 | `document_folder_id` | `str` | no | Folder for generated docs |
 | `drive_folder_id` | `str` | no | Folder for uploaded chart images |
 | `section_marker_prefix` | `str` | no | Marker prefix (default `{{SECTION:`) |
 | `section_marker_suffix` | `str` | no | Marker suffix (default `}}`) |
 | `remove_section_markers` | `bool` | no | Remove `{{SECTION:...}}` markers after render finalization |
-| `default_chart_width_pt` | `float` | no | Reserved config field; currently not applied at render time |
+| `default_chart_width_pt` | `float` | no | Defaults to `480`; reserved for future inline chart sizing and currently not applied at render time |
 | `share_with` | `list[str]` | no | Emails to share generated document with |
 | `share_role` | `str` | no | `reader` (default), `writer`, or `commenter` |
 | `transfer_ownership_to` | `str` | no | Optional owner handoff target email (Google My Drive only) |
@@ -104,7 +104,7 @@ For provider setup and marker behavior, see [Google Docs Provider](providers/goo
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `credentials` | `str` | conditionally | Path/raw JSON; can also come from env |
+| `credentials` | `str` | conditionally | Path to an untracked file, or secret-manager/env injected raw JSON; can also come from env |
 | `spreadsheet_id` | `str` | no | Reuse an existing spreadsheet instead of creating one |
 | `drive_folder_id` | `str` | no | Destination folder for newly created spreadsheets |
 | `share_with` | `list[str]` | no | Emails to share generated spreadsheet with |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -385,11 +385,18 @@ dbt:
   project_dir: "/tmp/dbt_project"
   branch: "main"
   target: "prod"
+  compile: true # optional; default true
   vars:
     as_of_date: "2026-02-18"
 warehouse:
   type: "databricks"
 ```
+
+`dbt.compile: true` clones the repository, runs `dbt deps`, and runs
+`dbt compile`. Set `dbt.compile: false` only when `dbt.project_dir` already
+points at a compiled dbt project with `target/manifest.json` and the compiled
+SQL files referenced by that manifest; SlideFlow will not clone or invoke dbt in
+that mode.
 
 Optional alias disambiguation fields for `dbt`:
 
@@ -456,6 +463,7 @@ package_url: "https://$GIT_TOKEN@github.com/org/repo.git"
 project_dir: "/tmp/dbt_project"
 branch: "main"
 target: "prod"
+compile: true # optional; default true
 vars:
   as_of_date: "2026-02-18"
 ```

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -283,7 +283,16 @@ SlideFlow caches connector fetches by config identity, which helps when:
 - multiple charts use the same query/file in one run
 - multiple replacements reuse one source
 
+Cached `DataFrame` values are copied on cache write and copied again on cache
+reads. This keeps table formatting, chart transforms, and custom replacements
+from mutating shared cached data. The tradeoff is extra memory and copy time for
+large frames, so prefer selecting only the columns and rows needed for the
+artifact before handing data to SlideFlow.
+
 Treat connectors as read-only sources during a run for predictable results.
+`clear()` and `disable()` also wake in-flight waiters; a waiter will either
+reload against the current cache state or run uncached when the cache has been
+disabled.
 
 Cache/compile tuning env vars:
 

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -173,6 +173,11 @@ Behavior highlights:
 
 - Repositories are cloned under `project_dir/.slideflow_dbt_clones/<key>`.
 - `project_dir` is treated as a workspace root, not a direct clone target.
+- Default `compile: true` runs `dbt deps` and `dbt compile`; dbt packages and
+  macros can execute during that step.
+- `compile: false` never clones and never runs dbt. In that mode,
+  `project_dir` must already be a compiled dbt project containing
+  `target/manifest.json` and the compiled SQL files referenced by the manifest.
 - If `package_url` embeds `$TOKEN_NAME`, that env var must exist at runtime.
 - If `profiles_dir` is provided, SlideFlow copies profiles into the cloned dbt
   workspace and runs dbt with `--profiles-dir <clone_dir>`.
@@ -301,3 +306,5 @@ Cache/compile tuning env vars:
 - dbt model not found: check `model_alias`, `branch`, and `target`.
 - dbt alias ambiguity: add `model_unique_id`, `model_package_name`, or `model_selector_name`.
 - dbt Git clone fails: verify token variable in `package_url` and repo access.
+- dbt `compile:false` fails: ensure `project_dir/target/manifest.json` exists
+  and every selected manifest node has a compiled SQL file on disk.

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -120,9 +120,13 @@ The reusable workflow exposes:
 - `presentation-urls`: comma-separated URLs for `presentation` builds
 - `workbook-urls`: comma-separated URLs for `sheets` builds
 - `artifact-urls`: comma-separated URLs for whichever artifact-kind was built
-- `build-result-json`: JSON summary from `slideflow build --output-json` or `slideflow sheets build --output-json`
-- `validate-result-json`: JSON summary from `slideflow validate --output-json` or `slideflow sheets validate --output-json`
-- `doctor-result-json`: JSON summary from `slideflow doctor --output-json` or `slideflow sheets doctor --output-json`
+- `build-result-json`: redacted, non-sensitive JSON summary from `slideflow build --output-json` or `slideflow sheets build --output-json`
+- `validate-result-json`: redacted, non-sensitive JSON summary from `slideflow validate --output-json` or `slideflow sheets validate --output-json`
+- `doctor-result-json`: redacted, non-sensitive JSON summary from `slideflow doctor --output-json` or `slideflow sheets doctor --output-json`
+
+Reusable workflow JSON outputs are compact summaries. They omit raw params,
+full result rows, check details, workbook/document IDs, and URLs; generated
+links remain available through the dedicated URL outputs.
 
 ```yaml
 jobs:

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -75,6 +75,9 @@ Runtime control note:
 
 - The reusable workflow forwards `threads` and `requests-per-second` to both
   `slideflow build` and `slideflow sheets build`.
+- The reusable workflow `dry-run` input applies only to `artifact-kind:
+  presentation`. It fails fast for `artifact-kind: sheets` because
+  `slideflow sheets build` performs workbook writes and has no dry-run mode.
 - Sheets runs tab writes with bounded parallelism based on `--threads` and tab
   count; requested/applied/supported/effective/workload values are reported in
   build JSON.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,6 +144,10 @@ For provider contract checks (recommended in CI):
 slideflow validate config.yml --provider-contract-check
 ```
 
+Provider contract checks use read-only Google scopes by default. Use
+`--provider-contract-full-auth-fallback` only for environments that explicitly
+accept validation with full build-provider scopes.
+
 To discover built-in chart templates:
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ source .venv/bin/activate
 
 SlideFlow accepts credentials via:
 
-1. `provider.config.credentials` in YAML
+1. `provider.config.credentials` in YAML as a path to an untracked file
 2. `GOOGLE_DOCS_CREDENTIALS` environment variable (for `google_docs`)
 3. `GOOGLE_SHEETS_CREDENTIALS` environment variable (for `google_sheets`)
 4. `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable (shared fallback)
@@ -39,7 +39,7 @@ SlideFlow accepts credentials via:
 Environment credential values support either:
 
 - Path to service-account JSON file
-- Raw JSON string content
+- Raw JSON string content injected by a secret manager or GitHub Secrets
 
 Example:
 
@@ -51,6 +51,8 @@ export GOOGLE_SHEETS_CREDENTIALS=/absolute/path/service-account.json
 
 For production service-account and Shared Drive setup, follow the end-to-end
 guide: [Google Service Accounts & Shared Drives](google-service-accounts-shared-drives.md).
+Do not commit raw service-account JSON, OAuth client secrets, refresh tokens, or
+`.env` files.
 
 ## Create a template deck
 
@@ -73,7 +75,7 @@ You will need:
 provider:
   type: "google_slides"
   config:
-    credentials: "/path/to/credentials.json"
+    credentials: null # set GOOGLE_SLIDEFLOW_CREDENTIALS or use an untracked path
     template_id: "your_template_presentation_id"
 
 presentation:

--- a/docs/google-service-accounts-shared-drives.md
+++ b/docs/google-service-accounts-shared-drives.md
@@ -160,6 +160,11 @@ slideflow doctor --config-file config.yml --strict
 slideflow validate config.yml --provider-contract-check
 ```
 
+Provider contract validation uses read-only Google scopes by default and fails
+closed if that auth path cannot initialize. Pass
+`--provider-contract-full-auth-fallback` only when validation is allowed to use
+the same broad scopes as a build.
+
 ## Troubleshooting Map
 
 | Error / Symptom | Likely Cause | Remediation |

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -69,7 +69,7 @@ Field behavior:
 - `document_folder_id`: destination folder for generated docs.
 - `drive_folder_id`: destination folder for uploaded chart images.
 - `section_marker_prefix` / `section_marker_suffix`: marker token format.
-- `share_with` / `share_role`: post-render sharing.
+- `share_with` / `share_role`: post-render sharing; `share_role` defaults to `reader`.
 - `transfer_ownership_to`: optional ownership handoff target after successful render/share.
 - `transfer_ownership_strict`: if `true`, ownership handoff failure fails the run.
 - `chart_image_sharing_mode`: uploaded chart-image ACL mode:
@@ -113,6 +113,10 @@ Use provider contract checks before build:
 ```bash
 slideflow validate config.yml --provider-contract-check --params-path variants.csv
 ```
+
+Contract checks use read-only Google Docs auth scopes by default. If read-only
+auth initialization fails, validation fails closed unless you explicitly pass
+`--provider-contract-full-auth-fallback`.
 
 Contract checks for `google_docs` validate:
 

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -16,9 +16,11 @@ It reuses `presentation.slides[]` from the core schema:
 2. Create a service account.
 3. Share the template document (and destination Drive folders) with that service account.
 4. Provide credentials via:
-   - `provider.config.credentials` in YAML, or
+   - `provider.config.credentials` in YAML as a path to an untracked file, or
    - `GOOGLE_DOCS_CREDENTIALS`, or
    - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback).
+
+Do not commit raw service-account JSON or `.env` files.
 
 For production Shared Drive setup and service-account bootstrap commands, see
 [Google Service Accounts & Shared Drives](../google-service-accounts-shared-drives.md).
@@ -45,7 +47,7 @@ Rules:
 provider:
   type: "google_docs"
   config:
-    credentials: "/path/to/service-account.json"
+    credentials: null # set GOOGLE_DOCS_CREDENTIALS or use an untracked path
     template_id: "<google_docs_template_id>"
     document_folder_id: "<folder_for_output_docs>"
     drive_folder_id: "<folder_for_chart_images>"

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -52,13 +52,13 @@ provider:
     section_marker_prefix: "{{SECTION:"
     section_marker_suffix: "}}"
     remove_section_markers: false
-    default_chart_width_pt: 300
+    default_chart_width_pt: 480
     share_with:
       - "team@example.com"
     share_role: "reader"
     transfer_ownership_to: "owner@example.com"
     transfer_ownership_strict: false
-    chart_image_sharing_mode: "public" # public | restricted
+    chart_image_sharing_mode: "restricted" # restricted | public
     requests_per_second: 1.0
     strict_cleanup: false
 ```
@@ -73,8 +73,8 @@ Field behavior:
 - `transfer_ownership_to`: optional ownership handoff target after successful render/share.
 - `transfer_ownership_strict`: if `true`, ownership handoff failure fails the run.
 - `chart_image_sharing_mode`: uploaded chart-image ACL mode:
-  - `public` (default): grants `anyone:reader` before insertion.
-  - `restricted`: skips public ACL grant (tighter access; insertion compatibility depends on your Drive permissions model).
+  - `restricted` (default): keeps uploaded Drive files private at rest, grants temporary non-discoverable access for chart insertion, then revokes it.
+  - `public`: keeps `anyone:reader` access after insertion and logs a warning because generated chart images may contain sensitive data.
 - `requests_per_second`: API pacing control.
 - `strict_cleanup`: fail run if chart-image cleanup fails.
 
@@ -152,7 +152,7 @@ presentation:
 - Start with conservative concurrency/rate settings and tune gradually.
 - Keep markers stable after config wiring.
 - Validate with `--provider-contract-check` in CI for template safety.
-- Cleanup logs include deleted/failed chart-image totals and failed file IDs when applicable.
+- Cleanup logs and build-result fields include deleted/failed chart-image totals and failed file IDs when applicable.
 
 Related references:
 

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -83,7 +83,8 @@ Field behavior:
 Current implementation notes:
 
 - `remove_section_markers` runs after render finalization and deletes section-marker tokens.
-- `default_chart_width_pt` is currently reserved and not yet applied at render time.
+- `default_chart_width_pt` defaults to `480`; it is reserved for future inline
+  chart sizing behavior and is not currently applied at render time.
 
 ## Runtime Behavior
 

--- a/docs/providers/google-sheets.md
+++ b/docs/providers/google-sheets.md
@@ -14,9 +14,11 @@ schema with tab-level write definitions and optional AI summary rules.
 3. Share destination Drive folders (and existing target sheet, if reusing one)
    with that service account.
 4. Provide credentials via:
-   - `provider.config.credentials`, or
+   - `provider.config.credentials` as a path to an untracked file, or
    - `GOOGLE_SHEETS_CREDENTIALS`, or
    - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback).
+
+Do not commit raw service-account JSON or `.env` files.
 
 ## Provider Config
 
@@ -24,7 +26,7 @@ schema with tab-level write definitions and optional AI summary rules.
 provider:
   type: "google_sheets"
   config:
-    credentials: "/path/to/service-account.json"
+    credentials: null # set GOOGLE_SHEETS_CREDENTIALS or use an untracked path
     spreadsheet_id: "<existing_sheet_id>"      # optional; reuse instead of create
     drive_folder_id: "<drive_folder_id>"       # optional; move created sheet
     share_with:

--- a/docs/providers/google-sheets.md
+++ b/docs/providers/google-sheets.md
@@ -37,7 +37,7 @@ Field behavior:
 
 - `spreadsheet_id`: if set, writes into an existing spreadsheet.
 - `drive_folder_id`: destination folder for newly created spreadsheets.
-- `share_with` / `share_role`: optional post-build sharing.
+- `share_with` / `share_role`: optional post-build sharing; `share_role` defaults to `reader`.
 - `requests_per_second`: Google API pacing for this build.
   - Can be overridden at runtime via `slideflow sheets build --rps ...`.
 

--- a/docs/providers/google-slides.md
+++ b/docs/providers/google-slides.md
@@ -49,7 +49,7 @@ provider:
     share_role: "reader"
     transfer_ownership_to: "owner@example.com"
     transfer_ownership_strict: false
-    chart_image_sharing_mode: "public" # public | restricted
+    chart_image_sharing_mode: "restricted" # restricted | public
     requests_per_second: 1.0
     strict_cleanup: false
 ```
@@ -67,8 +67,8 @@ Field behavior:
 - `transfer_ownership_to`: optional ownership handoff target after successful render/share.
 - `transfer_ownership_strict`: if `true`, ownership handoff failure fails the run.
 - `chart_image_sharing_mode`: uploaded chart-image ACL mode:
-  - `public` (default): grants `anyone:reader` before insertion.
-  - `restricted`: skips public ACL grant (tighter access; insertion compatibility depends on your Drive permissions model).
+  - `restricted` (default): keeps uploaded Drive files private at rest, grants temporary non-discoverable access for chart insertion, then revokes it.
+  - `public`: keeps `anyone:reader` access after insertion and logs a warning because generated chart images may contain sensitive data.
 - `requests_per_second`: throttles API calls.
 - `strict_cleanup`: if `true`, cleanup failures (chart image trash) fail the render.
 
@@ -92,7 +92,7 @@ After render, SlideFlow attempts to trash those images.
 
 - Default behavior: cleanup issues are logged but do not fail the run.
 - With `strict_cleanup: true`: cleanup failure raises an error and fails the run.
-- Cleanup now emits a summary log with deleted/failed counts and failed file IDs when applicable.
+- Cleanup emits a summary log and build-result fields with deleted/failed counts and failed file IDs when applicable.
 
 ## Citation Rendering
 

--- a/docs/providers/google-slides.md
+++ b/docs/providers/google-slides.md
@@ -63,7 +63,7 @@ Field behavior:
 - `drive_folder_id`: destination folder for uploaded chart images.
   - If omitted, SlideFlow falls back to the presentation destination folder logic.
 - `new_folder_name` + `new_folder_name_fn`: optional dynamic subfolder under `presentation_folder_id`.
-- `share_with` + `share_role`: shares the rendered deck after generation.
+- `share_with` + `share_role`: shares the rendered deck after generation; `share_role` defaults to `reader`.
 - `transfer_ownership_to`: optional ownership handoff target after successful render/share.
 - `transfer_ownership_strict`: if `true`, ownership handoff failure fails the run.
 - `chart_image_sharing_mode`: uploaded chart-image ACL mode:
@@ -77,13 +77,25 @@ Field behavior:
 Sharing is performed by the service account, not your personal user.
 
 - Ensure the service account has permission to share files in the target drive/folder.
-- `share_role` supports `reader`, `writer`, and `commenter`.
+- `share_role` supports `reader`, `writer`, and `commenter`; omit it for least-privilege reader access and set `writer` only when recipients must edit.
 - Google may send notification emails when sharing is executed.
 - Ownership transfer is explicit opt-in and only works for files in **My Drive** (not Shared Drives).
 - Transfer uses Google Drive ownership APIs and may notify the target owner.
 
 For Shared Drive-first permission patterns and ownership-transfer constraints,
 see [Google Service Accounts & Shared Drives](../google-service-accounts-shared-drives.md).
+
+## Contract Validation
+
+Use provider contract checks before build:
+
+```bash
+slideflow validate config.yml --provider-contract-check --params-path variants.csv
+```
+
+Contract checks use read-only Google Slides auth scopes by default. If read-only
+auth initialization fails, validation fails closed unless you explicitly pass
+`--provider-contract-full-auth-fallback`.
 
 ## Cleanup Semantics
 

--- a/docs/providers/google-slides.md
+++ b/docs/providers/google-slides.md
@@ -11,8 +11,10 @@ It can create a blank deck or copy a template, insert chart images, run text/tab
 2. Create a service account.
 3. Share the template deck (and destination Drive folder) with that service account email.
 4. Supply credentials via either:
-   - `provider.config.credentials` in YAML (file path or raw JSON), or
+   - `provider.config.credentials` in YAML as a path to an untracked file, or
    - `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable.
+
+Do not commit raw service-account JSON or `.env` files.
 
 For production Shared Drive setup and command-by-command service-account
 bootstrap, see [Google Service Accounts & Shared Drives](../google-service-accounts-shared-drives.md).
@@ -38,7 +40,7 @@ Use that object ID in `presentation.slides[].id`.
 provider:
   type: "google_slides"
   config:
-    credentials: "/path/to/service-account.json"
+    credentials: null # set GOOGLE_SLIDEFLOW_CREDENTIALS or use an untracked path
     template_id: "<template_presentation_id>"
     presentation_folder_id: "<folder_for_output_decks>"
     drive_folder_id: "<folder_for_chart_images>"

--- a/docs/quickstart/config.yml
+++ b/docs/quickstart/config.yml
@@ -4,7 +4,7 @@ provider:
     credentials: "/path/to/your/credentials.json"
     template_id: "your_google_slides_template_id"
     share_with: ["your_email@email.com"]
-    share_role: "writer"
+    share_role: "reader"
 
 presentation:
   name: "Quickstart Presentation"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -114,6 +114,14 @@ uv run mkdocs build --strict
 8. Push and monitor `CI`, `Docs`, and `Release` workflows.
 9. After release completion, merge the release result back to `master` and verify
    `git merge-base --is-ancestor vX.Y.Z master`.
+10. For release or hardening PRs that update vulnerable dependencies, record
+    which Dependabot PRs are superseded or merged, then verify after the
+    default-branch merge that the related Dependabot alerts are fixed.
+
+```bash
+gh api '/repos/OWNER/REPO/dependabot/alerts?state=open' --paginate
+gh pr list --author app/dependabot --state open
+```
 
 ## PyPI trusted publishing setup
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -111,7 +111,10 @@ uv run mkdocs build --strict
 5. Bump versions in `pyproject.toml` and `slideflow/__init__.py`.
 6. Ensure `CHANGELOG.md` has the matching released header.
 7. Create release branch `release/vX.Y.Z`.
-8. Push and monitor `CI`, `Docs`, and `Release` workflows.
+8. Push and monitor the `Release` workflow plus any branch CI/Audit checks. The
+   `Release` workflow runs its own strict docs build; the standalone `Docs`
+   workflow builds docs on docs-related PRs and deploys only after pushes to
+   `master`/`main`.
 9. After release completion, merge the release result back to `master` and verify
    `git merge-base --is-ancestor vX.Y.Z master`.
 10. For release or hardening PRs that update vulnerable dependencies, record

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,25 +10,60 @@ Example:
 
 - `release/vX.Y.Z`
 
+## Post-release master policy
+
+After a release completes, `master` tracks the latest released version metadata
+until the next release branch is prepared. Unreleased work stays under the
+`[Unreleased]` changelog section, while `pyproject.toml`,
+`slideflow/__init__.py`, `uv.lock`, and the latest released changelog header all
+continue to agree on the last published version.
+
+Release tags must remain ancestors of `master` after release completion. If a
+tag was created on a side branch, reconcile by merging the tag side back into
+`master`; do not move a published tag unless the package has not been published
+and the correction is explicitly approved.
+
 ## Automated release flow
 
 On push to a `release/vX.Y.Z` branch, the `Release` workflow:
 
 1. validates branch naming
-2. validates project version consistency
-3. validates NumPy/Pandas ABI compatibility
-4. runs release test suite + coverage gate
-5. builds wheel and source distributions
-6. installs built wheel and runs quickstart smoke validation (`validate` + `build --dry-run`)
+2. blocks publishing on workflow lint, full CI-style tests, optional connector
+   tests, docs build, dependency audit, and live Google validation evidence for
+   the same commit
+3. validates project version consistency
+4. builds wheel and source distributions
+5. installs built wheel and runs package smoke validation:
+   - `twine check`
+   - `pip check`
+   - CLI entrypoint import/help
+   - packaged built-in template discovery and render
+   - quickstart `validate` + `build --dry-run`
+6. creates and pushes Git tag `vX.Y.Z`
 7. publishes package to PyPI (OIDC trusted publishing)
-8. creates and pushes Git tag `vX.Y.Z`
-9. creates GitHub release with artifacts
+8. creates GitHub release with artifacts
+
+The protected `google-live-validation` environment must define these variables
+with successful GitHub Actions run IDs for the current release commit:
+
+- `SLIDEFLOW_LIVE_GOOGLE_SLIDES_RUN_ID`
+- `SLIDEFLOW_LIVE_GOOGLE_DOCS_RUN_ID`
+- `SLIDEFLOW_LIVE_GOOGLE_SHEETS_RUN_ID`
+
+The release workflow verifies each run through the GitHub API and requires the
+run to be completed, successful, from the matching live workflow file, and bound
+to the current `GITHUB_SHA`. Configure required reviewers on the environment so
+a human verifies the evidence before publishing can continue.
 
 Idempotency behavior:
 
 - If the same version is already published on PyPI, publish is skipped.
-- If tag/release already exist, those steps are skipped.
-- This keeps reruns green when a release branch receives a follow-up docs/metadata commit.
+- If tag/release already exist on the same artifact-producing commit, those
+  steps are skipped.
+- If the PyPI version already exists but the matching tag is missing, or if the
+  tag points at any commit other than the current workflow commit, the workflow
+  fails. Follow-up commits on a release branch must not silently reuse an
+  existing package version or tag.
 
 ## Version consistency contract
 
@@ -36,6 +71,7 @@ These must match:
 
 - `pyproject.toml` -> `[project].version`
 - `slideflow/__init__.py` -> `__version__`
+- latest released `CHANGELOG.md` header
 - release branch suffix -> `release/vX.Y.Z`
 
 PyPI package identity:
@@ -73,8 +109,11 @@ uv run mkdocs build --strict
    - `uv.lock` is current for the release branch
 
 5. Bump versions in `pyproject.toml` and `slideflow/__init__.py`.
-6. Create release branch `release/vX.Y.Z`.
-7. Push and monitor `CI`, `Docs`, and `Release` workflows.
+6. Ensure `CHANGELOG.md` has the matching released header.
+7. Create release branch `release/vX.Y.Z`.
+8. Push and monitor `CI`, `Docs`, and `Release` workflows.
+9. After release completion, merge the release result back to `master` and verify
+   `git merge-base --is-ancestor vX.Y.Z master`.
 
 ## PyPI trusted publishing setup
 
@@ -85,8 +124,12 @@ uv run mkdocs build --strict
 
 ## Rollback guidance
 
-If release publish fails after tag creation:
+If release publish fails after tag creation before PyPI publication:
 
 1. fix issue in a new commit on release branch
 2. re-run workflow (or push follow-up commit)
-3. if needed, delete bad tag and recreate only when corrected artifacts are ready
+3. if explicitly approved, delete the bad tag and recreate only when corrected
+   artifacts are ready
+
+If PyPI publication succeeded, do not move the tag. Publish a corrective release
+with a new version and document the incident.

--- a/docs/security.md
+++ b/docs/security.md
@@ -112,6 +112,28 @@ Audit enforcement policy:
 - Static Bandit findings remain advisory while existing low-signal findings are
   triaged and converted into explicit suppressions or code changes.
 
+Default-branch dependency alert closure:
+
+- Treat the locked all-extras `pip-audit` result as the branch-side proof that a
+  dependency vulnerability is fixed.
+- GitHub Dependabot alerts are considered closed only after the patched
+  `uv.lock` reaches the default branch and GitHub reports the alert fixed.
+- Before merging a security or hardening PR, list the open Dependabot alerts and
+  dependency PRs it supersedes, merges, or intentionally leaves open.
+- After the merge, re-check open Dependabot alerts and close superseded
+  Dependabot PRs with a comment that points at the fixing PR.
+- If any alert remains open after the default-branch merge, keep a follow-up
+  issue with the alert IDs, affected package, manifest, patched version, and
+  remaining action.
+
+Useful checks:
+
+```bash
+uv run pip-audit --progress-spinner off
+gh api '/repos/OWNER/REPO/dependabot/alerts?state=open' --paginate
+gh pr list --author app/dependabot --state open
+```
+
 Action pinning policy:
 
 - GitHub-maintained actions are version-pinned by major (`@vN`) and updated

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,6 +55,13 @@ https://$DBT_GIT_TOKEN@github.com/org/dbt-project.git
 
 Set `DBT_GIT_TOKEN` in environment, not in YAML.
 
+With the default `compile: true`, dbt sources clone the configured repository,
+run `dbt deps`, and run `dbt compile`; dbt package code and macros may execute
+during that phase. Use trusted dbt repositories/packages and least-privilege
+CI secrets. Set `compile: false` only for precompiled local projects with
+`target/manifest.json` and compiled SQL files already present; that mode does
+not clone or invoke dbt.
+
 ## Logging hygiene
 
 - Do not print raw credential payloads.

--- a/docs/security.md
+++ b/docs/security.md
@@ -37,6 +37,15 @@ Google Sheets provider scopes:
 - `https://www.googleapis.com/auth/drive`
 - `https://www.googleapis.com/auth/drive.file`
 
+Provider contract validation scopes:
+
+- `slideflow validate --provider-contract-check` for `google_slides` uses
+  `https://www.googleapis.com/auth/presentations.readonly`
+- `slideflow validate --provider-contract-check` for `google_docs` uses
+  `https://www.googleapis.com/auth/documents.readonly`
+- Validation does not fall back to the broader build-provider scopes unless
+  `--provider-contract-full-auth-fallback` is passed explicitly.
+
 ## Databricks auth
 
 Databricks connectors require:

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,7 +15,38 @@ Credential value can be:
 - Path to service-account JSON
 - Raw JSON payload
 
-Recommended: use environment variables in CI and avoid storing secrets in repo files.
+Recommended: use environment variables in CI and avoid storing secrets in repo
+files. If you use raw JSON, inject it through a secret manager or GitHub
+Secrets-backed environment variable; do not paste it into checked-in YAML.
+
+## Credential hygiene policy
+
+Do:
+
+- Store Google service-account JSON, OAuth client secrets, refresh tokens,
+  Databricks tokens, OpenAI/Gemini keys, dbt Git tokens, and BigQuery credential
+  JSON in GitHub Secrets, a platform secret manager, or an untracked local file.
+- Prefer `provider.config.credentials` as a path to an untracked local file for
+  local work, and prefer provider environment variables in CI.
+- Keep generated build JSON, doctor output, and live-test artifacts out of
+  public issue comments unless they have been reviewed for sensitive IDs.
+- Rotate credentials periodically and after any suspected exposure.
+
+Do not:
+
+- Commit `.env` files, `client_secret*.json`, service-account JSON,
+  refresh-token exports, private keys, or raw credential JSON in YAML.
+- Put long-lived credentials in examples, docs, screenshots, or generated
+  artifacts.
+- Share generated chart images publicly unless `chart_image_sharing_mode:
+  public` is an explicit, reviewed exception.
+
+Local and CI checks:
+
+```bash
+uv run python scripts/ci/check_secret_hygiene.py
+uv run pre-commit run detect-secrets --all-files
+```
 
 ## Required scopes
 
@@ -105,6 +136,22 @@ The repository includes a dedicated `Audit` workflow that runs:
 
 Both reports are uploaded as artifacts for triage.
 
+The main `CI` and `Release` workflows also run pre-commit, which includes:
+
+- `scripts/ci/check_secret_hygiene.py` for SlideFlow-specific credential file
+  names and token shapes
+- `detect-secrets` for private keys, high-entropy strings, and provider tokens
+
+Repository controls:
+
+- GitHub secret scanning: enabled
+- GitHub secret scanning push protection: enabled
+- GitHub secret scanning non-provider patterns: disabled
+- GitHub secret scanning validity checks: disabled
+
+Keep `check_secret_hygiene.py` and `detect-secrets` as local/CI controls for
+credential classes not covered by repository-level secret scanning.
+
 Audit enforcement policy:
 
 - Dependency vulnerabilities are blocking for pull requests, pushes, schedules,
@@ -154,10 +201,23 @@ Use OIDC trusted publishing instead of API tokens.
 3. Add required reviewers for release protection if needed.
 4. Keep `id-token: write` enabled in release workflow permissions.
 
+## Secret incident handling
+
+1. Revoke or rotate the exposed credential at the provider first.
+2. Remove the secret from the working tree and from generated artifacts.
+3. If the secret reached Git history, coordinate history purging and force-push
+   only after maintainers approve the repository impact.
+4. Open a private advisory or security issue with affected provider, scope,
+   exposure window, rotation evidence, and follow-up owner.
+5. Re-run local checks, pre-commit, and GitHub secret-scanning alerts; keep the
+   issue open until alerts are closed or explicitly dismissed with rationale.
+
 ## Hardening checklist
 
 - [ ] Secrets only via environment or secret manager
 - [ ] No credentials committed to Git
+- [ ] GitHub secret scanning and push protection enabled
+- [ ] `scripts/ci/check_secret_hygiene.py` and `detect-secrets` passing
 - [ ] Pre-commit hooks installed and passing (`uv run pre-commit run --all-files`)
 - [ ] `slideflow validate` enforced in CI before build/release
 - [ ] Audit workflow reviewed weekly

--- a/docs/security.md
+++ b/docs/security.md
@@ -77,17 +77,18 @@ when `--registry` or `registry:` config paths are provided.
 
 The repository includes a dedicated `Audit` workflow that runs:
 
-- dependency audit (`pip-audit`)
+- dependency audit (`pip-audit`) from a locked environment that includes the
+  supported optional connector extras
 - static security scan (`bandit`)
 
 Both reports are uploaded as artifacts for triage.
 
 Audit enforcement policy:
 
-- Audit findings are advisory for all events (pull requests, pushes, schedules).
-- Findings are surfaced as warnings and uploaded artifacts for triage follow-up.
-- Audit workflow is intentionally non-blocking until baseline findings are
-  reduced and a blocking threshold policy is adopted.
+- Dependency vulnerabilities are blocking for pull requests, pushes, schedules,
+  and manual runs.
+- Static Bandit findings remain advisory while existing low-signal findings are
+  triaged and converted into explicit suppressions or code changes.
 
 Action pinning policy:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -60,6 +60,12 @@ Set `DBT_GIT_TOKEN` in environment, not in YAML.
 - Do not print raw credential payloads.
 - Keep logs at `INFO` or lower in production.
 - Use `--debug` only for short-lived troubleshooting sessions.
+- CLI error rendering, machine-readable JSON output, and reusable workflow JSON
+  outputs share centralized redaction for common secret fields, authorization
+  headers, bearer/basic tokens, URL userinfo, and sensitive URL query
+  parameters.
+- `slideflow build --output-json` does not emit batch params by default. Workflow
+  JSON outputs publish compact summaries instead of full local result JSON.
 - Built-in networked providers/connectors include a `Slideflow` client
   identifier where SDK/API support exists, improving service-side auditability.
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -66,6 +66,17 @@ Template resolution is deterministic and non-breaking:
 If the same template name exists in multiple locations, earlier paths win. This
 means local/project templates override packaged built-ins.
 
+`template_paths` are scoped to the individual build. Concurrent builds can use
+different template directories with the same template names without changing
+process-global template state. Template charts and custom chart functions that
+call `get_template_engine()` during rendering see the active build-scoped
+engine. The global template engine is retained for direct template inspection
+APIs such as `slideflow templates ...` outside a build render.
+
+Each build-scoped engine has its own in-memory template cache. Long-running
+services that render many presentations trade a small amount of repeated
+template parsing for isolation between concurrent builds.
+
 ## Names and categories
 
 Built-ins are organized in category folders (for example `bars/bar_basic`). You can

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,6 +87,9 @@ Fixes:
 
 - set `dbt.profiles_dir` in your `dbt` source config (or `profiles_dir` in legacy `databricks_dbt`), or
 - ensure `profiles.yml` exists at the dbt project root in the cloned repo.
+- if using `compile: false`, run `dbt deps` and `dbt compile` before SlideFlow
+  and point `project_dir` at that compiled project; SlideFlow expects
+  `target/manifest.json` and the selected node's compiled SQL file to exist.
 
 For private dbt deps/repo access, ensure token env vars referenced by
 `package_url` or `env_var(...)` are present at runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slideflow-presentations"
-version = "0.0.6"
+version = "0.0.7"
 description = "Automated Google Slides, Docs, and Sheets builder with charts, data replacements, and workbook automation."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "hypothesis",
     "ruff",
     "mypy",
+    "pip-audit",
     "pre-commit",
     "pandas-stubs",
     "types-PyYAML",

--- a/scripts/ci/check_live_validation_evidence.py
+++ b/scripts/ci/check_live_validation_evidence.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Validate protected live Google workflow evidence for a release commit."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from typing import Any
+
+EXPECTED_WORKFLOWS = {
+    "slides": ".github/workflows/live-google-slides.yml",
+    "docs": ".github/workflows/live-google-docs.yml",
+    "sheets": ".github/workflows/live-google-sheets.yml",
+}
+
+
+def _fetch_workflow_run(
+    *,
+    api_base: str,
+    repository: str,
+    run_id: str,
+    token: str | None,
+) -> dict[str, Any]:
+    request = urllib.request.Request(
+        f"{api_base.rstrip('/')}/repos/{repository}/actions/runs/{run_id}",
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+
+    with urllib.request.urlopen(request, timeout=15) as response:
+        payload = response.read().decode("utf-8")
+
+    import json
+
+    data = json.loads(payload)
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Workflow run {run_id} response was not an object")
+    return data
+
+
+def _validate_run_payload(
+    *,
+    run_name: str,
+    expected_sha: str,
+    expected_workflow_path: str,
+    payload: Mapping[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+
+    if payload.get("head_sha") != expected_sha:
+        errors.append(
+            f"{run_name} run SHA mismatch: "
+            f"head_sha={payload.get('head_sha')!r} expected={expected_sha!r}"
+        )
+
+    if payload.get("status") != "completed":
+        errors.append(f"{run_name} run is not completed: {payload.get('status')!r}")
+
+    if payload.get("conclusion") != "success":
+        errors.append(f"{run_name} run did not succeed: {payload.get('conclusion')!r}")
+
+    if payload.get("path") != expected_workflow_path:
+        errors.append(
+            f"{run_name} workflow mismatch: "
+            f"path={payload.get('path')!r} expected={expected_workflow_path!r}"
+        )
+
+    if not payload.get("html_url"):
+        errors.append(f"{run_name} run response is missing html_url")
+
+    return errors
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--expected-sha", default=os.environ.get("GITHUB_SHA", ""))
+    parser.add_argument("--github-token", default=os.environ.get("GITHUB_TOKEN"))
+    parser.add_argument("--api-base", default="https://api.github.com")
+    parser.add_argument("--slides-run-id", required=True)
+    parser.add_argument("--docs-run-id", required=True)
+    parser.add_argument("--sheets-run-id", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.repository:
+        parser.error("--repository or GITHUB_REPOSITORY is required")
+    if not args.expected_sha:
+        parser.error("--expected-sha or GITHUB_SHA is required")
+
+    run_ids = {
+        "slides": args.slides_run_id,
+        "docs": args.docs_run_id,
+        "sheets": args.sheets_run_id,
+    }
+
+    errors: list[str] = []
+    validated_urls: list[str] = []
+
+    for run_name, run_id in run_ids.items():
+        try:
+            payload = _fetch_workflow_run(
+                api_base=args.api_base,
+                repository=args.repository,
+                run_id=run_id,
+                token=args.github_token,
+            )
+        except (RuntimeError, urllib.error.URLError) as error:
+            errors.append(f"{run_name} run {run_id} could not be fetched: {error}")
+            continue
+
+        errors.extend(
+            _validate_run_payload(
+                run_name=run_name,
+                expected_sha=args.expected_sha,
+                expected_workflow_path=EXPECTED_WORKFLOWS[run_name],
+                payload=payload,
+            )
+        )
+        if payload.get("html_url"):
+            validated_urls.append(str(payload["html_url"]))
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+
+    print("Live Google validation evidence passed for current release SHA:")
+    for url in validated_urls:
+        print(f"- {url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_release_artifact_state.py
+++ b/scripts/ci/check_release_artifact_state.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Validate release artifact state before publishing or reusing a release."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_PACKAGE_NAME = "slideflow-presentations"
+
+
+def _url_exists(url: str, headers: dict[str, str] | None = None) -> bool:
+    request = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            return response.status == 200
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return False
+        raise
+
+
+def _run_git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _resolve_commitish(commitish: str) -> str:
+    result = _run_git("rev-parse", "--verify", f"{commitish}^{{commit}}")
+    if result.returncode != 0:
+        raise RuntimeError(f"Unable to resolve expected commit {commitish!r}")
+    return result.stdout.strip()
+
+
+def _tag_commit(tag: str) -> str | None:
+    result = _run_git("rev-parse", "--verify", "--quiet", f"refs/tags/{tag}^{{commit}}")
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _parse_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected 'true' or 'false'")
+
+
+def _pypi_version_exists(
+    *,
+    package_name: str,
+    version: str,
+    override: bool | None,
+) -> bool:
+    if override is not None:
+        return override
+    return _url_exists(f"https://pypi.org/pypi/{package_name}/{version}/json")
+
+
+def _github_release_exists(
+    *,
+    repository: str,
+    tag: str,
+    token: str | None,
+    override: bool | None,
+) -> bool:
+    if override is not None:
+        return override
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return _url_exists(
+        f"https://api.github.com/repos/{repository}/releases/tags/{tag}",
+        headers=headers,
+    )
+
+
+def _write_github_outputs(
+    *,
+    output_file: Path | None,
+    package_exists: bool,
+    tag_exists: bool,
+    release_exists: bool,
+    tag_sha: str | None,
+) -> None:
+    if output_file is None:
+        return
+
+    lines = [
+        f"package_exists={str(package_exists).lower()}",
+        f"tag_exists={str(tag_exists).lower()}",
+        f"release_exists={str(release_exists).lower()}",
+    ]
+    if tag_sha is not None:
+        lines.append(f"tag_sha={tag_sha}")
+
+    with output_file.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+        handle.write("\n")
+
+
+def _validate_release_state(
+    *,
+    version: str,
+    tag: str,
+    expected_commit: str,
+    package_exists: bool,
+    tag_sha: str | None,
+) -> list[str]:
+    errors: list[str] = []
+
+    if tag_sha is not None and tag_sha != expected_commit:
+        errors.append(
+            f"Release tag {tag} points at {tag_sha}, "
+            f"but expected artifact-producing commit {expected_commit}."
+        )
+
+    if package_exists and tag_sha is None:
+        errors.append(
+            f"PyPI version {version} already exists, but matching tag {tag} is missing."
+        )
+
+    return errors
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--github-token", default=os.environ.get("GITHUB_TOKEN"))
+    parser.add_argument("--package-name", default=DEFAULT_PACKAGE_NAME)
+    parser.add_argument("--output-file", default=os.environ.get("GITHUB_OUTPUT"))
+    parser.add_argument("--package-exists-override", type=_parse_bool)
+    parser.add_argument("--release-exists-override", type=_parse_bool)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.repository and args.release_exists_override is None:
+        parser.error("--repository is required unless --release-exists-override is set")
+
+    tag = f"v{args.version}"
+    output_file = Path(args.output_file) if args.output_file else None
+
+    try:
+        expected_commit = _resolve_commitish(args.expected_commit)
+        package_exists = _pypi_version_exists(
+            package_name=args.package_name,
+            version=args.version,
+            override=args.package_exists_override,
+        )
+        tag_sha = _tag_commit(tag)
+        release_exists = _github_release_exists(
+            repository=args.repository,
+            tag=tag,
+            token=args.github_token,
+            override=args.release_exists_override,
+        )
+    except (RuntimeError, urllib.error.URLError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    _write_github_outputs(
+        output_file=output_file,
+        package_exists=package_exists,
+        tag_exists=tag_sha is not None,
+        release_exists=release_exists,
+        tag_sha=tag_sha,
+    )
+
+    errors = _validate_release_state(
+        version=args.version,
+        tag=tag,
+        expected_commit=expected_commit,
+        package_exists=package_exists,
+        tag_sha=tag_sha,
+    )
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+
+    print(
+        "Release artifact state validated: "
+        f"version={args.version}, "
+        f"package_exists={str(package_exists).lower()}, "
+        f"tag_exists={str(tag_sha is not None).lower()}, "
+        f"release_exists={str(release_exists).lower()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_secret_hygiene.py
+++ b/scripts/ci/check_secret_hygiene.py
@@ -1,0 +1,226 @@
+"""Reject tracked credentials that generic high-entropy scanners may miss."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+SECRET_FILENAME_PATTERNS = (
+    ".env",
+    ".env.*",
+    "sa.json",
+    "*credential*.json",
+    "*credentials*.json",
+    "client_secret*.json",
+    "*client-secret*.json",
+    "*refresh-token*.json",
+    "*.pem",
+    "*.key",
+    "*.p12",
+    "*.pfx",
+    "*.der",
+)
+
+TOKEN_PATTERNS = (
+    ("private key block", re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")),
+    ("Google OAuth token", re.compile(r"\bya29\.[A-Za-z0-9._-]{20,}\b")),
+    ("Google OAuth refresh token", re.compile(r"\b1//[A-Za-z0-9._-]{20,}\b")),
+    (
+        "Google OAuth client secret",
+        re.compile(r"\bGOCSPX-[A-Za-z0-9_-]{20,}\b"),
+    ),
+    (
+        "GitHub token",
+        re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}\b"),
+    ),
+    ("GitHub fine-grained token", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")),
+    ("OpenAI API key", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b")),
+    ("PyPI API token", re.compile(r"\bpypi-[A-Za-z0-9_-]{20,}\b")),
+    (
+        "SendGrid API key",
+        re.compile(r"\bSG\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+    ),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
+)
+
+SENSITIVE_ASSIGNMENT_SUFFIXES = (
+    ".cfg",
+    ".env",
+    ".ini",
+    ".json",
+    ".toml",
+    ".yaml",
+    ".yml",
+)
+
+SENSITIVE_ASSIGNMENT = re.compile(
+    r"""
+    (?P<key>
+        client_secret
+        |refresh_token
+        |private_key
+        |access_token
+        |api_key
+        |openai_api_key
+        |gemini_api_key
+        |databricks_access_token
+    )
+    ["']?\s*[:=]\s*
+    (?P<quote>["'])
+    (?P<value>[^"'\n]{8,})
+    (?P=quote)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+PLACEHOLDER_VALUES = {
+    "abc",
+    "def",
+    "example",
+    "fake",
+    "placeholder",
+    "provider-token",
+    "raw-token",
+    "redacted",
+    "secret",
+    "secret-value",
+    "test",
+    "token",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    reason: str
+    line_number: int | None = None
+
+    def format(self, root: Path) -> str:
+        display_path = self.path.relative_to(root)
+        if self.line_number is None:
+            return f"{display_path}: {self.reason}"
+        return f"{display_path}:{self.line_number}: {self.reason}"
+
+
+def _git_scanned_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    return [
+        root / filename.decode() for filename in result.stdout.split(b"\0") if filename
+    ]
+
+
+def _is_placeholder(value: str) -> bool:
+    normalized = value.strip().strip("'\"").lower()
+    if normalized in PLACEHOLDER_VALUES:
+        return True
+    if normalized.startswith(("<", "${", "$")):
+        return True
+    if normalized.startswith(("/path/", "/absolute/path")):
+        return True
+    return any(token in normalized for token in ("example", "fake", "dummy"))
+
+
+def _matches_secret_filename(path: Path) -> bool:
+    name = path.name
+    return any(fnmatch.fnmatch(name, pattern) for pattern in SECRET_FILENAME_PATTERNS)
+
+
+def _should_scan_sensitive_assignments(path: Path) -> bool:
+    return (
+        path.name.startswith(".env")
+        or path.suffix.lower() in SENSITIVE_ASSIGNMENT_SUFFIXES
+    )
+
+
+def scan_paths(paths: list[Path], root: Path = ROOT) -> list[Finding]:
+    findings: list[Finding] = []
+
+    for path in paths:
+        if not path.exists() or not path.is_file():
+            continue
+
+        if _matches_secret_filename(path):
+            findings.append(
+                Finding(
+                    path=path,
+                    reason="tracked credential/key filename; keep this untracked or in a secret manager",
+                )
+            )
+
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            for reason, pattern in TOKEN_PATTERNS:
+                if pattern.search(line):
+                    findings.append(
+                        Finding(path=path, line_number=line_number, reason=reason)
+                    )
+
+            if not _should_scan_sensitive_assignments(path):
+                continue
+
+            for match in SENSITIVE_ASSIGNMENT.finditer(line):
+                value = match.group("value")
+                if not _is_placeholder(value):
+                    key = match.group("key")
+                    findings.append(
+                        Finding(
+                            path=path,
+                            line_number=line_number,
+                            reason=f"non-placeholder value assigned to {key}",
+                        )
+                    )
+
+    return findings
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reject tracked credentials and high-risk secret literals."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files to scan. Defaults to all git-tracked files.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    root = ROOT
+    paths = (
+        [root / path for path in args.paths] if args.paths else _git_scanned_files(root)
+    )
+    findings = scan_paths(paths, root=root)
+
+    if not findings:
+        print("Secret hygiene check passed.")
+        return 0
+
+    print("Secret hygiene check failed:")
+    for finding in findings:
+        print(f"- {finding.format(root)}")
+    print(
+        "\nMove real credentials to environment variables, GitHub Secrets, or a secret manager."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_version_consistency.py
+++ b/scripts/ci/check_version_consistency.py
@@ -4,6 +4,7 @@
 Checks:
 - pyproject.toml `[project].version`
 - slideflow.__version__
+- Latest released CHANGELOG.md header
 - Optional release branch version (release/vX.Y.Z)
 """
 
@@ -17,6 +18,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT_PATH = ROOT / "pyproject.toml"
 INIT_PATH = ROOT / "slideflow" / "__init__.py"
+CHANGELOG_PATH = ROOT / "CHANGELOG.md"
 
 
 def _read_pyproject_version() -> str:
@@ -38,32 +40,72 @@ def _read_package_version() -> str:
     return match.group(1)
 
 
+def _read_latest_changelog_release_version() -> str:
+    for line in CHANGELOG_PATH.read_text().splitlines():
+        match = re.fullmatch(
+            r"## \[(\d+\.\d+\.\d+)\] - \d{4}-\d{2}-\d{2}",
+            line.strip(),
+        )
+        if match:
+            return match.group(1)
+    raise RuntimeError("CHANGELOG.md is missing a released version header")
+
+
 def _parse_release_branch_version(branch: str) -> str | None:
     match = re.fullmatch(r"release/v(\d+\.\d+\.\d+)", branch)
     return match.group(1) if match else None
 
 
-def main() -> int:
-    pyproject_version = _read_pyproject_version()
-    package_version = _read_package_version()
+def _collect_version_errors(
+    *,
+    pyproject_version: str,
+    package_version: str,
+    changelog_version: str,
+    release_version: str | None,
+) -> list[str]:
+    errors: list[str] = []
 
     if pyproject_version != package_version:
-        print(
+        errors.append(
             "Version mismatch: "
-            f"pyproject.toml={pyproject_version} vs slideflow/__init__.py={package_version}",
-            file=sys.stderr,
+            f"pyproject.toml={pyproject_version} vs slideflow/__init__.py={package_version}"
         )
+
+    if changelog_version != pyproject_version:
+        errors.append(
+            "Changelog latest release mismatch: "
+            f"CHANGELOG.md={changelog_version} vs project={pyproject_version}"
+        )
+
+    if release_version and release_version != pyproject_version:
+        errors.append(
+            "Release branch version mismatch: "
+            f"branch={release_version} vs project={pyproject_version}"
+        )
+
+    return errors
+
+
+def main() -> int:
+    try:
+        pyproject_version = _read_pyproject_version()
+        package_version = _read_package_version()
+        changelog_version = _read_latest_changelog_release_version()
+    except RuntimeError as error:
+        print(str(error), file=sys.stderr)
         return 1
 
     branch = sys.argv[1] if len(sys.argv) > 1 else ""
     release_version = _parse_release_branch_version(branch) if branch else None
 
-    if release_version and release_version != pyproject_version:
-        print(
-            "Release branch version mismatch: "
-            f"branch={release_version} vs project={pyproject_version}",
-            file=sys.stderr,
-        )
+    errors = _collect_version_errors(
+        pyproject_version=pyproject_version,
+        package_version=package_version,
+        changelog_version=changelog_version,
+        release_version=release_version,
+    )
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
         return 1
 
     print(f"Version checks passed ({pyproject_version})")

--- a/scripts/ci/smoke_installed_wheel.sh
+++ b/scripts/ci/smoke_installed_wheel.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIST_DIR="${1:-dist}"
+SMOKE_DIR="${2:-docs/quickstart/smoke}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DIST_PATH="$(cd "${DIST_DIR}" && pwd)"
+SMOKE_PATH="$(cd "${SMOKE_DIR}" && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+python -m twine check "${DIST_PATH}"/*
+python -m pip check
+
+slideflow --help >/dev/null
+templates_output="$(slideflow templates list)"
+grep -q "bars/bar_basic" <<<"${templates_output}"
+template_info="$(slideflow templates info bars/bar_basic)"
+grep -q "name: Bar Basic" <<<"${template_info}"
+
+pushd "${TMP_DIR}" >/dev/null
+python - <<'PY'
+from importlib import resources
+
+templates_root = resources.files("slideflow").joinpath("templates")
+bar_template = templates_root.joinpath("bars", "bar_basic.yml")
+if not bar_template.is_file():
+    raise SystemExit(f"Packaged template not found: {bar_template}")
+
+from slideflow.builtins.template_engine import get_template_engine
+
+engine = get_template_engine()
+template_names = engine.list_templates()
+if "bars/bar_basic" not in template_names:
+    raise SystemExit(f"bars/bar_basic missing from template catalog: {template_names}")
+
+rendered = engine.render_template(
+    "bars/bar_basic",
+    {
+        "title": "Smoke",
+        "x_column": "region",
+        "y_column": "revenue",
+    },
+)
+if rendered["traces"][0]["type"] != "bar":
+    raise SystemExit(f"Unexpected rendered template payload: {rendered}")
+
+print("Installed wheel template resource smoke passed.")
+PY
+popd >/dev/null
+
+bash "${REPO_ROOT}/scripts/ci/run_quickstart_smoke.sh" "${SMOKE_PATH}"

--- a/slideflow/__init__.py
+++ b/slideflow/__init__.py
@@ -88,7 +88,7 @@ Integration Features:
     - CLI interface for automation and scripting
 """
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 # AI providers
 from slideflow.ai import AIProvider, DatabricksProvider, GeminiProvider, OpenAIProvider

--- a/slideflow/builtins/template_engine.py
+++ b/slideflow/builtins/template_engine.py
@@ -56,8 +56,10 @@ Functions:
     reset_template_engine: Reset to default configuration
 """
 
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Union
 
 import yaml  # type: ignore[import-untyped]
 from jinja2 import BaseLoader, Environment, select_autoescape
@@ -676,6 +678,9 @@ class TemplateEngine:
 
 # Global template engine instance
 _template_engine = None
+_context_template_engine: ContextVar[Optional[TemplateEngine]] = ContextVar(
+    "slideflow_template_engine", default=None
+)
 
 
 def _default_template_paths() -> List[Path]:
@@ -708,9 +713,43 @@ def get_template_engine() -> TemplateEngine:
         - Use set_template_paths() to configure custom paths
     """
     global _template_engine
+    context_engine = _context_template_engine.get()
+    if context_engine is not None:
+        return context_engine
+
     if _template_engine is None:
         _template_engine = TemplateEngine()
     return _template_engine
+
+
+@contextmanager
+def use_template_engine(engine: Optional[TemplateEngine]) -> Iterator[None]:
+    """Temporarily expose a build-scoped template engine via get_template_engine()."""
+    if engine is None:
+        yield
+        return
+
+    token = _context_template_engine.set(engine)
+    try:
+        yield
+    finally:
+        _context_template_engine.reset(token)
+
+
+def create_template_engine(
+    template_paths: Optional[List[Union[str, Path]]] = None,
+    include_defaults: bool = True,
+) -> TemplateEngine:
+    """Create an isolated template engine without mutating global state."""
+    paths: List[Union[str, Path]] = (
+        [] if template_paths is None else list(template_paths)
+    )
+    if include_defaults:
+        for default_path in _default_template_paths():
+            if default_path not in paths:
+                paths.append(default_path)
+
+    return TemplateEngine(template_paths=paths)
 
 
 def set_template_paths(
@@ -747,14 +786,8 @@ def set_template_paths(
         - When include_defaults=True, custom paths override defaults
         - Use reset_template_engine() to return to default paths
     """
-    paths: List[Union[str, Path]] = list(template_paths)
-    if include_defaults:
-        for default_path in _default_template_paths():
-            if default_path not in paths:
-                paths.append(default_path)
-
     global _template_engine
-    _template_engine = TemplateEngine(template_paths=paths)
+    _template_engine = create_template_engine(template_paths, include_defaults)
 
 
 def reset_template_engine() -> None:

--- a/slideflow/cli/commands/build.py
+++ b/slideflow/cli/commands/build.py
@@ -54,6 +54,8 @@ from slideflow.presentations import PresentationBuilder
 from slideflow.presentations.config import PresentationConfig
 from slideflow.presentations.providers.factory import ProviderFactory
 from slideflow.utilities import ConfigLoader
+from slideflow.utilities.error_messages import redacted_error_line
+from slideflow.utilities.redaction import redact_value
 
 
 def _sleep_for_progress(seconds: float) -> None:
@@ -162,7 +164,7 @@ def build_single_presentation(
 
     except Exception as e:
         with print_lock:
-            print(f"❌ [{index}/{total}] Failed: {str(e)}")
+            print(f"❌ [{index}/{total}] Failed: {redacted_error_line(e)}")
         raise
 
 
@@ -381,45 +383,46 @@ def build_command(
             for future in as_completed(future_to_params):
                 index, params = future_to_params[future]
                 try:
-                    name, result, pres_index, returned_params = future.result()
+                    name, result, pres_index, _returned_params = future.result()
 
-                    result_dict = returned_params.copy()
-                    result_dict["url"] = result.presentation_url
-                    result_dict["presentation_name"] = name
-                    result_dict["chart_image_cleanup_failed_count"] = getattr(
-                        result, "chart_image_cleanup_failed_count", 0
-                    )
-                    result_dict["chart_image_cleanup_failed_ids"] = getattr(
-                        result, "chart_image_cleanup_failed_ids", []
-                    )
-                    result_dict["ownership_transfer_attempted"] = getattr(
-                        result, "ownership_transfer_attempted", False
-                    )
-                    result_dict["ownership_transfer_succeeded"] = getattr(
-                        result, "ownership_transfer_succeeded", None
-                    )
-                    result_dict["ownership_transfer_target"] = getattr(
-                        result, "ownership_transfer_target", None
-                    )
-                    result_dict["ownership_transfer_error"] = getattr(
-                        result, "ownership_transfer_error", None
-                    )
-                    result_dict["citations_enabled"] = getattr(
-                        result, "citations_enabled", False
-                    )
-                    result_dict["citations_total_sources"] = getattr(
-                        result, "citations_total_sources", 0
-                    )
-                    result_dict["citations_emitted_sources"] = getattr(
-                        result, "citations_emitted_sources", 0
-                    )
-                    result_dict["citations_truncated"] = getattr(
-                        result, "citations_truncated", False
-                    )
-                    result_dict["citations"] = getattr(result, "citations", [])
-                    result_dict["citations_by_scope"] = getattr(
-                        result, "citations_by_scope", {}
-                    )
+                    result_dict = {
+                        "variant_index": pres_index,
+                        "url": result.presentation_url,
+                        "presentation_name": name,
+                        "chart_image_cleanup_failed_count": getattr(
+                            result, "chart_image_cleanup_failed_count", 0
+                        ),
+                        "chart_image_cleanup_failed_ids": getattr(
+                            result, "chart_image_cleanup_failed_ids", []
+                        ),
+                        "ownership_transfer_attempted": getattr(
+                            result, "ownership_transfer_attempted", False
+                        ),
+                        "ownership_transfer_succeeded": getattr(
+                            result, "ownership_transfer_succeeded", None
+                        ),
+                        "ownership_transfer_target": getattr(
+                            result, "ownership_transfer_target", None
+                        ),
+                        "ownership_transfer_error": getattr(
+                            result, "ownership_transfer_error", None
+                        ),
+                        "citations_enabled": getattr(
+                            result, "citations_enabled", False
+                        ),
+                        "citations_total_sources": getattr(
+                            result, "citations_total_sources", 0
+                        ),
+                        "citations_emitted_sources": getattr(
+                            result, "citations_emitted_sources", 0
+                        ),
+                        "citations_truncated": getattr(
+                            result, "citations_truncated", False
+                        ),
+                        "citations": getattr(result, "citations", []),
+                        "citations_by_scope": getattr(result, "citations_by_scope", {}),
+                    }
+                    result_dict = redact_value(result_dict)
                     results.append(result_dict)
 
                     completed_count += 1
@@ -433,7 +436,7 @@ def build_command(
 
                 except Exception as e:
                     with print_lock:
-                        print(f"❌ Artifact {index} failed: {e}")
+                        print(f"❌ Artifact {index} failed: {redacted_error_line(e)}")
                     raise
 
         print_build_progress(6, 6, "All artifacts deployed!")
@@ -503,7 +506,7 @@ def build_command(
                 "started_at": run_started_at,
                 "completed_at": now_iso8601_utc(),
                 "config_file": str(config_file),
-                "error": {"code": error_code, "message": str(e).split("\n")[0]},
+                "error": {"code": error_code, "message": redacted_error_line(e)},
             },
         )
         print_build_error(str(e), error_code=error_code)

--- a/slideflow/cli/commands/build.py
+++ b/slideflow/cli/commands/build.py
@@ -386,6 +386,12 @@ def build_command(
                     result_dict = returned_params.copy()
                     result_dict["url"] = result.presentation_url
                     result_dict["presentation_name"] = name
+                    result_dict["chart_image_cleanup_failed_count"] = getattr(
+                        result, "chart_image_cleanup_failed_count", 0
+                    )
+                    result_dict["chart_image_cleanup_failed_ids"] = getattr(
+                        result, "chart_image_cleanup_failed_ids", []
+                    )
                     result_dict["ownership_transfer_attempted"] = getattr(
                         result, "ownership_transfer_attempted", False
                     )
@@ -454,6 +460,14 @@ def build_command(
         citations_truncated_any = any(
             bool(res.get("citations_truncated", False)) for res in results
         )
+        chart_image_cleanup_failed_count = sum(
+            int(res.get("chart_image_cleanup_failed_count", 0)) for res in results
+        )
+        chart_image_cleanup_failed_ids = [
+            file_id
+            for res in results
+            for file_id in res.get("chart_image_cleanup_failed_ids", [])
+        ]
         write_output_json(
             output_json,
             {
@@ -470,6 +484,8 @@ def build_command(
                 "citations_total_sources": citations_total_sources,
                 "citations_emitted_sources": citations_emitted_sources,
                 "citations_truncated": citations_truncated_any,
+                "chart_image_cleanup_failed_count": chart_image_cleanup_failed_count,
+                "chart_image_cleanup_failed_ids": chart_image_cleanup_failed_ids,
                 "results": results,
             },
         )

--- a/slideflow/cli/commands/doctor.py
+++ b/slideflow/cli/commands/doctor.py
@@ -16,7 +16,7 @@ from slideflow.constants import Environment
 from slideflow.presentations.config import PresentationConfig
 from slideflow.presentations.providers.factory import ProviderFactory
 from slideflow.utilities import ConfigLoader
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line
 
 CheckSeverity = Literal["error", "warning", "info"]
 
@@ -29,7 +29,7 @@ def _check(
 
 def _first_error_line(error: Exception) -> str:
     """Return a safe single-line error description."""
-    return safe_error_line(error)
+    return redacted_error_line(error)
 
 
 def _resolve_binary_candidate(candidate: Optional[str]) -> Optional[str]:

--- a/slideflow/cli/commands/sheets.py
+++ b/slideflow/cli/commands/sheets.py
@@ -12,7 +12,7 @@ from slideflow.cli.error_codes import CliErrorCode, resolve_cli_error_code
 from slideflow.cli.json_output import now_iso8601_utc, write_output_json
 from slideflow.cli.theme import print_error, print_success, print_validation_header
 from slideflow.utilities import ConfigLoader
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line
 from slideflow.workbooks import WorkbookBuilder, WorkbookConfig
 from slideflow.workbooks.providers.factory import WorkbookProviderFactory
 
@@ -27,8 +27,8 @@ def _first_error_line(error: Exception) -> str:
         if details:
             msg = str(details[0].get("msg", "")).strip()
             if msg:
-                return msg
-    return safe_error_line(error)
+                return redacted_error_line(RuntimeError(msg))
+    return redacted_error_line(error)
 
 
 def _check(

--- a/slideflow/cli/commands/validate.py
+++ b/slideflow/cli/commands/validate.py
@@ -56,7 +56,7 @@ from slideflow.presentations.builder import PresentationBuilder
 from slideflow.presentations.config import PresentationConfig
 from slideflow.utilities import ConfigLoader
 from slideflow.utilities.auth import handle_google_credentials
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line
 
 _GOOGLE_SLIDES_CONTRACT_FIELDS = (
     "slides(objectId,pageElements(shape(text(textElements(textRun(content))))))"
@@ -200,7 +200,7 @@ class ProviderContractValidationError(ValueError):
 
 def _first_error_line(error: Exception) -> str:
     """Return a safe single-line error description."""
-    return safe_error_line(error)
+    return redacted_error_line(error)
 
 
 def _collect_expected_contract(

--- a/slideflow/cli/commands/validate.py
+++ b/slideflow/cli/commands/validate.py
@@ -158,11 +158,21 @@ def _build_readonly_google_contract_client(
 
 def _create_google_contract_check_client(
     presentation_config: PresentationConfig,
+    *,
+    allow_full_auth_fallback: bool = False,
 ) -> Any:
-    """Create readonly contract-check clients with provider fallback."""
+    """Create readonly contract-check clients with explicit provider fallback."""
     try:
         return _build_readonly_google_contract_client(presentation_config)
-    except Exception:
+    except Exception as error:
+        if not allow_full_auth_fallback:
+            raise ValueError(
+                "Read-only Google provider contract auth failed; refusing to "
+                "fall back to broader provider scopes without "
+                "--provider-contract-full-auth-fallback. "
+                f"Cause: {_first_error_line(error)}"
+            ) from error
+
         from slideflow.presentations.providers.factory import ProviderFactory
 
         provider = ProviderFactory.create_provider(presentation_config.provider)
@@ -705,6 +715,16 @@ def validate_command(
             help="Run provider-aware contract checks (Google Slides or Google Docs templates)",
         ),
     ] = False,
+    provider_contract_full_auth_fallback: Annotated[
+        bool,
+        typer.Option(
+            "--provider-contract-full-auth-fallback",
+            help=(
+                "Allow provider contract checks to fall back to the full Google "
+                "provider scopes when read-only auth initialization fails"
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Validate YAML configuration and registry files.
 
@@ -733,6 +753,9 @@ def validate_command(
         provider_contract_check: When true, runs provider-aware contract checks
             for Google Slides (slide IDs/placeholders) and Google Docs
             (section markers/placeholders).
+        provider_contract_full_auth_fallback: When true, allows contract checks
+            to instantiate the full provider if least-privilege read-only auth
+            initialization fails.
 
     Raises:
         typer.Exit: Exits with code 1 if validation fails at any stage.
@@ -818,7 +841,10 @@ def validate_command(
                     "provider types 'google_slides' and 'google_docs'."
                 )
 
-            contract_client = _create_google_contract_check_client(presentation_config)
+            contract_client = _create_google_contract_check_client(
+                presentation_config,
+                allow_full_auth_fallback=provider_contract_full_auth_fallback,
+            )
             if provider_type == "google_slides":
                 provider_contract_summary = _run_google_provider_contract_check(
                     presentation_config=presentation_config,

--- a/slideflow/cli/json_output.py
+++ b/slideflow/cli/json_output.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from slideflow.utilities.redaction import redact_value
+
 
 def now_iso8601_utc() -> str:
     """Return current timestamp in ISO 8601 UTC format."""
@@ -36,9 +38,10 @@ def write_output_json(path: Optional[Path], payload: Dict[str, Any]) -> None:
 
     path.parent.mkdir(parents=True, exist_ok=True)
     normalized_payload = _normalize_json_value(payload)
+    redacted_payload = redact_value(normalized_payload)
     path.write_text(
         json.dumps(
-            normalized_payload,
+            redacted_payload,
             indent=2,
             sort_keys=True,
             allow_nan=False,

--- a/slideflow/cli/theme.py
+++ b/slideflow/cli/theme.py
@@ -37,6 +37,8 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from slideflow.utilities.redaction import redact_text
+
 console = Console(force_terminal=True, color_system="truecolor")
 
 
@@ -218,9 +220,9 @@ def print_error(
         console.print(f"[bold yellow]Error Code:[/bold yellow] [red]{error_code}[/red]")
 
     if verbose:
-        console.print(f"[red]{error_msg}[/red]")
+        console.print(f"[red]{redact_text(str(error_msg))}[/red]")
     else:
-        first_line = str(error_msg).split("\n")[0]
+        first_line = redact_text(str(error_msg).split("\n")[0])
         console.print(f"[red]{first_line}[/red]")
 
     console.print("[red]━━━━━━━━━━━━━━━━━━━━━━━[/red]")
@@ -331,10 +333,10 @@ def print_build_error(
         console.print(f"[bold yellow]Error Code:[/bold yellow] [red]{error_code}[/red]")
 
     if verbose:
-        console.print(f"[red]{error_msg}[/red]")
+        console.print(f"[red]{redact_text(str(error_msg))}[/red]")
     else:
         # Show first line only
-        first_line = str(error_msg).split("\n")[0]
+        first_line = redact_text(str(error_msg).split("\n")[0])
         console.print(f"[red]{first_line}[/red]")
 
     console.print("[red]━━━━━━━━━━━━━━━━━━━━━━━[/red]")

--- a/slideflow/data/cache.py
+++ b/slideflow/data/cache.py
@@ -10,7 +10,7 @@ Key Features:
     - Thread-safe operations with reentrant locking
     - MD5-based key generation from source parameters
     - Enable/disable functionality for cache control
-    - Memory-efficient reference storage (no copying)
+    - Copy-on-read/write storage to isolate callers from mutations
     - Cache introspection and debugging capabilities
 
 The cache is designed to be transparent to data connectors and automatically
@@ -46,15 +46,25 @@ import json
 import os
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
 import pandas as pd
 
 from slideflow.constants import Defaults, Environment
+from slideflow.utilities.dataframes import copy_dataframe
 from slideflow.utilities.error_messages import redacted_error_line
 from slideflow.utilities.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class _InflightLoad:
+    """Tracks one cache load that other callers may wait on."""
+
+    event: threading.Event
+    generation: int
 
 
 def _resolve_data_cache_max_entries() -> int:
@@ -77,9 +87,9 @@ class DataSourceCache:
     retrieving DataFrames using MD5-based keys generated from source parameters.
 
     The cache is designed to be transparent to data connectors and automatically
-    manages memory-efficient storage by storing DataFrame references rather than
-    copies. This is safe because the cache lifecycle is contained within single
-    build operations.
+    stores DataFrame copies and returns fresh copies to callers so replacement
+    formatting, chart transforms, and other consumers cannot mutate cached data
+    shared by the rest of the build.
 
     Thread Safety:
         All operations are protected by a reentrant lock (RLock) to ensure
@@ -100,7 +110,7 @@ class DataSourceCache:
 
     Attributes:
         _instance: Class-level singleton instance storage
-        _cache: Thread-safe dictionary storing DataFrame references
+        _cache: Thread-safe dictionary storing isolated DataFrame copies
         _enabled: Boolean flag controlling cache operations
         _lock: Reentrant lock for thread-safe operations
     """
@@ -108,8 +118,9 @@ class DataSourceCache:
     _instance: Optional["DataSourceCache"] = None
     _instance_lock: threading.Lock = threading.Lock()
     _cache: "OrderedDict[str, pd.DataFrame]"
-    _inflight: Dict[str, threading.Event]
+    _inflight: Dict[str, _InflightLoad]
     _enabled: bool
+    _generation: int
     _max_entries: int
     _lock: threading.RLock
 
@@ -130,9 +141,20 @@ class DataSourceCache:
                     cls._instance._cache = OrderedDict()
                     cls._instance._inflight = {}
                     cls._instance._enabled = True
+                    cls._instance._generation = 0
                     cls._instance._max_entries = _resolve_data_cache_max_entries()
                     cls._instance._lock = threading.RLock()
         return cls._instance
+
+    @staticmethod
+    def _copy_frame(data: pd.DataFrame) -> pd.DataFrame:
+        """Return an isolated DataFrame copy for cache storage or consumers."""
+        return copy_dataframe(data)
+
+    @staticmethod
+    def _new_inflight_event() -> threading.Event:
+        """Create an event for coordinating one in-flight cache load."""
+        return threading.Event()
 
     @staticmethod
     def _stable_json(value: Any) -> str:
@@ -266,24 +288,25 @@ class DataSourceCache:
             ... else:
             ...     print("Data not in cache, need to fetch")
         """
-        if not self._enabled:
-            return None
         key = self._generate_key(source_type, **kwargs)
         with self._lock:
+            if not self._enabled:
+                return None
             # guard the lookup
             df = self._cache.get(key)
             if df is not None:
                 # LRU: move most recently used key to the end.
                 self._cache.move_to_end(key)
-        return df
+            else:
+                return None
+        return self._copy_frame(df)
 
     def set(self, data: pd.DataFrame, source_type: str, **kwargs) -> None:
         """Store a DataFrame in the cache.
 
-        Caches the provided DataFrame using a key generated from the source type
-        and parameters. The cache stores a reference to the DataFrame rather than
-        a copy for memory efficiency. This is safe because the cache lifecycle
-        is contained within single build operations.
+        Caches a copy of the provided DataFrame using a key generated from the
+        source type and parameters. Later reads return fresh copies so callers
+        can safely mutate their returned frames without corrupting the cache.
 
         Args:
             data: The DataFrame to cache.
@@ -298,13 +321,12 @@ class DataSourceCache:
             >>> # Later retrieval will use the same parameters
             >>> cached_data = cache.get("csv", file_path="/data/sales.csv")
         """
-        if not self._enabled:
-            return
         key = self._generate_key(source_type, **kwargs)
+        cache_entry = self._copy_frame(data)
         with self._lock:
-            # Store reference instead of copy - safe since cache lifecycle
-            # is contained within a single build operation
-            self._cache[key] = data
+            if not self._enabled:
+                return
+            self._cache[key] = cache_entry
             self._cache.move_to_end(key)
             self._enforce_size_limit_locked()
 
@@ -327,44 +349,65 @@ class DataSourceCache:
         key = self._generate_key(source_type, **kwargs)
 
         while True:
-            if not self._enabled:
+            cached = None
+            pending = None
+            is_owner = False
+            load_uncached = False
+            with self._lock:
+                if not self._enabled:
+                    load_uncached = True
+                else:
+                    cached = self._cache.get(key)
+                    if cached is not None:
+                        self._cache.move_to_end(key)
+                    else:
+                        pending = self._inflight.get(key)
+                        if pending is None:
+                            pending = _InflightLoad(
+                                event=self._new_inflight_event(),
+                                generation=self._generation,
+                            )
+                            self._inflight[key] = pending
+                            is_owner = True
+
+            if load_uncached:
                 return loader()
 
-            with self._lock:
-                cached = self._cache.get(key)
-                if cached is not None:
-                    self._cache.move_to_end(key)
-                    return cached
-
-                pending = self._inflight.get(key)
-                if pending is None:
-                    pending = threading.Event()
-                    self._inflight[key] = pending
-                    is_owner = True
-                else:
-                    is_owner = False
+            if cached is not None:
+                return self._copy_frame(cached)
 
             if is_owner:
+                assert pending is not None
                 try:
                     data = loader()
                 except BaseException:
                     with self._lock:
-                        event = self._inflight.pop(key, None)
-                        if event is not None:
-                            event.set()
+                        current = self._inflight.get(key)
+                        if current is pending:
+                            self._inflight.pop(key, None)
+                        pending.event.set()
                     raise
 
+                cache_entry = self._copy_frame(data)
                 with self._lock:
-                    if self._enabled:
-                        self._cache[key] = data
+                    current = self._inflight.get(key)
+                    if (
+                        self._enabled
+                        and self._generation == pending.generation
+                        and current is pending
+                    ):
+                        self._cache[key] = cache_entry
                         self._cache.move_to_end(key)
                         self._enforce_size_limit_locked()
-                    event = self._inflight.pop(key, None)
-                    if event is not None:
-                        event.set()
+                        self._inflight.pop(key, None)
+                    elif current is pending:
+                        self._inflight.pop(key, None)
+                    pending.event.set()
                 return data
 
-            pending.wait()
+            if pending is None:
+                continue
+            pending.event.wait()
 
     def clear(self) -> None:
         """Remove all cached DataFrames.
@@ -378,7 +421,9 @@ class DataSourceCache:
             >>> print(f"Cache size after clear: {cache.size}")  # 0
         """
         with self._lock:
+            self._generation += 1
             self._cache.clear()
+            self._release_inflight_locked()
 
     def disable(self) -> None:
         """Disable the cache and clear all cached data.
@@ -394,7 +439,9 @@ class DataSourceCache:
         """
         with self._lock:
             self._enabled = False
+            self._generation += 1
             self._cache.clear()
+            self._release_inflight_locked()
 
     def enable(self) -> None:
         """Re-enable cache operations.
@@ -410,6 +457,13 @@ class DataSourceCache:
         with self._lock:
             self._enabled = True
             self._max_entries = _resolve_data_cache_max_entries()
+
+    def _release_inflight_locked(self) -> None:
+        """Wake all waiters after cache state invalidation. Caller holds lock."""
+        inflight = list(self._inflight.values())
+        self._inflight.clear()
+        for pending in inflight:
+            pending.event.set()
 
     @property
     def is_enabled(self) -> bool:

--- a/slideflow/data/cache.py
+++ b/slideflow/data/cache.py
@@ -51,7 +51,7 @@ from typing import Any, Callable, Dict, Optional
 import pandas as pd
 
 from slideflow.constants import Defaults, Environment
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line
 from slideflow.utilities.logging import get_logger
 
 logger = get_logger(__name__)
@@ -202,7 +202,7 @@ class DataSourceCache:
                 logger.debug(
                     "Data cache key normalization: model_dump failed (%s); "
                     "falling back to repr().",
-                    safe_error_line(error),
+                    redacted_error_line(error),
                     exc_info=True,
                 )
 

--- a/slideflow/data/connectors/bigquery.py
+++ b/slideflow/data/connectors/bigquery.py
@@ -21,7 +21,7 @@ from google.auth.exceptions import DefaultCredentialsError
 
 from slideflow.constants import Defaults, Environment
 from slideflow.data.connectors.base import DataConnector, SQLExecutor
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line, safe_error_line
 from slideflow.utilities.exceptions import DataSourceError
 from slideflow.utilities.logging import (
     get_logger,
@@ -174,7 +174,7 @@ class BigQueryConnector(DataConnector):
                 raise BigQueryConnectorError(
                     "configuration",
                     "Failed to load BigQuery credentials from credentials_json "
-                    f"({safe_error_line(error)})",
+                    f"({redacted_error_line(error)})",
                 ) from error
 
             inferred_project = payload.get("project_id") or getattr(
@@ -192,7 +192,7 @@ class BigQueryConnector(DataConnector):
                 raise BigQueryConnectorError(
                     "configuration",
                     "Failed to load BigQuery credentials from credentials_path "
-                    f"({safe_error_line(error)})",
+                    f"({redacted_error_line(error)})",
                 ) from error
 
             inferred_project = getattr(credentials, "project_id", None)
@@ -236,7 +236,7 @@ class BigQueryConnector(DataConnector):
                 raise BigQueryConnectorError(
                     category,
                     "Failed to initialize BigQuery client "
-                    f"({safe_error_line(error)})",
+                    f"({redacted_error_line(error)})",
                 ) from error
         return self._client
 
@@ -286,7 +286,7 @@ class BigQueryConnector(DataConnector):
                 if isinstance(error, BigQueryConnectorError)
                 else BigQueryConnectorError(
                     self._categorize_error(error),
-                    f"BigQuery query failed ({safe_error_line(error)})",
+                    f"BigQuery query failed ({redacted_error_line(error)})",
                 )
             )
             log_api_operation(

--- a/slideflow/data/connectors/databricks.py
+++ b/slideflow/data/connectors/databricks.py
@@ -49,7 +49,7 @@ from pydantic import ConfigDict, Field
 from slideflow.citations import CitationEntry, fingerprint_text
 from slideflow.constants import Defaults, Environment
 from slideflow.data.connectors.base import BaseSourceConfig, DataConnector, SQLExecutor
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line, safe_error_line
 from slideflow.utilities.exceptions import DataSourceError
 from slideflow.utilities.logging import (
     get_logger,
@@ -59,6 +59,7 @@ from slideflow.utilities.logging import (
 
 logger = get_logger(__name__)
 
+_databricks_sql: Any
 try:
     from databricks import sql as _databricks_sql
 except ImportError:  # pragma: no cover - exercised in optional-dependency tests
@@ -297,7 +298,7 @@ class DatabricksConnector(DataConnector):
                 category = self._categorize_connect_error(error)
                 raise DatabricksConnectorError(
                     category,
-                    f"Failed to connect to Databricks ({safe_error_line(error)})",
+                    f"Failed to connect to Databricks ({redacted_error_line(error)})",
                 ) from error
         return self._connection
 
@@ -375,7 +376,7 @@ class DatabricksConnector(DataConnector):
                 if isinstance(e, DatabricksConnectorError)
                 else DatabricksConnectorError(
                     self._categorize_error(e),
-                    f"Databricks query failed ({safe_error_line(e)})",
+                    f"Databricks query failed ({redacted_error_line(e)})",
                 )
             )
             log_api_operation(

--- a/slideflow/data/connectors/databricks.py
+++ b/slideflow/data/connectors/databricks.py
@@ -41,6 +41,7 @@ Example:
 
 import os
 import time
+from importlib import import_module
 from typing import Annotated, Any, ClassVar, Literal, Optional, Type
 
 import pandas as pd
@@ -59,14 +60,13 @@ from slideflow.utilities.logging import (
 
 logger = get_logger(__name__)
 
-_databricks_sql: Any
 try:
-    from databricks import sql as _databricks_sql
+    _imported_databricks_sql: Any = import_module("databricks.sql")
 except ImportError:  # pragma: no cover - exercised in optional-dependency tests
-    _databricks_sql = None
+    _imported_databricks_sql = None
 
 # Keep a module-level symbol for test monkeypatching and compatibility.
-sql = _databricks_sql
+sql: Any = _imported_databricks_sql
 
 
 def _resolve_positive_float_from_env(env_var: str, default: float) -> float:

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -78,15 +78,21 @@ from slideflow.utilities.logging import get_logger, log_data_operation, log_perf
 
 logger = get_logger(__name__)
 
+_dbt_runner_cls: Any = None
 try:
-    from dbt.cli.main import dbtRunner as _dbt_runner_cls
-except ImportError:  # pragma: no cover - exercised in optional-dependency tests
-    _dbt_runner_cls = None
+    from dbt.cli.main import dbtRunner as _imported_dbt_runner_cls
 
-try:
-    from git import Repo as _git_repo_cls
+    _dbt_runner_cls = _imported_dbt_runner_cls
 except ImportError:  # pragma: no cover - exercised in optional-dependency tests
-    _git_repo_cls = None
+    pass
+
+_git_repo_cls: Any = None
+try:
+    from git import Repo as _imported_git_repo_cls
+
+    _git_repo_cls = _imported_git_repo_cls
+except ImportError:  # pragma: no cover - exercised in optional-dependency tests
+    pass
 
 # Keep module-level symbols for test monkeypatch compatibility.
 dbtRunner = _dbt_runner_cls

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -686,6 +686,28 @@ def _resolve_managed_clone_dir(
     return managed_root / key
 
 
+def _resolve_existing_compiled_project_dir(
+    project_dir: str,
+    *,
+    acquire_lease: bool = False,
+) -> Path:
+    """Resolve and validate an existing compiled dbt project directory."""
+    compiled_project_dir = Path(project_dir).expanduser().resolve()
+    manifest_path = compiled_project_dir / "target" / "manifest.json"
+    if not manifest_path.is_file():
+        raise DataSourceError(
+            "dbt compile:false requires an existing compiled dbt project at "
+            f"{compiled_project_dir}. Expected manifest at {manifest_path}. "
+            "Run `dbt deps` and `dbt compile` first, or set compile:true to let "
+            "Slideflow clone and compile the project."
+        )
+
+    if acquire_lease:
+        with _cache_lock:
+            _acquire_compiled_project_lease_locked(compiled_project_dir)
+    return compiled_project_dir
+
+
 def _get_compiled_project(
     package_url: str,
     project_dir: str,
@@ -694,6 +716,7 @@ def _get_compiled_project(
     vars: Optional[dict[str, Any]],
     profiles_dir: Optional[str] = None,
     profile_name: Optional[str] = None,
+    compile: bool = Defaults.DBT_COMPILE,
     acquire_lease: bool = False,
 ) -> Path:
     """Get or create a compiled DBT project with caching.
@@ -731,8 +754,14 @@ def _get_compiled_project(
         ...     {"start_date": "2024-01-01"}
         ... )
     """
-    canonical_profiles_dir = _canonical_profiles_dir(profiles_dir)
     canonical_project_dir = _canonical_project_dir(project_dir)
+    if not compile:
+        return _resolve_existing_compiled_project_dir(
+            canonical_project_dir,
+            acquire_lease=acquire_lease,
+        )
+
+    canonical_profiles_dir = _canonical_profiles_dir(profiles_dir)
     cache_key = (
         package_url,
         canonical_project_dir,
@@ -901,6 +930,7 @@ def _compiled_project_lease(
     vars: Optional[dict[str, Any]],
     profiles_dir: Optional[str] = None,
     profile_name: Optional[str] = None,
+    compile: bool = Defaults.DBT_COMPILE,
 ) -> Iterator[Path]:
     """Acquire a temporary usage lease for a compiled DBT clone directory."""
     clone_dir = _get_compiled_project(
@@ -911,6 +941,7 @@ def _compiled_project_lease(
         vars=vars,
         profiles_dir=profiles_dir,
         profile_name=profile_name,
+        compile=compile,
         acquire_lease=True,
     )
     try:
@@ -1003,6 +1034,7 @@ class DBTManifestConnector(BaseModel, DataConnector):
             vars=self.vars,
             profiles_dir=self.profiles_dir,
             profile_name=self.profile_name,
+            compile=self.compile,
         ) as clone_dir:
             manifest_index = _get_manifest_index(clone_dir)
             candidates = list(manifest_index.by_alias.get(model_name, []))
@@ -1092,6 +1124,13 @@ class DBTManifestConnector(BaseModel, DataConnector):
                 selected.alias,
                 selected.compiled_path,
             )
+            if not self.compile:
+                raise DataSourceError(
+                    "dbt compile:false requires compiled SQL files referenced by "
+                    f"manifest.json. Missing compiled file for alias "
+                    f"'{selected.alias}': {selected.compiled_path}. Run `dbt compile` "
+                    "for this project, or set compile:true to let Slideflow compile it."
+                )
             return None
 
     def fetch_data(self) -> pd.DataFrame:

--- a/slideflow/data/connectors/duckdb.py
+++ b/slideflow/data/connectors/duckdb.py
@@ -12,7 +12,7 @@ from pydantic import ConfigDict, Field
 
 from slideflow.citations import CitationEntry, fingerprint_text
 from slideflow.data.connectors.base import BaseSourceConfig, DataConnector, SQLExecutor
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line
 from slideflow.utilities.exceptions import DataSourceError
 
 
@@ -91,7 +91,7 @@ class DuckDBConnector(DataConnector):
                 raise DuckDBConnectorError(
                     "connection",
                     "Failed to initialize DuckDB connection "
-                    f"({safe_error_line(error)})",
+                    f"({redacted_error_line(error)})",
                 ) from error
         return self._connection
 
@@ -141,7 +141,8 @@ class DuckDBConnector(DataConnector):
         except Exception as error:
             raise DuckDBConnectorError(
                 "configuration",
-                "Failed to set DuckDB file_search_path " f"({safe_error_line(error)})",
+                "Failed to set DuckDB file_search_path "
+                f"({redacted_error_line(error)})",
             ) from error
         self._file_search_path_applied = True
 
@@ -157,7 +158,7 @@ class DuckDBConnector(DataConnector):
         except Exception as error:
             raise DuckDBConnectorError(
                 "query",
-                f"Failed to execute DuckDB query ({safe_error_line(error)})",
+                f"Failed to execute DuckDB query ({redacted_error_line(error)})",
             ) from error
 
 

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -149,6 +149,20 @@ class PresentationResult(BaseModel):
     replacements_made: Annotated[
         int, Field(..., description="Number of text replacements made")
     ]
+    chart_image_cleanup_failed_count: Annotated[
+        int,
+        Field(
+            default=0,
+            description="Number of uploaded chart images that could not be cleaned up",
+        ),
+    ]
+    chart_image_cleanup_failed_ids: Annotated[
+        List[str],
+        Field(
+            default_factory=list,
+            description="Uploaded chart image file IDs that could not be cleaned up",
+        ),
+    ]
     render_time: Annotated[
         float, Field(..., description="Time taken to render presentation in seconds")
     ]
@@ -944,6 +958,8 @@ class Presentation(BaseModel):
             ),
             charts_generated=context.total_charts,
             replacements_made=context.total_replacements,
+            chart_image_cleanup_failed_count=len(context.failed_cleanup_ids),
+            chart_image_cleanup_failed_ids=list(context.failed_cleanup_ids),
             render_time=render_time,
             created_at=datetime.now(),
             ownership_transfer_attempted=context.ownership_transfer_attempted,
@@ -978,6 +994,14 @@ class Presentation(BaseModel):
                         cleanup_error,
                     )
 
+            provider_cleanup_failures = getattr(
+                self.provider, "consume_chart_image_cleanup_failures", None
+            )
+            if callable(provider_cleanup_failures):
+                for file_id in provider_cleanup_failures():
+                    if file_id not in context.failed_cleanup_ids:
+                        context.failed_cleanup_ids.append(file_id)
+
             deleted_cleanup_count = len(context.uploaded_file_ids) - len(
                 context.failed_cleanup_ids
             )
@@ -1010,6 +1034,7 @@ class Presentation(BaseModel):
     def render(self) -> PresentationResult:
         """Render the complete presentation with all content and styling."""
         context: Optional[_RenderContext] = None
+        cleanup_attempted = False
         try:
             context = self._create_render_context(start_time=time.time())
             self._prefetch_data_sources()
@@ -1018,13 +1043,15 @@ class Presentation(BaseModel):
             citation_summary = self._summarize_and_render_citations(context)
             self._finalize_and_share_presentation(context)
             self._apply_ownership_transfer(context)
+            cleanup_attempted = True
+            self._cleanup_uploaded_chart_images(context)
             return self._build_presentation_result(context, citation_summary)
         except Exception as error:
             if context is not None:
                 context.original_error = error
             raise
         finally:
-            if context is not None:
+            if context is not None and not cleanup_attempted:
                 self._cleanup_uploaded_chart_images(context)
 
     def get_slide(self, slide_id: str) -> Optional[Slide]:

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -69,7 +69,7 @@ from slideflow.presentations.config import CitationConfig
 from slideflow.presentations.positioning import compute_chart_dimensions
 from slideflow.presentations.providers.base import PresentationProvider
 from slideflow.replacements.base import BaseReplacement
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line
 from slideflow.utilities.exceptions import RenderingError
 from slideflow.utilities.logging import get_logger
 
@@ -934,7 +934,7 @@ class Presentation(BaseModel):
             context.ownership_transfer_succeeded = True
         except Exception as transfer_error:  # pragma: no cover - guarded via tests
             context.ownership_transfer_succeeded = False
-            context.ownership_transfer_error = safe_error_line(transfer_error)
+            context.ownership_transfer_error = redacted_error_line(transfer_error)
             logger.error(
                 "Ownership transfer failed for '%s' -> '%s': %s",
                 context.presentation_id,

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -66,6 +66,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from slideflow.builtins.template_engine import use_template_engine
 from slideflow.citations import CitationEntry, CitationRegistry, CitationSummary
 from slideflow.constants import GoogleSlides, Timing
+from slideflow.presentations.charts import chart_export_executor_scope
 from slideflow.presentations.config import CitationConfig
 from slideflow.presentations.positioning import compute_chart_dimensions
 from slideflow.presentations.providers.base import PresentationProvider
@@ -1045,7 +1046,8 @@ class Presentation(BaseModel):
             context = self._create_render_context(start_time=time.time())
             self._prefetch_data_sources()
             self._collect_citations_for_slides(context)
-            self._process_slide_content(context)
+            with chart_export_executor_scope():
+                self._process_slide_content(context)
             citation_summary = self._summarize_and_render_citations(context)
             self._finalize_and_share_presentation(context)
             self._apply_ownership_transfer(context)

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -63,6 +63,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Callable, Dict, List, Optional
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from slideflow.builtins.template_engine import use_template_engine
 from slideflow.citations import CitationEntry, CitationRegistry, CitationSummary
 from slideflow.constants import GoogleSlides, Timing
 from slideflow.presentations.config import CitationConfig
@@ -695,7 +696,8 @@ class Presentation(BaseModel):
                     if chart.data_source
                     else pd.DataFrame()
                 )
-                image_data = chart.generate_chart_image(df)
+                with use_template_engine(getattr(chart, "template_engine", None)):
+                    image_data = chart.generate_chart_image(df)
                 image_url, file_id = self.provider.upload_chart_image(
                     context.presentation_id,
                     image_data,

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -894,7 +894,11 @@ class Presentation(BaseModel):
             self.provider.share_presentation(
                 context.presentation_id,
                 self.provider.config.share_with,
-                getattr(self.provider.config, "share_role", "writer"),
+                getattr(
+                    self.provider.config,
+                    "share_role",
+                    GoogleSlides.PERMISSION_READER,
+                ),
             )
 
     def _apply_ownership_transfer(self, context: _RenderContext) -> None:

--- a/slideflow/presentations/builder.py
+++ b/slideflow/presentations/builder.py
@@ -46,7 +46,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 from pydantic import TypeAdapter
 
-from slideflow.builtins.template_engine import set_template_paths
+from slideflow.builtins.template_engine import TemplateEngine, create_template_engine
 from slideflow.data.connectors import DataSourceConfig
 from slideflow.presentations.base import Presentation, Slide
 from slideflow.presentations.charts import BaseChart, ChartUnion
@@ -239,14 +239,15 @@ class PresentationBuilder:
             >>> presentation = PresentationBuilder.from_config(config)
             >>> result = presentation.render()
         """
-        if config.template_paths:
-            set_template_paths(cast(List[str | Path], config.template_paths))
+        template_engine = create_template_engine(
+            cast(Optional[List[str | Path]], config.template_paths)
+        )
 
         provider = ProviderFactory.create_provider(config.provider)
 
         slides = []
         for slide_spec in config.presentation.slides:
-            slide = cls._build_slide(slide_spec)
+            slide = cls._build_slide(slide_spec, template_engine=template_engine)
             slides.append(slide)
 
         presentation = Presentation(
@@ -260,7 +261,9 @@ class PresentationBuilder:
         return presentation
 
     @classmethod
-    def _build_slide(cls, spec) -> Slide:
+    def _build_slide(
+        cls, spec, template_engine: Optional[TemplateEngine] = None
+    ) -> Slide:
         """Build a slide from its specification with all content elements.
 
         Constructs a Slide object by processing the slide specification and
@@ -293,7 +296,7 @@ class PresentationBuilder:
 
         charts: List[BaseChart] = []
         for chart_spec in spec.charts:
-            chart = cls._build_chart(chart_spec)
+            chart = cls._build_chart(chart_spec, template_engine=template_engine)
             charts.append(cast(BaseChart, chart))
 
         return Slide(
@@ -358,7 +361,9 @@ class PresentationBuilder:
         return adapter.validate_python(config)
 
     @classmethod
-    def _build_chart(cls, spec) -> ChartUnion:
+    def _build_chart(
+        cls, spec, template_engine: Optional[TemplateEngine] = None
+    ) -> ChartUnion:
         """Build a chart object from its specification.
 
         Constructs the appropriate chart type based on the specification using
@@ -407,6 +412,9 @@ class PresentationBuilder:
 
         if "data_source" in config:
             config["data_source"] = cls._build_data_source(config["data_source"])
+
+        if template_engine is not None:
+            config["template_engine"] = template_engine
 
         # Add type to config and let Pydantic discriminated union handle the rest
         config["type"] = spec.type

--- a/slideflow/presentations/charts.py
+++ b/slideflow/presentations/charts.py
@@ -29,7 +29,7 @@ Key Features:
 Example:
     Creating a line chart with data transformation:
 
-    >>> from slideflow.presentations.charts import PlotlyGraphObjects
+    >>> from slideflow.presentations.charts import PlotlyGraphObjects, chart_export_executor_scope
     >>> from slideflow.data.connectors import CSVDataSource
     >>>
     >>> chart = PlotlyGraphObjects(
@@ -47,17 +47,29 @@ Example:
     ...     x=100, y=150, width=500, height=400
     ... )
     >>>
-    >>> # Generate chart image bytes; provider handles upload/insertion
-    >>> image_bytes = chart.generate_chart_image(chart.fetch_data())
+    >>> # Generate chart image bytes; provider handles upload/insertion.
+    >>> # Presentation.render() manages this scope automatically.
+    >>> with chart_export_executor_scope():
+    ...     image_bytes = chart.generate_chart_image(chart.fetch_data())
 """
 
-import atexit
 import re
 import uuid
 from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor, TimeoutError
-from threading import Lock
-from typing import Annotated, Any, Callable, Dict, List, Literal, Optional, Union
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Union,
+)
 
 import pandas as pd
 import plotly.graph_objects as go
@@ -74,46 +86,79 @@ from slideflow.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 _LIST_COLUMN_REF_PATTERN = re.compile(r"^\$([a-zA-Z_]\w*)(?:\[(-?\d+)\])?$")
-
-_CHART_EXPORT_EXECUTOR: Optional[ProcessPoolExecutor] = None
-_CHART_EXPORT_EXECUTOR_LOCK = Lock()
-
-
-def _get_chart_export_executor() -> ProcessPoolExecutor:
-    global _CHART_EXPORT_EXECUTOR
-    with _CHART_EXPORT_EXECUTOR_LOCK:
-        if _CHART_EXPORT_EXECUTOR is None:
-            _CHART_EXPORT_EXECUTOR = ProcessPoolExecutor(max_workers=1)
-        return _CHART_EXPORT_EXECUTOR
+_CHART_EXPORT_SCOPE_ACTIVE: ContextVar[bool] = ContextVar(
+    "slideflow_chart_export_scope_active",
+    default=False,
+)
+_CHART_EXPORT_EXECUTOR: ContextVar[Optional[ProcessPoolExecutor]] = ContextVar(
+    "slideflow_chart_export_executor",
+    default=None,
+)
 
 
-def _reset_chart_export_executor() -> None:
-    global _CHART_EXPORT_EXECUTOR
-    with _CHART_EXPORT_EXECUTOR_LOCK:
-        executor = _CHART_EXPORT_EXECUTOR
-        _CHART_EXPORT_EXECUTOR = None
+def _create_chart_export_executor() -> ProcessPoolExecutor:
+    """Create an executor owned by one chart export attempt."""
+    return ProcessPoolExecutor(max_workers=1)
 
-    if executor is None:
+
+@contextmanager
+def chart_export_executor_scope() -> Iterator[None]:
+    """Reuse one chart export executor within the current render context.
+
+    ``Presentation.render()`` enters this scope automatically. Direct callers
+    that generate multiple chart images should wrap those calls in this scope to
+    reuse one export worker/Kaleido server without sharing it across builds.
+    """
+    if _CHART_EXPORT_SCOPE_ACTIVE.get():
+        yield
         return
 
-    # Best effort teardown: terminate worker process to avoid hanging exports.
+    active_token = _CHART_EXPORT_SCOPE_ACTIVE.set(True)
+    executor_token = _CHART_EXPORT_EXECUTOR.set(None)
     try:
-        for process in getattr(executor, "_processes", {}).values():
-            process.terminate()
-    except Exception as error:
-        logger.debug("Chart export worker teardown failed: %s", error, exc_info=True)
+        yield
+    finally:
+        executor = _CHART_EXPORT_EXECUTOR.get()
+        _CHART_EXPORT_EXECUTOR.reset(executor_token)
+        _CHART_EXPORT_SCOPE_ACTIVE.reset(active_token)
+        if executor is not None:
+            _shutdown_chart_export_executor(executor, terminate_workers=False)
+
+
+def _get_chart_export_executor() -> tuple[ProcessPoolExecutor, bool]:
+    """Return an executor and whether the caller owns its success cleanup."""
+    if _CHART_EXPORT_SCOPE_ACTIVE.get():
+        executor = _CHART_EXPORT_EXECUTOR.get()
+        if executor is None:
+            executor = _create_chart_export_executor()
+            _CHART_EXPORT_EXECUTOR.set(executor)
+        return executor, False
+    return _create_chart_export_executor(), True
+
+
+def _replace_scoped_chart_export_executor() -> None:
+    if _CHART_EXPORT_SCOPE_ACTIVE.get():
+        _CHART_EXPORT_EXECUTOR.set(None)
+
+
+def _shutdown_chart_export_executor(
+    executor: ProcessPoolExecutor, *, terminate_workers: bool
+) -> None:
+    """Clean up a chart export executor without touching unrelated exports."""
+    # Best effort teardown: terminate worker process to avoid hanging exports.
+    if terminate_workers:
+        try:
+            for process in getattr(executor, "_processes", {}).values():
+                process.terminate()
+        except Exception as error:
+            logger.debug(
+                "Chart export worker teardown failed: %s", error, exc_info=True
+            )
 
     try:
-        executor.shutdown(wait=False, cancel_futures=True)
+        executor.shutdown(wait=not terminate_workers, cancel_futures=True)
     except Exception as error:
         logger.debug("Chart export executor shutdown failed: %s", error, exc_info=True)
-
-
-def _shutdown_chart_export_executor() -> None:
-    _reset_chart_export_executor()
-
-
-atexit.register(_shutdown_chart_export_executor)
 
 
 def _plotly_to_image(
@@ -161,23 +206,27 @@ def _plotly_to_image(
         )
 
 
-def _execute_with_retry(func, *args, **kwargs):
+def _execute_with_retry(func, *args, context: Optional[str] = None, **kwargs):
     """
     Executes a function with a retry mechanism.
 
     The timeout sequence is configured via ``Timing.CHART_EXPORT_RETRY_TIMEOUTS_S``.
-    If execution times out, the chart export worker is reset before retrying.
+    Render contexts reuse one worker process, but a timed-out export only
+    terminates the worker owned by that context.
     If all retries are exhausted, raises ChartGenerationError.
     """
     execution_id = uuid.uuid4().hex[:8]
     timeouts = Timing.CHART_EXPORT_RETRY_TIMEOUTS_S
+    context_suffix = f" ({context})" if context else ""
     for i, timeout in enumerate(timeouts):
-        executor = _get_chart_export_executor()
+        executor, owns_executor = _get_chart_export_executor()
+        future = None
         try:
             logger.info(
-                "[%s] Attempting execution of %s (Attempt %s/%s, timeout=%ss)",
+                "[%s] Attempting execution of %s%s (Attempt %s/%s, timeout=%ss)",
                 execution_id,
                 func.__name__,
+                context_suffix,
                 i + 1,
                 len(timeouts),
                 timeout,
@@ -185,29 +234,41 @@ def _execute_with_retry(func, *args, **kwargs):
             future = executor.submit(func, *args, **kwargs)
             result = future.result(timeout=timeout)
             logger.info(
-                "[%s] Execution of %s completed successfully",
+                "[%s] Execution of %s%s completed successfully",
                 execution_id,
                 func.__name__,
+                context_suffix,
             )
+            if owns_executor:
+                _shutdown_chart_export_executor(executor, terminate_workers=False)
             return result
         except TimeoutError:
-            # Reset the worker on timeout to clear stuck browser state.
-            _reset_chart_export_executor()
+            if future is not None:
+                cancel = getattr(future, "cancel", None)
+                if callable(cancel):
+                    cancel()
+            _shutdown_chart_export_executor(executor, terminate_workers=True)
+            if not owns_executor:
+                _replace_scoped_chart_export_executor()
 
             logger.warning(
-                "[%s] Function %s timed out after %s seconds. Retrying... Attempt %s of %s",
+                "[%s] Function %s%s timed out after %s seconds. "
+                "Retrying... Attempt %s of %s",
                 execution_id,
                 func.__name__,
+                context_suffix,
                 timeout,
                 i + 1,
                 len(timeouts),
             )
             continue
         except Exception:
-            _reset_chart_export_executor()
+            _shutdown_chart_export_executor(executor, terminate_workers=False)
+            if not owns_executor:
+                _replace_scoped_chart_export_executor()
             raise
     raise ChartGenerationError(
-        f"[{execution_id}] Function {func.__name__} failed after all retries."
+        f"[{execution_id}] Function {func.__name__}{context_suffix} failed after all retries."
     )
 
 
@@ -596,6 +657,11 @@ class PlotlyGraphObjects(BaseChart):
             image_width,
             image_height,
             self.scale,
+            context=(
+                f"{self.type} chart title={self.title!r}"
+                if self.title
+                else f"{self.type} chart"
+            ),
         )
 
     @staticmethod

--- a/slideflow/presentations/charts.py
+++ b/slideflow/presentations/charts.py
@@ -64,7 +64,7 @@ import plotly.graph_objects as go
 import plotly.io as pio
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from slideflow.builtins.template_engine import get_template_engine
+from slideflow.builtins.template_engine import TemplateEngine, get_template_engine
 from slideflow.constants import GoogleSlides, Timing
 from slideflow.data.connectors.base import BaseSourceConfig as DataSourceConfig
 from slideflow.presentations.positioning import safe_eval_expression
@@ -293,6 +293,15 @@ class BaseChart(BaseModel, ABC):
         Optional[float],
         Field(2.0, description="Image scaling factor for higher resolution"),
     ]
+    template_engine: Annotated[
+        Optional[TemplateEngine],
+        Field(
+            None,
+            exclude=True,
+            repr=False,
+            description="Build-scoped template engine for resolving chart templates.",
+        ),
+    ] = None
 
     @field_validator("dimensions_format")
     @classmethod
@@ -950,7 +959,7 @@ class TemplateChart(BaseChart):
             >>> image_bytes = chart.generate_chart_image(sales_df)
         """
 
-        engine = get_template_engine()
+        engine = self.template_engine or get_template_engine()
 
         # Render the template with user config
         rendered_config = engine.render_template(

--- a/slideflow/presentations/providers/base.py
+++ b/slideflow/presentations/providers/base.py
@@ -36,6 +36,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
+from slideflow.constants import GoogleSlides
+
 
 class ProviderSlideResult(BaseModel):
     """Result model for individual slide operations in presentation providers.
@@ -394,7 +396,10 @@ class PresentationProvider(ABC):
 
     @abstractmethod
     def share_presentation(
-        self, presentation_id: str, emails: List[str], role: str = "writer"
+        self,
+        presentation_id: str,
+        emails: List[str],
+        role: str = GoogleSlides.PERMISSION_READER,
     ) -> None:
         """Share the presentation with specified users.
 

--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -114,10 +114,10 @@ class GoogleDocsProviderConfig(PresentationProviderConfig):
         description="If true, fail rendering when chart image cleanup fails.",
     )
     chart_image_sharing_mode: Literal["public", "restricted"] = Field(
-        "public",
+        "restricted",
         description=(
-            "Chart image sharing mode. 'public' grants anyone:reader (default); "
-            "'restricted' skips public sharing for tighter access control."
+            "Chart image sharing mode. 'restricted' skips public sharing (default); "
+            "'public' grants anyone:reader and should be used only when explicitly needed."
         ),
     )
     transfer_ownership_to: Optional[str] = Field(
@@ -165,6 +165,8 @@ class GoogleDocsProvider(PresentationProvider):
         super().__init__(config)
         self.config: GoogleDocsProviderConfig = config
         self._section_insert_indices: Dict[Tuple[str, str], int] = {}
+        self._uploaded_chart_image_ids_by_url: Dict[str, str] = {}
+        self._chart_image_cleanup_failed_ids: List[str] = []
 
         loaded_credentials = handle_google_credentials(
             config.credentials,
@@ -256,7 +258,9 @@ class GoogleDocsProvider(PresentationProvider):
         self, presentation_id: str, image_data: bytes, filename: str
     ) -> Tuple[str, str]:
         del presentation_id
-        return self._upload_image_to_drive(image_data, filename)
+        url, file_id = self._upload_image_to_drive(image_data, filename)
+        self._remember_uploaded_chart_image(url, file_id)
+        return url, file_id
 
     def insert_chart_to_slide(
         self,
@@ -298,23 +302,27 @@ class GoogleDocsProvider(PresentationProvider):
         if insert_index < anchor.section_start:
             insert_index = anchor.section_start
 
-        requests = [
-            {
-                "insertInlineImage": {
-                    "uri": image_url,
-                    "location": {"index": insert_index},
-                    "objectSize": {
-                        "width": {"magnitude": width, "unit": "PT"},
-                        "height": {"magnitude": height, "unit": "PT"},
-                    },
+        temporary_permission = self._grant_temporary_chart_image_access(image_url)
+        try:
+            requests = [
+                {
+                    "insertInlineImage": {
+                        "uri": image_url,
+                        "location": {"index": insert_index},
+                        "objectSize": {
+                            "width": {"magnitude": width, "unit": "PT"},
+                            "height": {"magnitude": height, "unit": "PT"},
+                        },
+                    }
                 }
-            }
-        ]
-        self._execute_request(
-            self.docs_service.documents().batchUpdate(
-                documentId=presentation_id, body={"requests": requests}
+            ]
+            self._execute_request(
+                self.docs_service.documents().batchUpdate(
+                    documentId=presentation_id, body={"requests": requests}
+                )
             )
-        )
+        finally:
+            self._revoke_temporary_chart_image_access(temporary_permission)
         # Docs inserts inline objects as a single position in the text stream.
         self._section_insert_indices[section_key] = insert_index + 1
 
@@ -893,8 +901,7 @@ class GoogleDocsProvider(PresentationProvider):
                 )
             else:
                 logger.error("Error trashing file %s: %s", file_id, error)
-            if self.config.strict_cleanup:
-                raise
+            raise
 
     def _create_document(self, title: str) -> str:
         created = self._execute_request(
@@ -937,7 +944,12 @@ class GoogleDocsProvider(PresentationProvider):
     def _upload_image_to_drive(
         self, image_bytes: bytes, filename: str
     ) -> Tuple[str, str]:
-        sharing_mode = getattr(self.config, "chart_image_sharing_mode", "public")
+        sharing_mode = getattr(self.config, "chart_image_sharing_mode", "restricted")
+        if sharing_mode == "public":
+            logger.warning(
+                "Chart image sharing mode is public; uploaded chart images will "
+                "be granted anyone:reader and may expose sensitive data."
+            )
         return upload_png_to_drive(
             drive_service=self.drive_service,
             execute_request=self._execute_request,
@@ -950,9 +962,80 @@ class GoogleDocsProvider(PresentationProvider):
             sleep_fn=time.sleep,
             on_restricted_file=(
                 lambda resolved_file_id: logger.info(
-                    "Chart image sharing mode is restricted; skipping public Drive permission "
+                    "Chart image sharing mode is restricted; uploaded Drive file "
+                    "will stay private except for temporary insertion access "
                     "(file_id=%s).",
                     resolved_file_id,
                 )
             ),
         )
+
+    def _remember_uploaded_chart_image(self, image_url: str, file_id: str) -> None:
+        if not hasattr(self, "_uploaded_chart_image_ids_by_url"):
+            self._uploaded_chart_image_ids_by_url = {}
+        self._uploaded_chart_image_ids_by_url[image_url] = file_id
+
+    def _grant_temporary_chart_image_access(
+        self, image_url: str
+    ) -> Optional[Tuple[str, str]]:
+        if (
+            getattr(self.config, "chart_image_sharing_mode", "restricted")
+            != "restricted"
+        ):
+            return None
+
+        file_id = getattr(self, "_uploaded_chart_image_ids_by_url", {}).get(image_url)
+        if not file_id:
+            return None
+
+        permission = self._execute_request(
+            self.drive_service.permissions().create(
+                fileId=file_id,
+                body={
+                    "role": "reader",
+                    "type": "anyone",
+                    "allowFileDiscovery": False,
+                },
+                fields="id",
+                supportsAllDrives=True,
+            )
+        )
+        permission_id = permission.get("id")
+        if not permission_id:
+            raise RenderingError(
+                f"Google Drive did not return a permission ID for temporary chart image access: {file_id}"
+            )
+        if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
+            time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
+        return file_id, str(permission_id)
+
+    def _revoke_temporary_chart_image_access(
+        self, temporary_permission: Optional[Tuple[str, str]]
+    ) -> None:
+        if temporary_permission is None:
+            return
+
+        file_id, permission_id = temporary_permission
+        try:
+            self._execute_request(
+                self.drive_service.permissions().delete(
+                    fileId=file_id,
+                    permissionId=permission_id,
+                    supportsAllDrives=True,
+                )
+            )
+        except Exception as error:
+            logger.error(
+                "Failed to revoke temporary public chart image access for %s: %s",
+                file_id,
+                error,
+            )
+            if not hasattr(self, "_chart_image_cleanup_failed_ids"):
+                self._chart_image_cleanup_failed_ids = []
+            if file_id not in self._chart_image_cleanup_failed_ids:
+                self._chart_image_cleanup_failed_ids.append(file_id)
+
+    def consume_chart_image_cleanup_failures(self) -> List[str]:
+        failures = list(getattr(self, "_chart_image_cleanup_failed_ids", []))
+        self._chart_image_cleanup_failed_ids = []
+        return failures

--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -40,6 +40,7 @@ from slideflow.utilities.google_api import (
     slideflow_google_request_builder,
     upload_png_to_drive,
 )
+from slideflow.utilities.google_permissions import normalize_google_share_role
 from slideflow.utilities.logging import get_logger
 from slideflow.utilities.rate_limiter import RateLimiter
 
@@ -101,7 +102,7 @@ class GoogleDocsProviderConfig(PresentationProviderConfig):
         description="Email addresses to share the generated document with.",
     )
     share_role: str = Field(
-        GoogleSlides.PERMISSION_WRITER,
+        GoogleSlides.PERMISSION_READER,
         description="Share role: reader, writer, or commenter.",
     )
     requests_per_second: float = Field(
@@ -133,6 +134,11 @@ class GoogleDocsProviderConfig(PresentationProviderConfig):
     @classmethod
     def _validate_transfer_ownership_to(cls, value: Optional[str]) -> Optional[str]:
         return normalize_transfer_owner_email(value)
+
+    @field_validator("share_role")
+    @classmethod
+    def _validate_share_role(cls, value: str) -> str:
+        return normalize_google_share_role(value)
 
 
 class GoogleDocsProvider(PresentationProvider):
@@ -836,11 +842,15 @@ class GoogleDocsProvider(PresentationProvider):
             return None
 
     def share_presentation(
-        self, presentation_id: str, emails: List[str], role: str = "writer"
+        self,
+        presentation_id: str,
+        emails: List[str],
+        role: str = GoogleSlides.PERMISSION_READER,
     ) -> None:
         if not emails:
             return
 
+        role = normalize_google_share_role(role)
         for email in emails:
             permission = {"type": "user", "role": role, "emailAddress": email}
             self._execute_request(

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -171,10 +171,10 @@ class GoogleSlidesProviderConfig(PresentationProviderConfig):
         description="If true, fail rendering when uploaded chart images cannot be cleaned up.",
     )
     chart_image_sharing_mode: Literal["public", "restricted"] = Field(
-        "public",
+        "restricted",
         description=(
-            "Chart image sharing mode. 'public' grants anyone:reader (default); "
-            "'restricted' skips public sharing for tighter access control."
+            "Chart image sharing mode. 'restricted' skips public sharing (default); "
+            "'public' grants anyone:reader and should be used only when explicitly needed."
         ),
     )
     transfer_ownership_to: Optional[str] = Field(
@@ -258,6 +258,8 @@ class GoogleSlidesProvider(PresentationProvider):
         """
         super().__init__(config)
         self.config: GoogleSlidesProviderConfig = config
+        self._uploaded_chart_image_ids_by_url: Dict[str, str] = {}
+        self._chart_image_cleanup_failed_ids: List[str] = []
 
         # Initialize Google API services
         loaded_credentials = handle_google_credentials(config.credentials)
@@ -389,6 +391,7 @@ class GoogleSlidesProvider(PresentationProvider):
             Tuple of (image_url, file_id)
         """
         url, file_id = self._upload_image_to_drive(image_data, filename)
+        self._remember_uploaded_chart_image(url, file_id)
         return (url, file_id)
 
     def insert_chart_to_slide(
@@ -410,29 +413,33 @@ class GoogleSlidesProvider(PresentationProvider):
             x, y: Position coordinates
             width, height: Chart dimensions
         """
-        requests = [
-            {
-                "createImage": {
-                    "url": image_url,
-                    "elementProperties": {
-                        "pageObjectId": slide_id,
-                        "size": {
-                            "width": {"magnitude": width, "unit": "PT"},
-                            "height": {"magnitude": height, "unit": "PT"},
+        temporary_permission = self._grant_temporary_chart_image_access(image_url)
+        try:
+            requests = [
+                {
+                    "createImage": {
+                        "url": image_url,
+                        "elementProperties": {
+                            "pageObjectId": slide_id,
+                            "size": {
+                                "width": {"magnitude": width, "unit": "PT"},
+                                "height": {"magnitude": height, "unit": "PT"},
+                            },
+                            "transform": {
+                                "scaleX": 1,
+                                "scaleY": 1,
+                                "translateX": x,
+                                "translateY": y,
+                                "unit": "PT",
+                            },
                         },
-                        "transform": {
-                            "scaleX": 1,
-                            "scaleY": 1,
-                            "translateX": x,
-                            "translateY": y,
-                            "unit": "PT",
-                        },
-                    },
+                    }
                 }
-            }
-        ]
+            ]
 
-        self._batch_update(presentation_id, requests)
+            self._batch_update(presentation_id, requests)
+        finally:
+            self._revoke_temporary_chart_image_access(temporary_permission)
 
     def replace_text_in_slide(
         self, presentation_id: str, slide_id: str, placeholder: str, replacement: str
@@ -918,7 +925,14 @@ class GoogleSlidesProvider(PresentationProvider):
                 self.config.drive_folder_id or self._get_or_create_destination_folder()
             )
 
-            sharing_mode = getattr(self.config, "chart_image_sharing_mode", "public")
+            sharing_mode = getattr(
+                self.config, "chart_image_sharing_mode", "restricted"
+            )
+            if sharing_mode == "public":
+                logger.warning(
+                    "Chart image sharing mode is public; uploaded chart images will "
+                    "be granted anyone:reader and may expose sensitive data."
+                )
             public_url, file_id = upload_png_to_drive(
                 drive_service=self.drive_service,
                 execute_request=self._execute_request,
@@ -931,7 +945,8 @@ class GoogleSlidesProvider(PresentationProvider):
                 sleep_fn=time.sleep,
                 on_restricted_file=(
                     lambda resolved_file_id: logger.info(
-                        "Chart image sharing mode is restricted; skipping public Drive permission "
+                        "Chart image sharing mode is restricted; uploaded Drive file "
+                        "will stay private except for temporary insertion access "
                         "(file_id=%s).",
                         resolved_file_id,
                     )
@@ -960,6 +975,76 @@ class GoogleSlidesProvider(PresentationProvider):
                 filename=filename,
             )
             raise
+
+    def _remember_uploaded_chart_image(self, image_url: str, file_id: str) -> None:
+        if not hasattr(self, "_uploaded_chart_image_ids_by_url"):
+            self._uploaded_chart_image_ids_by_url = {}
+        self._uploaded_chart_image_ids_by_url[image_url] = file_id
+
+    def _grant_temporary_chart_image_access(
+        self, image_url: str
+    ) -> Optional[Tuple[str, str]]:
+        if (
+            getattr(self.config, "chart_image_sharing_mode", "restricted")
+            != "restricted"
+        ):
+            return None
+
+        file_id = getattr(self, "_uploaded_chart_image_ids_by_url", {}).get(image_url)
+        if not file_id:
+            return None
+
+        permission = self._execute_request(
+            self.drive_service.permissions().create(
+                fileId=file_id,
+                body={
+                    "role": "reader",
+                    "type": "anyone",
+                    "allowFileDiscovery": False,
+                },
+                fields="id",
+                supportsAllDrives=True,
+            )
+        )
+        permission_id = permission.get("id")
+        if not permission_id:
+            raise RuntimeError(
+                f"Google Drive did not return a permission ID for temporary chart image access: {file_id}"
+            )
+        if Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S > 0:
+            time.sleep(Timing.GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S)
+        return file_id, str(permission_id)
+
+    def _revoke_temporary_chart_image_access(
+        self, temporary_permission: Optional[Tuple[str, str]]
+    ) -> None:
+        if temporary_permission is None:
+            return
+
+        file_id, permission_id = temporary_permission
+        try:
+            self._execute_request(
+                self.drive_service.permissions().delete(
+                    fileId=file_id,
+                    permissionId=permission_id,
+                    supportsAllDrives=True,
+                )
+            )
+        except Exception as error:
+            logger.error(
+                "Failed to revoke temporary public chart image access for %s: %s",
+                file_id,
+                error,
+            )
+            if not hasattr(self, "_chart_image_cleanup_failed_ids"):
+                self._chart_image_cleanup_failed_ids = []
+            if file_id not in self._chart_image_cleanup_failed_ids:
+                self._chart_image_cleanup_failed_ids.append(file_id)
+
+    def consume_chart_image_cleanup_failures(self) -> List[str]:
+        failures = list(getattr(self, "_chart_image_cleanup_failed_ids", []))
+        self._chart_image_cleanup_failed_ids = []
+        return failures
 
     def _batch_update(
         self, presentation_id: str, requests: List[Dict[str, Any]]
@@ -1029,4 +1114,4 @@ class GoogleSlidesProvider(PresentationProvider):
                 logger.error(
                     "Error trashing file %s: %s", file_id, error, exc_info=True
                 )
-            # Do not re-raise, we want to continue cleanup
+            raise

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -95,6 +95,7 @@ from slideflow.utilities.google_api import (
     slideflow_google_request_builder,
     upload_png_to_drive,
 )
+from slideflow.utilities.google_permissions import normalize_google_share_role
 from slideflow.utilities.logging import get_logger, log_api_operation
 from slideflow.utilities.rate_limiter import RateLimiter
 
@@ -160,7 +161,7 @@ class GoogleSlidesProviderConfig(PresentationProviderConfig):
         default_factory=list, description="Email addresses to share presentation with"
     )
     share_role: str = Field(
-        GoogleSlides.PERMISSION_WRITER,
+        GoogleSlides.PERMISSION_READER,
         description="Permission role: reader, writer, or commenter",
     )
     requests_per_second: float = Field(
@@ -190,6 +191,11 @@ class GoogleSlidesProviderConfig(PresentationProviderConfig):
     @classmethod
     def _validate_transfer_ownership_to(cls, value: Optional[str]) -> Optional[str]:
         return normalize_transfer_owner_email(value)
+
+    @field_validator("share_role")
+    @classmethod
+    def _validate_share_role(cls, value: str) -> str:
+        return normalize_google_share_role(value)
 
 
 class GoogleSlidesProvider(PresentationProvider):
@@ -638,7 +644,7 @@ class GoogleSlidesProvider(PresentationProvider):
         self,
         presentation_id: str,
         emails: List[str],
-        role: str = GoogleSlides.PERMISSION_WRITER,
+        role: str = GoogleSlides.PERMISSION_READER,
     ) -> None:
         """Share Google Slides presentation with users.
 
@@ -648,6 +654,7 @@ class GoogleSlidesProvider(PresentationProvider):
             role: Permission role (reader, writer, commenter)
         """
         if emails:
+            role = normalize_google_share_role(role)
             try:
                 for email in emails:
                     permission = {"type": "user", "role": role, "emailAddress": email}

--- a/slideflow/replacements/ai_text.py
+++ b/slideflow/replacements/ai_text.py
@@ -82,7 +82,7 @@ from slideflow.ai.providers import AIProvider
 from slideflow.ai.registry import get_provider_class
 from slideflow.data.connectors.connect import DataSourceConfig
 from slideflow.replacements.base import BaseReplacement
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line
 from slideflow.utilities.exceptions import ReplacementError
 from slideflow.utilities.logging import get_logger
 
@@ -371,7 +371,7 @@ class AITextReplacement(BaseReplacement):
                             "AI text replacement fallback: data transform failed for "
                             "source '%s' (%s)",
                             name,
-                            safe_error_line(error),
+                            redacted_error_line(error),
                             exc_info=True,
                         )
                         return f'Summary unable to be generated as data source "{name}" was not available'

--- a/slideflow/replacements/table.py
+++ b/slideflow/replacements/table.py
@@ -79,6 +79,7 @@ from slideflow.constants import Timing
 from slideflow.data.connectors.connect import DataSourceConfig
 from slideflow.replacements.base import BaseReplacement
 from slideflow.replacements.utils import dataframe_to_replacement_object
+from slideflow.utilities.dataframes import copy_dataframe
 
 
 class TableColumnFormatter(BaseModel):
@@ -446,6 +447,9 @@ class TableReplacement(BaseReplacement):
             )
 
         df = self.apply_data_transforms(df)
+
+        if self.formatting.custom_formatters:
+            df = copy_dataframe(df)
 
         for col, fmt in self.formatting.custom_formatters.items():
             if col in df.columns:

--- a/slideflow/utilities/__init__.py
+++ b/slideflow/utilities/__init__.py
@@ -54,7 +54,7 @@ Performance Features:
 
 from slideflow.utilities.config import ConfigLoader
 from slideflow.utilities.data_transforms import apply_data_transforms
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line, safe_error_line
 from slideflow.utilities.exceptions import (
     APIError,
     APIRateLimitError,
@@ -75,11 +75,16 @@ from slideflow.utilities.logging import (
     log_performance,
     setup_logging,
 )
+from slideflow.utilities.redaction import REDACTED, redact_text, redact_value
 
 __all__ = [
     "ConfigLoader",
     "apply_data_transforms",
     "safe_error_line",
+    "redacted_error_line",
+    "REDACTED",
+    "redact_text",
+    "redact_value",
     "SlideFlowError",
     "ConfigurationError",
     "DataSourceError",

--- a/slideflow/utilities/dataframes.py
+++ b/slideflow/utilities/dataframes.py
@@ -1,0 +1,14 @@
+"""DataFrame utility helpers shared across runtime components."""
+
+import pandas as pd
+
+
+def copy_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Return an isolated copy of a pandas-compatible DataFrame."""
+    copy_method = getattr(df, "copy", None)
+    if callable(copy_method):
+        try:
+            return copy_method(deep=True)
+        except TypeError:
+            return copy_method()
+    return pd.DataFrame(df)

--- a/slideflow/utilities/error_messages.py
+++ b/slideflow/utilities/error_messages.py
@@ -2,8 +2,12 @@
 
 from typing import Optional
 
+from slideflow.utilities.redaction import redact_text
 
-def safe_error_line(error: BaseException, fallback: Optional[str] = None) -> str:
+
+def safe_error_line(
+    error: BaseException, fallback: Optional[str] = None, *, redact: bool = False
+) -> str:
     """Return a non-empty single-line error message.
 
     - Collapses multi-line exception strings to the first line.
@@ -14,9 +18,14 @@ def safe_error_line(error: BaseException, fallback: Optional[str] = None) -> str
     if message:
         first_line = message.splitlines()[0].strip()
         if first_line:
-            return first_line
+            return redact_text(first_line) if redact else first_line
 
     if fallback:
-        return fallback
+        return redact_text(fallback) if redact else fallback
 
     return error.__class__.__name__
+
+
+def redacted_error_line(error: BaseException, fallback: Optional[str] = None) -> str:
+    """Return a non-empty single-line error message with secrets redacted."""
+    return safe_error_line(error, fallback=fallback, redact=True)

--- a/slideflow/utilities/google_api.py
+++ b/slideflow/utilities/google_api.py
@@ -84,7 +84,7 @@ def upload_png_to_drive(
     on_restricted_file: Optional[Callable[[str], None]] = None,
     sleep_fn: Callable[[float], None] = time.sleep,
 ) -> Tuple[str, str]:
-    """Upload PNG bytes to Drive and return (public_url, file_id)."""
+    """Upload PNG bytes to Drive and return (image_url, file_id)."""
     file_metadata: Dict[str, Any] = {"name": filename}
     if destination_folder_id:
         file_metadata["parents"] = [destination_folder_id]
@@ -105,6 +105,8 @@ def upload_png_to_drive(
     )
     file_id = uploaded_file.get("id")
 
+    image_url = f"https://drive.google.com/uc?id={file_id}"
+
     if sharing_mode == "public":
         execute_request(
             drive_service.permissions().create(
@@ -115,7 +117,8 @@ def upload_png_to_drive(
         )
         if permission_delay_seconds > 0:
             sleep_fn(permission_delay_seconds)
-    elif on_restricted_file is not None:
-        on_restricted_file(file_id)
+    elif sharing_mode == "restricted":
+        if on_restricted_file is not None:
+            on_restricted_file(file_id)
 
-    return f"https://drive.google.com/uc?id={file_id}", file_id
+    return image_url, file_id

--- a/slideflow/utilities/google_permissions.py
+++ b/slideflow/utilities/google_permissions.py
@@ -1,0 +1,20 @@
+"""Shared Google Drive permission helpers."""
+
+from __future__ import annotations
+
+from slideflow.constants import GoogleSlides
+
+ALLOWED_GOOGLE_SHARE_ROLES = (
+    GoogleSlides.PERMISSION_READER,
+    GoogleSlides.PERMISSION_WRITER,
+    GoogleSlides.PERMISSION_COMMENTER,
+)
+
+
+def normalize_google_share_role(value: str) -> str:
+    """Normalize and validate a Google Drive share role."""
+    role = value.strip().lower() if isinstance(value, str) else ""
+    if role not in ALLOWED_GOOGLE_SHARE_ROLES:
+        allowed = ", ".join(ALLOWED_GOOGLE_SHARE_ROLES)
+        raise ValueError(f"share_role must be one of: {allowed}")
+    return role

--- a/slideflow/utilities/redaction.py
+++ b/slideflow/utilities/redaction.py
@@ -1,0 +1,150 @@
+"""Central redaction helpers for logs, errors, and machine-readable output."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+REDACTED = "***REDACTED***"
+
+_SENSITIVE_KEY_NAMES = {
+    "access_token",
+    "api_key",
+    "authorization",
+    "auth_token",
+    "client_email",
+    "client_secret",
+    "credential",
+    "credentials",
+    "credentials_json",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "service_account",
+    "token",
+}
+
+_NON_SECRET_KEY_NAMES = {
+    "run_key",
+}
+
+_SENSITIVE_URL_PARAMS = {
+    "access_token",
+    "api_key",
+    "auth_token",
+    "client_secret",
+    "credential",
+    "credentials",
+    "key",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "token",
+}
+
+_URL_USERINFO_RE = re.compile(
+    r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)(?P<userinfo>[^/@\s]+@)"
+)
+_URL_QUERY_SECRET_RE = re.compile(
+    r"(?P<prefix>[?&](?:"
+    + "|".join(sorted(re.escape(param) for param in _SENSITIVE_URL_PARAMS))
+    + r")=)(?P<value>[^&#\s]+)",
+    re.IGNORECASE,
+)
+_AUTH_HEADER_RE = re.compile(
+    r"\b(?P<prefix>authorization\s*[:=]\s*)"
+    r"(?:(?P<scheme>[A-Za-z][A-Za-z0-9._-]*)\s+)?(?P<value>[^\s,;]+)",
+    re.IGNORECASE,
+)
+_BEARER_RE = re.compile(
+    r"\b(?P<scheme>bearer|basic)\s+(?P<value>[A-Za-z0-9._~+/\-=]+)",
+    re.IGNORECASE,
+)
+_PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_SENSITIVE_FIELD_RE = re.compile(
+    r"(?P<prefix>\b(?:[A-Z0-9_]*TOKEN|[A-Z0-9_]*SECRET|[A-Z0-9_]*KEY|"
+    r"access_token|api_key|auth_token|client_email|client_secret|"
+    r"credentials?|credentials_json|password|private_key|refresh_token)"
+    r"\b\s*[:=]\s*)(?P<quote>[\"']?)(?P<value>[^&\"'\s,;)}]+)(?P=quote)",
+    re.IGNORECASE,
+)
+
+
+def _normalize_key(key: object) -> str:
+    key_text = str(key).strip().lower()
+    normalized = re.sub(r"[^a-z0-9]+", "_", key_text).strip("_")
+    return normalized
+
+
+def is_sensitive_key(key: object) -> bool:
+    """Return whether a mapping key conventionally carries sensitive data."""
+    normalized = _normalize_key(key)
+    if normalized in _NON_SECRET_KEY_NAMES:
+        return False
+    if normalized in _SENSITIVE_KEY_NAMES:
+        return True
+    return normalized.endswith(("_token", "_secret", "_key", "_credentials"))
+
+
+def redact_text(text: str) -> str:
+    """Redact common secret patterns in free-form text."""
+    redacted = _PRIVATE_KEY_BLOCK_RE.sub(REDACTED, text)
+    redacted = _URL_USERINFO_RE.sub(
+        lambda match: f"{match.group('scheme')}***@", redacted
+    )
+    redacted = _URL_QUERY_SECRET_RE.sub(
+        lambda match: f"{match.group('prefix')}{REDACTED}",
+        redacted,
+    )
+    redacted = _AUTH_HEADER_RE.sub(
+        _redact_authorization_header,
+        redacted,
+    )
+    redacted = _BEARER_RE.sub(
+        lambda match: f"{match.group('scheme')} {REDACTED}",
+        redacted,
+    )
+    redacted = _SENSITIVE_FIELD_RE.sub(
+        lambda match: (
+            f"{match.group('prefix')}{match.group('quote')}"
+            f"{REDACTED}{match.group('quote')}"
+        ),
+        redacted,
+    )
+    return redacted
+
+
+def _redact_authorization_header(match: re.Match[str]) -> str:
+    scheme = match.group("scheme")
+    if scheme:
+        return f"{match.group('prefix')}{scheme} {REDACTED}"
+    return f"{match.group('prefix')}{REDACTED}"
+
+
+def redact_value(value: Any, *, key: object | None = None) -> Any:
+    """Recursively redact sensitive values while preserving payload shape."""
+    if key is not None and is_sensitive_key(key):
+        return None if value is None else REDACTED
+
+    if isinstance(value, Mapping):
+        return {
+            mapping_key: redact_value(mapping_value, key=mapping_key)
+            for mapping_key, mapping_value in value.items()
+        }
+
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+
+    if isinstance(value, tuple):
+        return [redact_value(item) for item in value]
+
+    if isinstance(value, str):
+        return redact_text(value)
+
+    return value

--- a/slideflow/workbooks/builder.py
+++ b/slideflow/workbooks/builder.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 from slideflow.ai.registry import create_provider as create_ai_provider
 from slideflow.utilities.config import ConfigLoader
 from slideflow.utilities.data_transforms import apply_data_transforms
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line
 from slideflow.utilities.logging import get_logger
 from slideflow.workbooks.base import (
     WorkbookBuildResult,
@@ -458,7 +458,7 @@ class WorkbookBuilder:
                 if bounds is not None:
                     indexed_tab_bounds[index] = bounds
             except Exception as error:
-                error_message = safe_error_line(error)
+                error_message = redacted_error_line(error)
                 logger.error(
                     "Workbook tab build failed for tab '%s': %s",
                     tab.name,
@@ -508,7 +508,7 @@ class WorkbookBuilder:
                 target_tab, target_cell, _ = self._summary_context(
                     summary, tab_dataframes
                 )
-                error_message = safe_error_line(error)
+                error_message = redacted_error_line(error)
                 logger.error(
                     "Workbook summary generation failed for summary '%s': %s",
                     summary.name,

--- a/slideflow/workbooks/providers/google_sheets.py
+++ b/slideflow/workbooks/providers/google_sheets.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from slideflow.constants import Environment, GoogleSlides
 from slideflow.utilities.auth import handle_google_credentials
@@ -20,6 +20,7 @@ from slideflow.utilities.google_api import (
     execute_rate_limited_request,
     slideflow_google_request_builder,
 )
+from slideflow.utilities.google_permissions import normalize_google_share_role
 from slideflow.utilities.logging import get_logger
 from slideflow.utilities.rate_limiter import RateLimiter
 from slideflow.workbooks.config import RESERVED_METADATA_TAB
@@ -69,6 +70,11 @@ class GoogleSheetsProviderConfig(WorkbookProviderConfig):
         gt=0,
         description="Maximum Google API requests per second.",
     )
+
+    @field_validator("share_role")
+    @classmethod
+    def _validate_share_role(cls, value: str) -> str:
+        return normalize_google_share_role(value)
 
 
 class GoogleSheetsProvider(WorkbookProvider):
@@ -767,10 +773,11 @@ class GoogleSheetsProvider(WorkbookProvider):
             return
 
         drive_api = self._drive_api()
+        share_role = normalize_google_share_role(self.config.share_role)
         for email in self.config.share_with:
             permission = {
                 "type": "user",
-                "role": self.config.share_role,
+                "role": share_role,
                 "emailAddress": email,
             }
             try:
@@ -785,7 +792,7 @@ class GoogleSheetsProvider(WorkbookProvider):
                 logger.info(
                     "Shared spreadsheet with %s as %s",
                     email,
-                    self.config.share_role,
+                    share_role,
                 )
             except HttpError as error:
                 raise RenderingError(

--- a/tests/test_charts_coverage_runtime.py
+++ b/tests/test_charts_coverage_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from concurrent.futures import TimeoutError
+import threading
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from types import SimpleNamespace
 from typing import Any, Dict, List, Literal
 
@@ -19,7 +20,7 @@ class _MinimalChart(charts_module.BaseChart):
         return b"image-bytes"
 
 
-def test_reset_chart_export_executor_terminates_processes_and_shutdowns():
+def test_shutdown_chart_export_executor_terminates_owned_processes_and_shutdowns():
     class _Process:
         def __init__(self) -> None:
             self.terminated = False
@@ -36,16 +37,14 @@ def test_reset_chart_export_executor_terminates_processes_and_shutdowns():
             self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
 
     executor = _Executor()
-    charts_module._CHART_EXPORT_EXECUTOR = executor
 
-    charts_module._reset_chart_export_executor()
+    charts_module._shutdown_chart_export_executor(executor, terminate_workers=True)
 
-    assert charts_module._CHART_EXPORT_EXECUTOR is None
     assert all(process.terminated for process in executor._processes.values())
     assert executor.shutdown_calls == [{"wait": False, "cancel_futures": True}]
 
 
-def test_reset_chart_export_executor_handles_terminate_and_shutdown_errors():
+def test_shutdown_chart_export_executor_handles_terminate_and_shutdown_errors():
     class _Process:
         def terminate(self) -> None:
             raise RuntimeError("terminate failed")
@@ -56,15 +55,41 @@ def test_reset_chart_export_executor_handles_terminate_and_shutdown_errors():
         def shutdown(self, wait: bool, cancel_futures: bool) -> None:
             raise RuntimeError("shutdown failed")
 
-    charts_module._CHART_EXPORT_EXECUTOR = _Executor()
+    charts_module._shutdown_chart_export_executor(_Executor(), terminate_workers=True)
 
-    charts_module._reset_chart_export_executor()
 
-    assert charts_module._CHART_EXPORT_EXECUTOR is None
+def test_shutdown_chart_export_executor_without_terminate_waits_for_cleanup():
+    class _Process:
+        def __init__(self) -> None:
+            self.terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+    class _Executor:
+        def __init__(self) -> None:
+            self._processes = {"a": _Process()}
+            self.shutdown_calls: List[Dict[str, Any]] = []
+
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+    executor = _Executor()
+
+    charts_module._shutdown_chart_export_executor(executor, terminate_workers=False)
+
+    assert executor._processes["a"].terminated is False
+    assert executor.shutdown_calls == [{"wait": True, "cancel_futures": True}]
 
 
 def test_execute_with_retry_timeout_then_success(monkeypatch):
     class _FutureTimeout:
+        def __init__(self) -> None:
+            self.cancelled = False
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
         def result(self, timeout: int) -> bytes:
             raise TimeoutError()
 
@@ -72,26 +97,43 @@ def test_execute_with_retry_timeout_then_success(monkeypatch):
         def result(self, timeout: int) -> bytes:
             return b"ok"
 
+    class _Process:
+        def __init__(self) -> None:
+            self.terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+
     class _Executor:
         def __init__(self, future: Any) -> None:
             self._future = future
+            self._processes = {"worker": _Process()}
+            self.shutdown_calls: List[Dict[str, Any]] = []
 
         def submit(self, func, *args, **kwargs):
             return self._future
 
-    executors = iter([_Executor(_FutureTimeout()), _Executor(_FutureSuccess())])
-    reset_calls: List[bool] = []
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+    timed_out_future = _FutureTimeout()
+    timed_out_executor = _Executor(timed_out_future)
+    success_executor = _Executor(_FutureSuccess())
+    executors = iter([timed_out_executor, success_executor])
     monkeypatch.setattr(
-        charts_module, "_get_chart_export_executor", lambda: next(executors)
-    )
-    monkeypatch.setattr(
-        charts_module, "_reset_chart_export_executor", lambda: reset_calls.append(True)
+        charts_module, "_create_chart_export_executor", lambda: next(executors)
     )
 
     result = charts_module._execute_with_retry(lambda: b"unused")
 
     assert result == b"ok"
-    assert reset_calls == [True]
+    assert timed_out_future.cancelled is True
+    assert timed_out_executor._processes["worker"].terminated is True
+    assert timed_out_executor.shutdown_calls == [
+        {"wait": False, "cancel_futures": True}
+    ]
+    assert success_executor._processes["worker"].terminated is False
+    assert success_executor.shutdown_calls == [{"wait": True, "cancel_futures": True}]
 
 
 def test_execute_with_retry_resets_and_reraises_non_timeout(monkeypatch):
@@ -100,44 +142,63 @@ def test_execute_with_retry_resets_and_reraises_non_timeout(monkeypatch):
             raise RuntimeError("boom")
 
     class _Executor:
+        def __init__(self) -> None:
+            self.shutdown_calls: List[Dict[str, Any]] = []
+
         def submit(self, func, *args, **kwargs):
             return _FutureError()
 
-    reset_calls: List[bool] = []
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+    executor = _Executor()
     monkeypatch.setattr(
-        charts_module, "_get_chart_export_executor", lambda: _Executor()
-    )
-    monkeypatch.setattr(
-        charts_module, "_reset_chart_export_executor", lambda: reset_calls.append(True)
+        charts_module, "_create_chart_export_executor", lambda: executor
     )
 
     with pytest.raises(RuntimeError, match="boom"):
         charts_module._execute_with_retry(lambda: b"unused")
 
-    assert reset_calls == [True]
+    assert executor.shutdown_calls == [{"wait": True, "cancel_futures": True}]
 
 
 def test_execute_with_retry_raises_after_all_timeouts(monkeypatch):
+    class _Process:
+        def __init__(self) -> None:
+            self.terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+
     class _FutureTimeout:
         def result(self, timeout: int) -> bytes:
             raise TimeoutError()
 
     class _Executor:
+        def __init__(self) -> None:
+            self._processes = {"worker": _Process()}
+            self.shutdown_calls: List[Dict[str, Any]] = []
+
         def submit(self, func, *args, **kwargs):
             return _FutureTimeout()
 
-    reset_calls: List[bool] = []
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+    executors = [_Executor(), _Executor(), _Executor()]
+    executor_iter = iter(executors)
     monkeypatch.setattr(
-        charts_module, "_get_chart_export_executor", lambda: _Executor()
-    )
-    monkeypatch.setattr(
-        charts_module, "_reset_chart_export_executor", lambda: reset_calls.append(True)
+        charts_module, "_create_chart_export_executor", lambda: next(executor_iter)
     )
 
     with pytest.raises(ChartGenerationError, match="failed after all retries"):
         charts_module._execute_with_retry(lambda: b"unused")
 
-    assert reset_calls == [True, True, True]
+    assert all(executor._processes["worker"].terminated for executor in executors)
+    assert all(
+        executor.shutdown_calls == [{"wait": False, "cancel_futures": True}]
+        for executor in executors
+    )
 
 
 def test_execute_with_retry_uses_configured_timeout_sequence(monkeypatch):
@@ -152,21 +213,22 @@ def test_execute_with_retry_uses_configured_timeout_sequence(monkeypatch):
     class _Executor:
         def __init__(self, future: _FutureTimeout) -> None:
             self.future = future
+            self.shutdown_calls: List[Dict[str, Any]] = []
 
         def submit(self, func, *args, **kwargs):
             return self.future
 
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
     future = _FutureTimeout()
-    executor = _Executor(future)
-    reset_calls: List[bool] = []
+    executors = [_Executor(future), _Executor(future), _Executor(future)]
+    executor_iter = iter(executors)
 
     monkeypatch.setattr(
         charts_module,
-        "_get_chart_export_executor",
-        lambda: executor,
-    )
-    monkeypatch.setattr(
-        charts_module, "_reset_chart_export_executor", lambda: reset_calls.append(True)
+        "_create_chart_export_executor",
+        lambda: next(executor_iter),
     )
     monkeypatch.setattr(
         charts_module.Timing,
@@ -178,7 +240,171 @@ def test_execute_with_retry_uses_configured_timeout_sequence(monkeypatch):
         charts_module._execute_with_retry(lambda: b"unused")
 
     assert future.timeouts == [1, 2, 3]
-    assert reset_calls == [True, True, True]
+    assert all(
+        executor.shutdown_calls == [{"wait": False, "cancel_futures": True}]
+        for executor in executors
+    )
+
+
+def test_chart_export_executor_scope_reuses_executor_for_successful_exports(
+    monkeypatch,
+):
+    class _FutureSuccess:
+        def result(self, timeout: int) -> bytes:
+            return b"ok"
+
+    class _Executor:
+        def __init__(self) -> None:
+            self.submit_count = 0
+            self.shutdown_calls: List[Dict[str, Any]] = []
+
+        def submit(self, func, *args, **kwargs):
+            self.submit_count += 1
+            return _FutureSuccess()
+
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+    executor = _Executor()
+    create_calls: List[bool] = []
+
+    def _create_executor():
+        create_calls.append(True)
+        return executor
+
+    monkeypatch.setattr(
+        charts_module,
+        "_create_chart_export_executor",
+        _create_executor,
+    )
+
+    with charts_module.chart_export_executor_scope():
+        assert charts_module._execute_with_retry(lambda: b"first") == b"ok"
+        assert charts_module._execute_with_retry(lambda: b"second") == b"ok"
+
+    assert create_calls == [True]
+    assert executor.submit_count == 2
+    assert executor.shutdown_calls == [{"wait": True, "cancel_futures": True}]
+
+
+def test_chart_export_executor_scope_replaces_timed_out_executor(monkeypatch):
+    class _Process:
+        def __init__(self) -> None:
+            self.terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+    class _FutureTimeout:
+        def result(self, timeout: int) -> bytes:
+            raise TimeoutError()
+
+    class _FutureSuccess:
+        def result(self, timeout: int) -> bytes:
+            return b"ok"
+
+    class _Executor:
+        def __init__(self, future: Any) -> None:
+            self.future = future
+            self._processes = {"worker": _Process()}
+            self.shutdown_calls: List[Dict[str, Any]] = []
+
+        def submit(self, func, *args, **kwargs):
+            return self.future
+
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+    timed_out_executor = _Executor(_FutureTimeout())
+    replacement_executor = _Executor(_FutureSuccess())
+    executors = iter([timed_out_executor, replacement_executor])
+
+    monkeypatch.setattr(
+        charts_module,
+        "_create_chart_export_executor",
+        lambda: next(executors),
+    )
+
+    with charts_module.chart_export_executor_scope():
+        assert charts_module._execute_with_retry(lambda: b"unused") == b"ok"
+
+    assert timed_out_executor._processes["worker"].terminated is True
+    assert timed_out_executor.shutdown_calls == [
+        {"wait": False, "cancel_futures": True}
+    ]
+    assert replacement_executor._processes["worker"].terminated is False
+    assert replacement_executor.shutdown_calls == [
+        {"wait": True, "cancel_futures": True}
+    ]
+
+
+def test_execute_with_retry_timeout_does_not_block_concurrent_export(monkeypatch):
+    monkeypatch.setattr(charts_module.Timing, "CHART_EXPORT_RETRY_TIMEOUTS_S", (1,))
+    barrier = threading.Barrier(2)
+
+    class _FutureTimeout:
+        def result(self, timeout: int) -> bytes:
+            barrier.wait(timeout=2)
+            raise TimeoutError()
+
+    class _FutureSuccess:
+        def result(self, timeout: int) -> bytes:
+            barrier.wait(timeout=2)
+            return b"ok"
+
+    class _Executor:
+        def submit(self, func, *args, **kwargs):
+            return _FutureTimeout() if func.__name__ == "_hang" else _FutureSuccess()
+
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            pass
+
+    monkeypatch.setattr(
+        charts_module, "_create_chart_export_executor", lambda: _Executor()
+    )
+
+    def _hang():
+        return b"hang"
+
+    def _ok():
+        return b"ok"
+
+    def _run(func):
+        with charts_module.chart_export_executor_scope():
+            return charts_module._execute_with_retry(func)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        timed_out = executor.submit(_run, _hang)
+        succeeded = executor.submit(_run, _ok)
+
+        assert succeeded.result(timeout=2) == b"ok"
+        with pytest.raises(ChartGenerationError, match="_hang"):
+            timed_out.result(timeout=2)
+
+
+def test_execute_with_retry_timeout_error_includes_chart_context(monkeypatch):
+    monkeypatch.setattr(charts_module.Timing, "CHART_EXPORT_RETRY_TIMEOUTS_S", (1,))
+
+    class _FutureTimeout:
+        def result(self, timeout: int) -> bytes:
+            raise TimeoutError()
+
+    class _Executor:
+        def submit(self, func, *args, **kwargs):
+            return _FutureTimeout()
+
+        def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+            pass
+
+    monkeypatch.setattr(
+        charts_module, "_create_chart_export_executor", lambda: _Executor()
+    )
+
+    with pytest.raises(ChartGenerationError, match="Revenue Trend"):
+        charts_module._execute_with_retry(
+            lambda: b"unused",
+            context="plotly_go chart title='Revenue Trend'",
+        )
 
 
 def test_plotly_to_image_without_scale_omits_scale_option(monkeypatch):
@@ -269,7 +495,7 @@ def test_plotly_generate_chart_image_evaluates_expressions_and_scale(monkeypatch
     monkeypatch.setattr(
         charts_module,
         "_execute_with_retry",
-        lambda func, fig, fmt, width, height, scale: retry_calls.append(
+        lambda func, fig, fmt, width, height, scale, **_kwargs: retry_calls.append(
             (func, fmt, width, height, scale)
         )
         or b"rendered",

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -678,6 +678,69 @@ def test_build_writes_citation_fields_in_output_json(tmp_path, monkeypatch):
     }
 
 
+def test_build_output_json_omits_params_and_redacts_errors(tmp_path, monkeypatch):
+    stub_build_validate_cli_output(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "config.yaml"
+    output_file = tmp_path / "build-redacted.json"
+    params_path = tmp_path / "params.csv"
+    config_file.write_text(
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n"
+    )
+    params_path.write_text("region,api_token\nus,raw-token\n")
+
+    def _fake_build_single(
+        _config_file,
+        _registry_files,
+        params,
+        index,
+        _total,
+        _print_lock,
+        _rps,
+    ):
+        return (
+            "Demo Deck",
+            types.SimpleNamespace(
+                presentation_url="https://example.com/deck",
+                ownership_transfer_error="Authorization: Bearer provider-token",
+            ),
+            index,
+            params,
+        )
+
+    monkeypatch.setattr(
+        build_command_module, "build_single_presentation", _fake_build_single
+    )
+
+    result = build_command_module.build_command(
+        config_file=config_file,
+        registry_files=None,
+        params_path=params_path,
+        dry_run=False,
+        output_json=output_file,
+        threads=1,
+    )
+
+    output_text = output_file.read_text(encoding="utf-8")
+    payload = json.loads(output_text)
+    result_row = payload["results"][0]
+
+    assert "api_token" not in result_row
+    assert "region" not in result_row
+    assert "raw-token" not in output_text
+    assert "provider-token" not in output_text
+    assert result_row["variant_index"] == 1
+    assert (
+        result[0]["ownership_transfer_error"] == "Authorization: Bearer ***REDACTED***"
+    )
+
+
 def test_validate_provider_contract_check_writes_success_json(tmp_path, monkeypatch):
     stub_build_validate_cli_output(monkeypatch)
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -625,6 +625,8 @@ def test_build_writes_citation_fields_in_output_json(tmp_path, monkeypatch):
             "Demo Deck",
             types.SimpleNamespace(
                 presentation_url="https://example.com/deck",
+                chart_image_cleanup_failed_count=1,
+                chart_image_cleanup_failed_ids=["file-1"],
                 citations_enabled=True,
                 citations_total_sources=3,
                 citations_emitted_sources=2,
@@ -666,6 +668,10 @@ def test_build_writes_citation_fields_in_output_json(tmp_path, monkeypatch):
     assert payload["citations_total_sources"] == 3
     assert payload["citations_emitted_sources"] == 2
     assert payload["citations_truncated"] is False
+    assert payload["chart_image_cleanup_failed_count"] == 1
+    assert payload["chart_image_cleanup_failed_ids"] == ["file-1"]
+    assert payload["results"][0]["chart_image_cleanup_failed_count"] == 1
+    assert payload["results"][0]["chart_image_cleanup_failed_ids"] == ["file-1"]
     assert payload["results"][0]["citations_enabled"] is True
     assert payload["results"][0]["citations_by_scope"] == {
         "slide-1": ["src-1", "src-2"]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -156,7 +156,38 @@ def test_build_readonly_google_contract_client_docs_uses_read_scope(monkeypatch)
     assert client.marker_suffix == ">>"
 
 
-def test_create_google_contract_check_client_falls_back_to_provider(monkeypatch):
+def test_create_google_contract_check_client_fails_closed_without_fallback(monkeypatch):
+    monkeypatch.setattr(
+        validate_command_module,
+        "_build_readonly_google_contract_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("readonly failed")
+        ),
+    )
+
+    def _unexpected_create_provider(_provider_config):
+        raise AssertionError("full provider fallback should not be used by default")
+
+    monkeypatch.setattr(
+        provider_factory_module.ProviderFactory,
+        "create_provider",
+        staticmethod(_unexpected_create_provider),
+    )
+
+    presentation_config = types.SimpleNamespace(
+        provider=types.SimpleNamespace(type="google_slides", config={})
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="--provider-contract-full-auth-fallback",
+    ):
+        validate_command_module._create_google_contract_check_client(
+            presentation_config
+        )
+
+
+def test_create_google_contract_check_client_falls_back_when_explicit(monkeypatch):
     monkeypatch.setattr(
         validate_command_module,
         "_build_readonly_google_contract_client",
@@ -177,11 +208,80 @@ def test_create_google_contract_check_client_falls_back_to_provider(monkeypatch)
     )
 
     result = validate_command_module._create_google_contract_check_client(
-        presentation_config
+        presentation_config,
+        allow_full_auth_fallback=True,
     )
 
     assert result is sentinel_provider
     assert result.auth_mode == "provider_fallback"
+
+
+def test_validate_provider_contract_check_fails_closed_without_fallback(
+    tmp_path, monkeypatch
+):
+    stub_build_validate_cli_output(monkeypatch)
+
+    monkeypatch.setattr(
+        validate_command_module,
+        "PresentationConfig",
+        lambda **_: types.SimpleNamespace(
+            provider=types.SimpleNamespace(type="google_slides", config={}),
+            presentation=types.SimpleNamespace(name="Demo", slides=[]),
+        ),
+    )
+    monkeypatch.setattr(
+        provider_factory_module.ProviderFactory,
+        "get_config_class",
+        staticmethod(lambda _provider_type: (lambda **_cfg: None)),
+    )
+    monkeypatch.setattr(
+        validate_command_module,
+        "_build_readonly_google_contract_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("readonly failed")
+        ),
+    )
+
+    def _unexpected_create_provider(_provider_config):
+        raise AssertionError("full provider fallback should not be used by default")
+
+    monkeypatch.setattr(
+        provider_factory_module.ProviderFactory,
+        "create_provider",
+        staticmethod(_unexpected_create_provider),
+    )
+
+    class FakeLoader:
+        def __init__(self, yaml_path: Path, registry_paths):
+            self.config = _minimal_loader_config()
+
+    monkeypatch.setattr(validate_command_module, "ConfigLoader", FakeLoader)
+
+    config_file = tmp_path / "config.yaml"
+    output_file = tmp_path / "validate-fail-closed.json"
+    config_file.write_text(
+        "provider:\n"
+        "  type: google_slides\n"
+        "  config: {}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n"
+    )
+
+    with pytest.raises(validate_command_module.typer.Exit) as exc_info:
+        validate_command_module.validate_command(
+            config_file=config_file,
+            registry_paths=None,
+            output_json=output_file,
+            params_path=None,
+            provider_contract_check=True,
+        )
+
+    assert exc_info.value.code == 1
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert "--provider-contract-full-auth-fallback" in payload["error"]["message"]
+    assert payload["provider_contract"] is None
 
 
 def test_build_dry_run_validates_all_param_rows_and_uses_empty_registry_default(
@@ -853,6 +953,7 @@ def test_validate_provider_contract_check_writes_success_json(tmp_path, monkeypa
         output_json=output_file,
         params_path=params_path,
         provider_contract_check=True,
+        provider_contract_full_auth_fallback=True,
     )
 
     payload = json.loads(output_file.read_text(encoding="utf-8"))
@@ -955,6 +1056,7 @@ def test_validate_provider_contract_check_writes_failure_json(tmp_path, monkeypa
             output_json=output_file,
             params_path=params_path,
             provider_contract_check=True,
+            provider_contract_full_auth_fallback=True,
         )
 
     assert exc_info.value.code == 1
@@ -1017,6 +1119,7 @@ def test_validate_provider_contract_check_requires_google_provider(
             registry_paths=None,
             output_json=output_file,
             provider_contract_check=True,
+            provider_contract_full_auth_fallback=True,
         )
 
     assert exc_info.value.code == 1
@@ -1136,6 +1239,7 @@ def test_validate_provider_contract_check_merges_duplicate_slide_ids(
             output_json=output_file,
             params_path=params_path,
             provider_contract_check=True,
+            provider_contract_full_auth_fallback=True,
         )
 
     assert exc_info.value.code == 1
@@ -1254,6 +1358,7 @@ def test_validate_provider_contract_check_google_docs_success(tmp_path, monkeypa
         output_json=output_file,
         params_path=params_path,
         provider_contract_check=True,
+        provider_contract_full_auth_fallback=True,
     )
 
     payload = json.loads(output_file.read_text(encoding="utf-8"))
@@ -1381,6 +1486,7 @@ def test_validate_provider_contract_check_google_docs_ignores_toc_markers(
         output_json=output_file,
         params_path=params_path,
         provider_contract_check=True,
+        provider_contract_full_auth_fallback=True,
     )
 
     payload = json.loads(output_file.read_text(encoding="utf-8"))
@@ -1487,6 +1593,7 @@ def test_validate_provider_contract_check_google_docs_does_not_stitch_split_mark
             output_json=output_file,
             params_path=params_path,
             provider_contract_check=True,
+            provider_contract_full_auth_fallback=True,
         )
 
     assert exc_info.value.code == 1
@@ -1595,6 +1702,7 @@ def test_validate_provider_contract_check_google_docs_does_not_stitch_split_plac
             output_json=output_file,
             params_path=params_path,
             provider_contract_check=True,
+            provider_contract_full_auth_fallback=True,
         )
 
     assert exc_info.value.code == 1
@@ -1705,6 +1813,7 @@ def test_validate_provider_contract_check_google_docs_missing_section_marker(
             output_json=output_file,
             params_path=params_path,
             provider_contract_check=True,
+            provider_contract_full_auth_fallback=True,
         )
 
     assert exc_info.value.code == 1
@@ -1817,6 +1926,7 @@ def test_validate_provider_contract_check_google_docs_duplicate_marker(
             output_json=output_file,
             params_path=params_path,
             provider_contract_check=True,
+            provider_contract_full_auth_fallback=True,
         )
 
     assert exc_info.value.code == 1
@@ -1923,6 +2033,7 @@ def test_validate_provider_contract_check_google_docs_missing_placeholder(
             output_json=output_file,
             params_path=params_path,
             provider_contract_check=True,
+            provider_contract_full_auth_fallback=True,
         )
 
     assert exc_info.value.code == 1

--- a/tests/test_cli_output_and_main.py
+++ b/tests/test_cli_output_and_main.py
@@ -77,6 +77,21 @@ def test_theme_validation_error_verbose_includes_full_message(monkeypatch):
     assert any("line1\nline2" in entry for entry in rendered)
 
 
+def test_theme_errors_redact_secret_values(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        theme_module.console, "print", lambda *a, **k: calls.append((a, k))
+    )
+
+    theme_module.print_error("Authorization: Bearer raw-token", verbose=True)
+    theme_module.print_build_error("client_secret=secret-value", verbose=True)
+    rendered = [str(args[0]) for args, _ in calls if args]
+
+    assert all("raw-token" not in entry for entry in rendered)
+    assert all("secret-value" not in entry for entry in rendered)
+    assert any("***REDACTED***" in entry for entry in rendered)
+
+
 def test_cli_utils_helpers_emit_summary_and_error(monkeypatch):
     header_calls = []
     summary_calls = []

--- a/tests/test_connectors_and_providers_unit.py
+++ b/tests/test_connectors_and_providers_unit.py
@@ -171,7 +171,9 @@ def test_base_source_config_fetch_data_deduplicates_concurrent_connector_fetches
         results = list(executor.map(lambda _i: config.fetch_data(), range(8)))
 
     assert CountingConnector.fetch_calls() == 1
-    assert all(result is results[0] for result in results)
+    assert len({id(result) for result in results}) == len(results)
+    for result in results:
+        assert result.to_dict(orient="records") == results[0].to_dict(orient="records")
 
     cache.clear()
 

--- a/tests/test_connectors_and_providers_unit.py
+++ b/tests/test_connectors_and_providers_unit.py
@@ -486,7 +486,9 @@ def test_google_provider_helper_methods(monkeypatch):
     assert provider.create_presentation("Deck2", template_id="template-2") == "copied"
     assert copy_calls[-1] == ("template-2", "Deck2")
 
-    provider.config = SimpleNamespace(template_id=None)
+    provider.config = SimpleNamespace(
+        template_id=None, chart_image_sharing_mode="public"
+    )
     assert provider.create_presentation("Plain Deck") == "created"
     assert create_calls == ["Plain Deck"]
 
@@ -552,7 +554,9 @@ def test_google_provider_execute_request_and_batch_update(monkeypatch):
 
 def test_google_provider_upload_image_uses_configured_propagation_delay(monkeypatch):
     provider = object.__new__(google_provider_module.GoogleSlidesProvider)
-    provider.config = SimpleNamespace(drive_folder_id="folder-1")
+    provider.config = SimpleNamespace(
+        drive_folder_id="folder-1", chart_image_sharing_mode="public"
+    )
 
     class _Files:
         def create(self, **kwargs):

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -1293,8 +1293,14 @@ def test_legacy_and_composable_dbt_configs_fetch_with_runtime_parity(monkeypatch
     assert legacy_first.to_dict(orient="records") == composable_first.to_dict(
         orient="records"
     )
-    assert legacy_first is legacy_second
-    assert composable_first is composable_second
+    assert legacy_first is not legacy_second
+    assert composable_first is not composable_second
+    assert legacy_first.to_dict(orient="records") == legacy_second.to_dict(
+        orient="records"
+    )
+    assert composable_first.to_dict(orient="records") == composable_second.to_dict(
+        orient="records"
+    )
     assert len(connector_calls) == 2
     assert connector_calls[0] == connector_calls[1]
 
@@ -1329,7 +1335,8 @@ def test_composable_dbt_source_config_fetch_data_routes_and_caches(monkeypatch):
     second = config.fetch_data()
 
     assert call_count == 1
-    assert first is second
+    assert first is not second
+    assert first.to_dict(orient="records") == second.to_dict(orient="records")
 
     cache.clear()
 

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -29,6 +29,32 @@ def _reset_dbt_caches() -> None:
     dbt_module._manifest_index_inflight.clear()
 
 
+def _write_compiled_dbt_project(
+    project_dir: Path,
+    *,
+    alias: str = "metrics_model",
+    compiled_path: str = "target/compiled.sql",
+    sql: str = "select 1 as answer",
+) -> None:
+    compiled_file = project_dir / compiled_path
+    compiled_file.parent.mkdir(parents=True, exist_ok=True)
+    compiled_file.write_text(sql)
+    manifest = {
+        "nodes": {
+            "model.project.metrics": {
+                "resource_type": "model",
+                "alias": alias,
+                "compiled_path": compiled_path,
+                "original_file_path": "models/metrics.sql",
+                "package_name": "project",
+                "name": "metrics",
+            }
+        }
+    }
+    (project_dir / "target").mkdir(parents=True, exist_ok=True)
+    (project_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+
 def test_sanitize_git_url_redacts_embedded_credentials():
     url = "https://mytoken@github.com/org/repo.git"
     redacted = dbt_module._sanitize_git_url(url)
@@ -68,6 +94,75 @@ def test_clone_repo_error_message_redacts_token_value(monkeypatch, tmp_path):
     message = str(exc_info.value)
     assert "secret-token-123" not in message
     assert "https://***@github.com/org/repo.git" in message
+
+
+def test_compile_false_uses_existing_compiled_project_without_clone_or_dbt(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    project_dir = tmp_path / "compiled_project"
+    _write_compiled_dbt_project(project_dir, sql="select 42 as answer")
+
+    def _unexpected_clone(*_args, **_kwargs):
+        raise AssertionError("compile:false must not clone repositories")
+
+    class _UnexpectedRunner:
+        def __init__(self):
+            raise AssertionError("compile:false must not create dbtRunner")
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _unexpected_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _UnexpectedRunner)
+
+    connector = dbt_module.DBTManifestConnector(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(project_dir),
+        branch="main",
+        target="prod",
+        compile=False,
+    )
+
+    assert connector.get_compiled_query("metrics_model") == "select 42 as answer"
+
+
+def test_compile_false_requires_existing_manifest(tmp_path):
+    _reset_dbt_caches()
+    project_dir = tmp_path / "missing_manifest"
+
+    connector = dbt_module.DBTManifestConnector(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(project_dir),
+        target="prod",
+        compile=False,
+    )
+
+    with pytest.raises(DataSourceError, match=r"compile:false requires.*manifest"):
+        connector.get_compiled_query("metrics_model")
+
+
+def test_compile_false_requires_manifest_compiled_file(tmp_path):
+    _reset_dbt_caches()
+    project_dir = tmp_path / "missing_compiled_file"
+    (project_dir / "target").mkdir(parents=True)
+    manifest = {
+        "nodes": {
+            "model.project.metrics": {
+                "resource_type": "model",
+                "alias": "metrics_model",
+                "compiled_path": "target/missing.sql",
+            }
+        }
+    }
+    (project_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    connector = dbt_module.DBTManifestConnector(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(project_dir),
+        target="prod",
+        compile=False,
+    )
+
+    with pytest.raises(DataSourceError, match=r"compile:false requires compiled SQL"):
+        connector.get_compiled_query("metrics_model")
 
 
 def test_resolve_managed_clone_dir_rejects_protected_roots():

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,4 +1,4 @@
-from slideflow.utilities.error_messages import safe_error_line
+from slideflow.utilities.error_messages import redacted_error_line, safe_error_line
 
 
 def test_safe_error_line_returns_first_line_for_multiline_errors():
@@ -14,3 +14,18 @@ def test_safe_error_line_handles_carriage_return_only_separator():
 def test_safe_error_line_falls_back_to_exception_type_when_empty():
     error = RuntimeError("")
     assert safe_error_line(error) == "RuntimeError"
+
+
+def test_safe_error_line_preserves_classifier_terms():
+    error = RuntimeError("Authorization: Bearer raw-token")
+    message = safe_error_line(error)
+
+    assert "Bearer raw-token" in message
+
+
+def test_redacted_error_line_redacts_secret_values():
+    error = RuntimeError("Authorization: Bearer raw-token\nsecond line")
+    message = redacted_error_line(error)
+
+    assert "raw-token" not in message
+    assert "Bearer ***REDACTED***" in message

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -46,6 +46,24 @@ def test_google_docs_config_defaults_chart_images_to_restricted():
     assert config.chart_image_sharing_mode == "restricted"
 
 
+def test_google_docs_config_defaults_share_role_to_reader():
+    config = google_docs_module.GoogleDocsProviderConfig()
+
+    assert config.share_role == "reader"
+
+
+@pytest.mark.parametrize("role", ["owner", "readerwriter", ""])
+def test_google_docs_config_rejects_invalid_share_role(role: str):
+    with pytest.raises(ValueError, match="share_role"):
+        google_docs_module.GoogleDocsProviderConfig(share_role=role)
+
+
+def test_google_docs_config_normalizes_share_role():
+    config = google_docs_module.GoogleDocsProviderConfig(share_role=" Commenter ")
+
+    assert config.share_role == "commenter"
+
+
 def _document_from_paragraph_run_groups(
     *paragraph_run_groups: Tuple[str, ...],
 ) -> Dict[str, Any]:
@@ -727,6 +745,20 @@ def test_upload_share_and_delete_paths():
     )
     with pytest.raises(google_docs_module.HttpError):
         provider.delete_chart_image("file-2")
+
+
+def test_google_docs_share_presentation_rejects_invalid_role_before_api_call():
+    provider = _provider_without_init()
+    provider.drive_service = SimpleNamespace(
+        permissions=lambda: SimpleNamespace(
+            create=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("API should not be called")
+            )
+        )
+    )
+
+    with pytest.raises(ValueError, match="share_role"):
+        provider.share_presentation("doc-1", ["a@example.com"], role="owner")
 
 
 def test_upload_chart_image_public_mode_waits_for_drive_acl_propagation_and_warns(

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -40,6 +40,12 @@ def _http_error(
     return error
 
 
+def test_google_docs_config_defaults_chart_images_to_restricted():
+    config = google_docs_module.GoogleDocsProviderConfig()
+
+    assert config.chart_image_sharing_mode == "restricted"
+
+
 def _document_from_paragraph_run_groups(
     *paragraph_run_groups: Tuple[str, ...],
 ) -> Dict[str, Any]:
@@ -719,10 +725,13 @@ def test_upload_share_and_delete_paths():
     provider._execute_request = lambda _request: (_ for _ in ()).throw(
         _http_error("forbidden", status=403)
     )
-    provider.delete_chart_image("file-2")
+    with pytest.raises(google_docs_module.HttpError):
+        provider.delete_chart_image("file-2")
 
 
-def test_upload_chart_image_waits_for_drive_acl_propagation(monkeypatch):
+def test_upload_chart_image_public_mode_waits_for_drive_acl_propagation_and_warns(
+    monkeypatch, caplog
+):
     provider = _provider_without_init()
     provider.config = SimpleNamespace(
         drive_folder_id="folder-1",
@@ -756,19 +765,18 @@ def test_upload_chart_image_waits_for_drive_acl_propagation(monkeypatch):
 
     provider._execute_request = _exec
 
-    url, file_id = provider.upload_chart_image("doc-1", b"bytes", "chart.png")
+    with caplog.at_level("WARNING"):
+        url, file_id = provider.upload_chart_image("doc-1", b"bytes", "chart.png")
     assert url == "https://drive.google.com/uc?id=file-1"
     assert file_id == "file-1"
+    assert [call for call in calls if call[0] == "perm-create"]
     assert sleep_calls == [1.5]
+    assert "Chart image sharing mode is public" in caplog.text
 
 
-def test_upload_chart_image_restricted_mode_skips_public_permission(monkeypatch):
+def test_upload_chart_image_default_mode_skips_public_permission(monkeypatch):
     provider = _provider_without_init()
-    provider.config = SimpleNamespace(
-        drive_folder_id="folder-1",
-        strict_cleanup=False,
-        chart_image_sharing_mode="restricted",
-    )
+    provider.config = google_docs_module.GoogleDocsProviderConfig()
     provider.drive_service = SimpleNamespace(
         files=lambda: SimpleNamespace(create=lambda **kwargs: ("files-create", kwargs)),
         permissions=lambda: SimpleNamespace(
@@ -803,9 +811,126 @@ def test_upload_chart_image_restricted_mode_skips_public_permission(monkeypatch)
     assert sleep_calls == []
 
 
-def test_delete_chart_image_raises_when_strict_cleanup_enabled():
+def test_insert_chart_restricted_mode_grants_and_revokes_temporary_permission(
+    monkeypatch,
+):
     provider = _provider_without_init()
-    provider.config = SimpleNamespace(strict_cleanup=True)
+    provider.config = google_docs_module.GoogleDocsProviderConfig()
+    image_url = "https://drive.google.com/uc?id=file-1"
+    provider._uploaded_chart_image_ids_by_url = {image_url: "file-1"}
+    provider._section_insert_indices = {}
+    provider._resolve_section_anchor = lambda _document_id, _section_id: (
+        google_docs_module.GoogleDocsProvider._SectionAnchor(
+            marker_id="intro",
+            marker_start=1,
+            marker_end=10,
+            section_start=11,
+            section_end=20,
+        ),
+        {},
+    )
+    provider.docs_service = SimpleNamespace(
+        documents=lambda: SimpleNamespace(
+            batchUpdate=lambda **kwargs: ("batch-update", kwargs)
+        )
+    )
+    provider.drive_service = SimpleNamespace(
+        permissions=lambda: SimpleNamespace(
+            create=lambda **kwargs: ("perm-create", kwargs),
+            delete=lambda **kwargs: ("perm-delete", kwargs),
+        )
+    )
+
+    sleep_calls: List[float] = []
+    monkeypatch.setattr(
+        google_docs_module, "time", SimpleNamespace(sleep=sleep_calls.append)
+    )
+    monkeypatch.setattr(
+        google_docs_module.Timing,
+        "GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S",
+        0.5,
+    )
+
+    calls: List[Any] = []
+
+    def _exec(request):
+        calls.append(request)
+        if request[0] == "perm-create":
+            return {"id": "perm-1"}
+        return {}
+
+    provider._execute_request = _exec
+
+    provider.insert_chart_to_slide("doc-1", "intro", image_url, 0, 0, 300, 200)
+
+    assert calls[0][0] == "perm-create"
+    assert calls[0][1]["body"] == {
+        "role": "reader",
+        "type": "anyone",
+        "allowFileDiscovery": False,
+    }
+    assert calls[0][1]["fields"] == "id"
+    assert calls[1][0] == "batch-update"
+    assert calls[1][1]["body"]["requests"][0]["insertInlineImage"]["uri"] == image_url
+    assert calls[2][0] == "perm-delete"
+    assert calls[2][1]["permissionId"] == "perm-1"
+    assert sleep_calls == [0.5]
+
+
+def test_insert_chart_records_temporary_permission_revoke_failure_without_raising():
+    provider = _provider_without_init()
+    provider.config = google_docs_module.GoogleDocsProviderConfig(strict_cleanup=True)
+    image_url = "https://drive.google.com/uc?id=file-1"
+    provider._uploaded_chart_image_ids_by_url = {image_url: "file-1"}
+    provider._chart_image_cleanup_failed_ids = []
+    provider._section_insert_indices = {}
+    provider._resolve_section_anchor = lambda _document_id, _section_id: (
+        google_docs_module.GoogleDocsProvider._SectionAnchor(
+            marker_id="intro",
+            marker_start=1,
+            marker_end=10,
+            section_start=11,
+            section_end=20,
+        ),
+        {},
+    )
+    provider.docs_service = SimpleNamespace(
+        documents=lambda: SimpleNamespace(
+            batchUpdate=lambda **kwargs: ("batch-update", kwargs)
+        )
+    )
+    provider.drive_service = SimpleNamespace(
+        permissions=lambda: SimpleNamespace(
+            create=lambda **kwargs: ("perm-create", kwargs),
+            delete=lambda **kwargs: ("perm-delete", kwargs),
+        )
+    )
+
+    calls: List[Any] = []
+
+    def _exec(request):
+        calls.append(request)
+        if request[0] == "perm-create":
+            return {"id": "perm-1"}
+        if request[0] == "perm-delete":
+            raise RuntimeError("revoke failed")
+        return {}
+
+    provider._execute_request = _exec
+
+    provider.insert_chart_to_slide("doc-1", "intro", image_url, 0, 0, 300, 200)
+
+    assert [call[0] for call in calls] == [
+        "perm-create",
+        "batch-update",
+        "perm-delete",
+    ]
+    assert provider.consume_chart_image_cleanup_failures() == ["file-1"]
+
+
+def test_delete_chart_image_raises_when_cleanup_fails():
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace(strict_cleanup=False)
     provider.drive_service = SimpleNamespace(
         files=lambda: SimpleNamespace(update=lambda **kwargs: ("files-update", kwargs))
     )

--- a/tests/test_google_sheets_workbook_provider.py
+++ b/tests/test_google_sheets_workbook_provider.py
@@ -57,6 +57,39 @@ def test_get_rate_limiter_creates_distinct_limiters_for_distinct_rates(monkeypat
     assert one_rps is not two_rps
 
 
+def test_google_sheets_config_defaults_share_role_to_reader():
+    config = sheets_provider_module.GoogleSheetsProviderConfig()
+
+    assert config.share_role == "reader"
+
+
+@pytest.mark.parametrize("role", ["owner", "readerwriter", ""])
+def test_google_sheets_config_rejects_invalid_share_role(role: str):
+    with pytest.raises(ValueError, match="share_role"):
+        sheets_provider_module.GoogleSheetsProviderConfig(share_role=role)
+
+
+def test_google_sheets_config_normalizes_share_role():
+    config = sheets_provider_module.GoogleSheetsProviderConfig(share_role=" Writer ")
+
+    assert config.share_role == "writer"
+
+
+def test_finalize_workbook_rejects_invalid_share_role_before_api_call():
+    provider = _provider_without_init()
+    provider.config = SimpleNamespace(share_with=["a@example.com"], share_role="owner")
+    provider.drive_service = SimpleNamespace(
+        permissions=lambda: SimpleNamespace(
+            create=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("API should not be called")
+            )
+        )
+    )
+
+    with pytest.raises(ValueError, match="share_role"):
+        provider.finalize_workbook("sheet_123")
+
+
 def test_load_run_key_cache_populates_and_reuses_cache():
     provider = _provider_without_init()
     provider._run_key_cache = {}

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -109,6 +109,12 @@ def test_google_slides_config_validates_transfer_ownership_target():
     assert config.transfer_ownership_to == "owner@example.com"
 
 
+def test_google_slides_config_defaults_chart_images_to_restricted():
+    config = google_provider_module.GoogleSlidesProviderConfig()
+
+    assert config.chart_image_sharing_mode == "restricted"
+
+
 @pytest.mark.parametrize(
     ("dimension", "expected"),
     [
@@ -390,7 +396,9 @@ def test_copy_template_success_and_error():
         provider._copy_template("template-2", "Deck 2")
 
 
-def test_upload_image_to_drive_success_and_error(monkeypatch):
+def test_upload_image_to_drive_public_mode_grants_permission_and_warns(
+    monkeypatch, caplog
+):
     provider = _provider_without_init()
     provider.config = SimpleNamespace(
         drive_folder_id=None, chart_image_sharing_mode="public"
@@ -417,10 +425,12 @@ def test_upload_image_to_drive_success_and_error(monkeypatch):
         return {"id": "file-123"} if request[0] == "files-create" else {}
 
     provider._execute_request = _exec
-    public_url, file_id = provider._upload_image_to_drive(b"png-bytes", "chart.png")
+    with caplog.at_level("WARNING"):
+        public_url, file_id = provider._upload_image_to_drive(b"png-bytes", "chart.png")
     assert public_url == "https://drive.google.com/uc?id=file-123"
     assert file_id == "file-123"
     assert len([call for call in calls if call[0] == "perm-create"]) == 1
+    assert "Chart image sharing mode is public" in caplog.text
     assert logs[-1][0][2] is True
 
     provider._execute_request = lambda _request: (_ for _ in ()).throw(
@@ -430,11 +440,9 @@ def test_upload_image_to_drive_success_and_error(monkeypatch):
         provider._upload_image_to_drive(b"png-bytes", "chart.png")
 
 
-def test_upload_image_to_drive_restricted_mode_skips_public_permission(monkeypatch):
+def test_upload_image_to_drive_default_mode_skips_public_permission(monkeypatch):
     provider = _provider_without_init()
-    provider.config = SimpleNamespace(
-        drive_folder_id=None, chart_image_sharing_mode="restricted"
-    )
+    provider.config = google_provider_module.GoogleSlidesProviderConfig()
     provider._get_or_create_destination_folder = lambda: "folder-1"
     provider.drive_service = SimpleNamespace(
         files=lambda: SimpleNamespace(create=lambda **kwargs: ("files-create", kwargs)),
@@ -454,7 +462,9 @@ def test_upload_image_to_drive_restricted_mode_skips_public_permission(monkeypat
 
     def _exec(request):
         calls.append(request)
-        return {"id": "file-123"} if request[0] == "files-create" else {}
+        if request[0] == "files-create":
+            return {"id": "file-123"}
+        return {}
 
     provider._execute_request = _exec
 
@@ -463,6 +473,107 @@ def test_upload_image_to_drive_restricted_mode_skips_public_permission(monkeypat
     assert file_id == "file-123"
     assert [call for call in calls if call[0] == "perm-create"] == []
     assert sleep_calls == []
+
+
+def test_insert_chart_restricted_mode_grants_and_revokes_temporary_permission(
+    monkeypatch,
+):
+    provider = _provider_without_init()
+    provider.config = google_provider_module.GoogleSlidesProviderConfig()
+    image_url = "https://drive.google.com/uc?id=file-123"
+    provider._uploaded_chart_image_ids_by_url = {image_url: "file-123"}
+    provider.drive_service = SimpleNamespace(
+        permissions=lambda: SimpleNamespace(
+            create=lambda **kwargs: ("perm-create", kwargs),
+            delete=lambda **kwargs: ("perm-delete", kwargs),
+        )
+    )
+
+    sleep_calls: List[float] = []
+    monkeypatch.setattr(
+        google_provider_module.time,
+        "sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
+    monkeypatch.setattr(
+        google_provider_module.Timing,
+        "GOOGLE_DRIVE_PERMISSION_PROPAGATION_DELAY_S",
+        0.5,
+    )
+
+    calls: List[Any] = []
+
+    def _exec(request):
+        calls.append(request)
+        if request[0] == "perm-create":
+            return {"id": "perm-1"}
+        return {}
+
+    provider._execute_request = _exec
+    provider._batch_update = (
+        lambda presentation_id, requests: calls.append(
+            ("batch-update", presentation_id, requests)
+        )
+        or {}
+    )
+
+    provider.insert_chart_to_slide("pres-1", "slide-1", image_url, 1, 2, 3, 4)
+
+    assert calls[0][0] == "perm-create"
+    assert calls[0][1]["body"] == {
+        "role": "reader",
+        "type": "anyone",
+        "allowFileDiscovery": False,
+    }
+    assert calls[0][1]["fields"] == "id"
+    assert calls[1][0] == "batch-update"
+    assert calls[1][2][0]["createImage"]["url"] == image_url
+    assert calls[2][0] == "perm-delete"
+    assert calls[2][1]["permissionId"] == "perm-1"
+    assert sleep_calls == [0.5]
+
+
+def test_insert_chart_records_temporary_permission_revoke_failure_without_raising():
+    provider = _provider_without_init()
+    provider.config = google_provider_module.GoogleSlidesProviderConfig(
+        strict_cleanup=True
+    )
+    image_url = "https://drive.google.com/uc?id=file-123"
+    provider._uploaded_chart_image_ids_by_url = {image_url: "file-123"}
+    provider._chart_image_cleanup_failed_ids = []
+    provider.drive_service = SimpleNamespace(
+        permissions=lambda: SimpleNamespace(
+            create=lambda **kwargs: ("perm-create", kwargs),
+            delete=lambda **kwargs: ("perm-delete", kwargs),
+        )
+    )
+
+    calls: List[Any] = []
+
+    def _exec(request):
+        calls.append(request)
+        if request[0] == "perm-create":
+            return {"id": "perm-1"}
+        if request[0] == "perm-delete":
+            raise RuntimeError("revoke failed")
+        return {}
+
+    provider._execute_request = _exec
+    provider._batch_update = (
+        lambda presentation_id, requests: calls.append(
+            ("batch-update", presentation_id, requests)
+        )
+        or {}
+    )
+
+    provider.insert_chart_to_slide("pres-1", "slide-1", image_url, 1, 2, 3, 4)
+
+    assert [call[0] for call in calls] == [
+        "perm-create",
+        "batch-update",
+        "perm-delete",
+    ]
+    assert provider.consume_chart_image_cleanup_failures() == ["file-123"]
 
 
 def test_batch_update_error_logs_and_raises(monkeypatch):
@@ -496,12 +607,14 @@ def test_delete_chart_image_handles_permission_and_other_errors():
     provider._execute_request = lambda _request: (_ for _ in ()).throw(
         _http_error("forbidden", status=403)
     )
-    provider.delete_chart_image("file-1")
+    with pytest.raises(google_provider_module.HttpError):
+        provider.delete_chart_image("file-1")
 
     provider._execute_request = lambda _request: (_ for _ in ()).throw(
         _http_error("server", status=500)
     )
-    provider.delete_chart_image("file-2")
+    with pytest.raises(google_provider_module.HttpError):
+        provider.delete_chart_image("file-2")
 
 
 def test_render_citations_inserts_sources_into_speaker_notes():

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -115,6 +115,24 @@ def test_google_slides_config_defaults_chart_images_to_restricted():
     assert config.chart_image_sharing_mode == "restricted"
 
 
+def test_google_slides_config_defaults_share_role_to_reader():
+    config = google_provider_module.GoogleSlidesProviderConfig()
+
+    assert config.share_role == "reader"
+
+
+@pytest.mark.parametrize("role", ["owner", "readerwriter", ""])
+def test_google_slides_config_rejects_invalid_share_role(role: str):
+    with pytest.raises(ValueError, match="share_role"):
+        google_provider_module.GoogleSlidesProviderConfig(share_role=role)
+
+
+def test_google_slides_config_normalizes_share_role():
+    config = google_provider_module.GoogleSlidesProviderConfig(share_role=" Writer ")
+
+    assert config.share_role == "writer"
+
+
 @pytest.mark.parametrize(
     ("dimension", "expected"),
     [
@@ -200,6 +218,20 @@ def test_share_presentation_success_and_error(monkeypatch):
 
     with pytest.raises(google_provider_module.HttpError):
         provider.share_presentation("pres-2", ["x@example.com"], role="writer")
+
+
+def test_share_presentation_rejects_invalid_role_before_api_call():
+    provider = _provider_without_init()
+    provider.drive_service = SimpleNamespace(
+        permissions=lambda: SimpleNamespace(
+            create=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("API should not be called")
+            )
+        )
+    )
+
+    with pytest.raises(ValueError, match="share_role"):
+        provider.share_presentation("pres-1", ["a@example.com"], role="owner")
 
 
 def test_transfer_presentation_ownership_success_and_shared_drive_guard():

--- a/tests/test_presentation_render.py
+++ b/tests/test_presentation_render.py
@@ -119,6 +119,8 @@ def test_render_passes_empty_dataframe_to_static_chart():
 
     assert isinstance(chart.generated_with, pd.DataFrame)
     assert result.charts_generated == 1
+    assert result.chart_image_cleanup_failed_count == 0
+    assert result.chart_image_cleanup_failed_ids == []
     assert provider.finalize_calls == ["presentation-1"]
 
 
@@ -145,12 +147,14 @@ def test_render_logs_cleanup_summary_on_failure(caplog):
     presentation, _chart = _build_presentation(provider)
 
     with caplog.at_level(logging.WARNING):
-        presentation.render()
+        result = presentation.render()
 
     assert (
         "Chart image cleanup completed with 1 failure(s): deleted 0/1." in caplog.text
     )
     assert "Failed IDs: ['file-1']" in caplog.text
+    assert result.chart_image_cleanup_failed_count == 1
+    assert result.chart_image_cleanup_failed_ids == ["file-1"]
 
 
 def test_render_uses_provider_page_dimensions_for_relative_chart():
@@ -518,6 +522,26 @@ def test_finalize_and_share_presentation_runs_provider_hooks():
 
 def test_cleanup_uploaded_chart_images_strict_mode_raises_when_cleanup_fails():
     provider = FakeProvider(strict_cleanup=True, fail_cleanup=True)
+    presentation, _chart = _build_presentation(provider)
+    context = presentation._create_render_context(start_time=time.time())
+    context.uploaded_file_ids = ["file-1"]
+
+    with pytest.raises(RenderingError, match="Strict cleanup enabled"):
+        presentation._cleanup_uploaded_chart_images(context)
+
+
+def test_cleanup_uploaded_chart_images_strict_mode_raises_for_provider_failures():
+    class ProviderCleanupFailure(FakeProvider):
+        def __init__(self):
+            super().__init__(strict_cleanup=True, fail_cleanup=False)
+            self._failures = ["file-1"]
+
+        def consume_chart_image_cleanup_failures(self):
+            failures = list(self._failures)
+            self._failures = []
+            return failures
+
+    provider = ProviderCleanupFailure()
     presentation, _chart = _build_presentation(provider)
     context = presentation._create_render_context(start_time=time.time())
     context.uploaded_file_ids = ["file-1"]

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,57 @@
+from slideflow.utilities.redaction import REDACTED, redact_text, redact_value
+
+
+def test_redact_value_recursively_masks_sensitive_keys_and_url_credentials():
+    private_key = "-----BEGIN " "PRIVATE KEY-----abc-----END " "PRIVATE KEY-----"
+    payload = {
+        "safe": "visible",
+        "api_token": "token-123",
+        "nested": [
+            {
+                "client_email": "svc@example.com",
+                "private_key": private_key,
+                "url": "https://user@example.com/path?access_token=abc&x=1",
+            }
+        ],
+    }
+
+    redacted = redact_value(payload)
+
+    assert redacted["safe"] == "visible"
+    assert redacted["api_token"] == REDACTED
+    assert redacted["nested"][0]["client_email"] == REDACTED
+    assert redacted["nested"][0]["private_key"] == REDACTED
+    assert redacted["nested"][0]["url"] == (
+        f"https://***@example.com/path?access_token={REDACTED}&x=1"
+    )
+
+
+def test_redact_text_masks_auth_headers_bearer_tokens_and_key_value_pairs():
+    message = (
+        "Authorization: Bearer raw-token "
+        "client_secret=secret-value "
+        "url=https://token@example.com/repo.git"
+    )
+
+    redacted = redact_text(message)
+
+    assert "raw-token" not in redacted
+    assert "secret-value" not in redacted
+    assert "token@example.com" not in redacted
+    assert f"Bearer {REDACTED}" in redacted
+    assert f"client_secret={REDACTED}" in redacted
+    assert "https://***@example.com/repo.git" in redacted
+
+
+def test_redact_text_masks_non_bearer_authorization_schemes():
+    redacted = redact_text("Authorization: token gh_secret123")
+
+    assert "gh_secret123" not in redacted
+    assert f"Authorization: token {REDACTED}" == redacted
+
+
+def test_redact_value_preserves_non_secret_operational_keys():
+    redacted = redact_value({"run_key": "append-2026-06-28", "api_key": "secret"})
+
+    assert redacted["run_key"] == "append-2026-06-28"
+    assert redacted["api_key"] == REDACTED

--- a/tests/test_release_scripts.py
+++ b/tests/test_release_scripts.py
@@ -1,17 +1,23 @@
+import importlib.util
 import subprocess
 import sys
 import tomllib
 from pathlib import Path
+from types import ModuleType
 
 ROOT = Path(__file__).resolve().parents[1]
 VALIDATE_SCRIPT = ROOT / "scripts" / "ci" / "validate_release_branch.py"
 VERSION_SCRIPT = ROOT / "scripts" / "ci" / "check_version_consistency.py"
+RELEASE_STATE_SCRIPT = ROOT / "scripts" / "ci" / "check_release_artifact_state.py"
+LIVE_VALIDATION_SCRIPT = ROOT / "scripts" / "ci" / "check_live_validation_evidence.py"
 
 
-def _run(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run(
+    script: Path, *args: str, cwd: Path = ROOT
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(script), *args],
-        cwd=ROOT,
+        cwd=cwd,
         text=True,
         capture_output=True,
         check=False,
@@ -26,6 +32,47 @@ def _current_version() -> str:
 def _mismatched_release_branch() -> str:
     major, minor, patch = _current_version().split(".")
     return f"release/v{major}.{minor}.{int(patch) + 1}"
+
+
+def _load_script_module(script: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(script.stem, script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_release_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "tests@example.com")
+    _git(repo, "config", "user.name", "Release Tests")
+
+    payload = repo / "payload.txt"
+    payload.write_text("first\n")
+    _git(repo, "add", "payload.txt")
+    _git(repo, "commit", "-qm", "release commit")
+    release_commit = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "tag", "v1.2.3")
+
+    payload.write_text("second\n")
+    _git(repo, "commit", "-am", "follow-up commit")
+    follow_up_commit = _git(repo, "rev-parse", "HEAD")
+
+    return repo, release_commit, follow_up_commit
 
 
 def test_validate_release_branch_accepts_semver_release_branch():
@@ -56,3 +103,123 @@ def test_check_version_consistency_fails_for_mismatched_release_branch_version()
 
     assert result.returncode == 1
     assert "Release branch version mismatch" in result.stderr
+
+
+def test_version_consistency_collects_changelog_mismatch():
+    module = _load_script_module(VERSION_SCRIPT)
+
+    errors = module._collect_version_errors(
+        pyproject_version="1.2.3",
+        package_version="1.2.3",
+        changelog_version="1.2.2",
+        release_version=None,
+    )
+
+    assert errors == [
+        "Changelog latest release mismatch: CHANGELOG.md=1.2.2 vs project=1.2.3"
+    ]
+
+
+def test_release_artifact_state_allows_existing_package_on_tagged_commit(tmp_path):
+    repo, release_commit, _ = _init_release_repo(tmp_path)
+    output_file = tmp_path / "github-output.txt"
+
+    result = _run(
+        RELEASE_STATE_SCRIPT,
+        "--version",
+        "1.2.3",
+        "--expected-commit",
+        release_commit,
+        "--package-exists-override",
+        "true",
+        "--release-exists-override",
+        "false",
+        "--output-file",
+        str(output_file),
+        cwd=repo,
+    )
+
+    output = output_file.read_text()
+    assert result.returncode == 0
+    assert "Release artifact state validated" in result.stdout
+    assert "package_exists=true" in output
+    assert "tag_exists=true" in output
+
+
+def test_release_artifact_state_rejects_existing_package_on_follow_up_commit(tmp_path):
+    repo, _, follow_up_commit = _init_release_repo(tmp_path)
+
+    result = _run(
+        RELEASE_STATE_SCRIPT,
+        "--version",
+        "1.2.3",
+        "--expected-commit",
+        follow_up_commit,
+        "--package-exists-override",
+        "true",
+        "--release-exists-override",
+        "false",
+        cwd=repo,
+    )
+
+    assert result.returncode == 1
+    assert "expected artifact-producing commit" in result.stderr
+
+
+def test_release_artifact_state_rejects_existing_package_without_tag(tmp_path):
+    repo, _, follow_up_commit = _init_release_repo(tmp_path)
+
+    result = _run(
+        RELEASE_STATE_SCRIPT,
+        "--version",
+        "9.9.9",
+        "--expected-commit",
+        follow_up_commit,
+        "--package-exists-override",
+        "true",
+        "--release-exists-override",
+        "false",
+        cwd=repo,
+    )
+
+    assert result.returncode == 1
+    assert "matching tag v9.9.9 is missing" in result.stderr
+
+
+def test_live_validation_accepts_successful_run_for_expected_sha():
+    module = _load_script_module(LIVE_VALIDATION_SCRIPT)
+
+    errors = module._validate_run_payload(
+        run_name="slides",
+        expected_sha="abc123",
+        expected_workflow_path=".github/workflows/live-google-slides.yml",
+        payload={
+            "head_sha": "abc123",
+            "status": "completed",
+            "conclusion": "success",
+            "path": ".github/workflows/live-google-slides.yml",
+            "html_url": "https://github.com/example/repo/actions/runs/1",
+        },
+    )
+
+    assert errors == []
+
+
+def test_live_validation_rejects_stale_or_failed_run():
+    module = _load_script_module(LIVE_VALIDATION_SCRIPT)
+
+    errors = module._validate_run_payload(
+        run_name="docs",
+        expected_sha="abc123",
+        expected_workflow_path=".github/workflows/live-google-docs.yml",
+        payload={
+            "head_sha": "def456",
+            "status": "completed",
+            "conclusion": "failure",
+            "path": ".github/workflows/live-google-docs.yml",
+            "html_url": "https://github.com/example/repo/actions/runs/2",
+        },
+    )
+
+    assert "docs run SHA mismatch: head_sha='def456' expected='abc123'" in errors
+    assert "docs run did not succeed: 'failure'" in errors

--- a/tests/test_replacements_and_transforms.py
+++ b/tests/test_replacements_and_transforms.py
@@ -162,6 +162,51 @@ def test_table_replacement_dynamic_mode_applies_transforms_and_formatters(monkey
     ]
 
 
+def test_table_formatting_does_not_mutate_shared_source_frame(monkeypatch):
+    _install_pandas_stub_compat(monkeypatch)
+
+    shared_df = pd.DataFrame({"label": ["Revenue"], "amount": [1.25]})
+
+    class SharedSource:
+        def fetch_data(self):
+            return shared_df
+
+    source = SharedSource()
+    table = TableReplacement.model_construct(
+        type="table",
+        prefix="T_",
+        data_source=source,
+        formatting=TableFormattingOptions(
+            custom_formatters={
+                "amount": TableColumnFormatter(
+                    format_fn=lambda value: f"{value:.1%}",
+                    format_fn_args={},
+                )
+            }
+        ),
+        replacements=None,
+        data_transforms=[],
+    )
+    text = TextReplacement.model_construct(
+        type="text",
+        placeholder="{{AMOUNT}}",
+        replacement=None,
+        data_source=source,
+        value_fn=lambda frame: str(frame.to_dict(orient="records")[0]["amount"]),
+        value_fn_args={},
+        data_transforms=[],
+    )
+
+    assert table.get_replacement() == {
+        "{{T_1,1}}": "Revenue",
+        "{{T_1,2}}": "125.0%",
+    }
+    amount = shared_df.to_dict(orient="records")[0]["amount"]
+    assert amount == 1.25
+    assert isinstance(amount, float)
+    assert text.get_replacement() == "1.25"
+
+
 def test_ai_text_replacement_provider_resolution_and_prompt_context(monkeypatch):
     _install_pandas_stub_compat(monkeypatch)
 

--- a/tests/test_runtime_utilities.py
+++ b/tests/test_runtime_utilities.py
@@ -14,6 +14,18 @@ from slideflow.utilities.auth import handle_google_credentials
 from slideflow.utilities.exceptions import AuthenticationError
 
 
+def _records(df):
+    return df.to_dict(orient="records")
+
+
+def _first_value(df, column="value"):
+    return _records(df)[0][column]
+
+
+def _assert_frame_records_equal(left, right):
+    assert _records(left) == _records(right)
+
+
 def test_data_source_cache_lifecycle_and_singleton_behavior():
     cache = data_cache_module.get_data_cache()
     cache.enable()
@@ -22,10 +34,19 @@ def test_data_source_cache_lifecycle_and_singleton_behavior():
     df = pd.DataFrame({"value": [1]})
     cache.set(df, source_type="csv", file_path="data.csv")
 
-    assert cache.get("csv", file_path="data.csv") is df
+    cached = cache.get("csv", file_path="data.csv")
+    assert cached is not None
+    _assert_frame_records_equal(cached, df)
+    assert cached is not df
     assert cache.size == 1
     assert cache.is_enabled is True
     assert data_cache_module.get_data_cache() is cache
+
+    df["value"] = [2]
+    cached["value"] = [3]
+    fresh_cached = cache.get("csv", file_path="data.csv")
+    assert fresh_cached is not None
+    assert _first_value(fresh_cached) == 1
 
     info = cache.get_cache_info()
     assert info["enabled"] is True
@@ -151,13 +172,21 @@ def test_data_source_cache_enforces_lru_entry_cap(monkeypatch):
         assert cache.size == 2
 
         # Touch a.csv so b.csv becomes least-recently-used.
-        assert cache.get("csv", file_path="a.csv") is df_a
+        cached_a = cache.get("csv", file_path="a.csv")
+        assert cached_a is not None
+        _assert_frame_records_equal(cached_a, df_a)
+        assert cached_a is not df_a
 
         cache.set(df_c, source_type="csv", file_path="c.csv")
         assert cache.size == 2
-        assert cache.get("csv", file_path="a.csv") is df_a
+        cached_a = cache.get("csv", file_path="a.csv")
+        assert cached_a is not None
+        _assert_frame_records_equal(cached_a, df_a)
         assert cache.get("csv", file_path="b.csv") is None
-        assert cache.get("csv", file_path="c.csv") is df_c
+        cached_c = cache.get("csv", file_path="c.csv")
+        assert cached_c is not None
+        _assert_frame_records_equal(cached_c, df_c)
+        assert cached_c is not df_c
     finally:
         cache._max_entries = original_max_entries
         cache.clear()
@@ -209,7 +238,15 @@ def test_data_source_cache_get_or_load_deduplicates_concurrent_loads():
         results = list(executor.map(lambda _i: worker(), range(8)))
 
     assert load_calls == 1
-    assert all(result is expected_df for result in results)
+    assert len({id(result) for result in results}) == len(results)
+    for result in results:
+        _assert_frame_records_equal(result, expected_df)
+
+    for result in results:
+        result["value"] = [-1]
+    cached = cache.get("csv", file_path="shared.csv")
+    assert cached is not None
+    assert _first_value(cached) == 42
 
     cache.clear()
 
@@ -257,7 +294,126 @@ def test_data_source_cache_get_or_load_unblocks_waiters_on_base_exception():
     assert any(isinstance(item, LoaderExit) for item in outcomes)
     data_results = [item for item in outcomes if isinstance(item, pd.DataFrame)]
     assert len(data_results) == 1
-    assert data_results[0] is expected_df
+    _assert_frame_records_equal(data_results[0], expected_df)
+    assert load_calls == 2
+
+    cache.clear()
+
+
+def test_data_source_cache_disable_unblocks_waiters(monkeypatch):
+    cache = data_cache_module.get_data_cache()
+    cache.enable()
+    cache.clear()
+
+    real_event = threading.Event
+    loader_started = real_event()
+    release_loader = real_event()
+    waiter_waiting = real_event()
+    counter_lock = threading.Lock()
+    load_calls = 0
+
+    class TrackingEvent:
+        def __init__(self):
+            self._event = real_event()
+
+        def set(self):
+            self._event.set()
+
+        def wait(self, timeout=None):
+            waiter_waiting.set()
+            return self._event.wait(timeout)
+
+    monkeypatch.setattr(cache, "_new_inflight_event", lambda: TrackingEvent())
+
+    def loader():
+        nonlocal load_calls
+        with counter_lock:
+            load_calls += 1
+            current = load_calls
+        if current == 1:
+            loader_started.set()
+            assert release_loader.wait(2), "owner loader was not released"
+        return pd.DataFrame({"value": [current]})
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        owner = executor.submit(cache.get_or_load, "csv", loader, file_path="slow.csv")
+        assert loader_started.wait(2), "owner loader did not start"
+
+        waiter = executor.submit(cache.get_or_load, "csv", loader, file_path="slow.csv")
+        assert waiter_waiting.wait(2), "waiter did not block on in-flight load"
+
+        cache.disable()
+
+        waiter_result = waiter.result(timeout=2)
+        assert _first_value(waiter_result) == 2
+        assert owner.done() is False
+
+        release_loader.set()
+        owner_result = owner.result(timeout=2)
+        assert _first_value(owner_result) == 1
+
+    assert load_calls == 2
+    assert cache.size == 0
+    cache.enable()
+    cache.clear()
+
+
+def test_data_source_cache_clear_unblocks_waiters_and_prevents_stale_fill(
+    monkeypatch,
+):
+    cache = data_cache_module.get_data_cache()
+    cache.enable()
+    cache.clear()
+
+    real_event = threading.Event
+    loader_started = real_event()
+    release_loader = real_event()
+    waiter_waiting = real_event()
+    counter_lock = threading.Lock()
+    load_calls = 0
+
+    class TrackingEvent:
+        def __init__(self):
+            self._event = real_event()
+
+        def set(self):
+            self._event.set()
+
+        def wait(self, timeout=None):
+            waiter_waiting.set()
+            return self._event.wait(timeout)
+
+    monkeypatch.setattr(cache, "_new_inflight_event", lambda: TrackingEvent())
+
+    def loader():
+        nonlocal load_calls
+        with counter_lock:
+            load_calls += 1
+            current = load_calls
+        if current == 1:
+            loader_started.set()
+            assert release_loader.wait(2), "owner loader was not released"
+        return pd.DataFrame({"value": [current]})
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        owner = executor.submit(cache.get_or_load, "csv", loader, file_path="slow.csv")
+        assert loader_started.wait(2), "owner loader did not start"
+
+        waiter = executor.submit(cache.get_or_load, "csv", loader, file_path="slow.csv")
+        assert waiter_waiting.wait(2), "waiter did not block on in-flight load"
+
+        cache.clear()
+
+        waiter_result = waiter.result(timeout=2)
+        assert _first_value(waiter_result) == 2
+
+        release_loader.set()
+        owner_result = owner.result(timeout=2)
+        assert _first_value(owner_result) == 1
+
+    cached = cache.get("csv", file_path="slow.csv")
+    assert cached is not None
+    assert _first_value(cached) == 2
     assert load_calls == 2
 
     cache.clear()

--- a/tests/test_runtime_workflows_phase4.py
+++ b/tests/test_runtime_workflows_phase4.py
@@ -406,11 +406,15 @@ def test_presentation_builder_from_config_sets_templates_and_builds_slides(monke
 
     template_calls = []
     slide_ids = []
+    template_engines = []
+    fake_engine = object()
     fake_provider = object()
     fake_slides = [SimpleNamespace(id="s1"), SimpleNamespace(id="s2")]
 
     monkeypatch.setattr(
-        builder_module, "set_template_paths", lambda paths: template_calls.append(paths)
+        builder_module,
+        "create_template_engine",
+        lambda paths: template_calls.append(paths) or fake_engine,
     )
     monkeypatch.setattr(
         builder_module.ProviderFactory,
@@ -418,8 +422,9 @@ def test_presentation_builder_from_config_sets_templates_and_builds_slides(monke
         staticmethod(lambda _provider_config: fake_provider),
     )
 
-    def _build_slide(cls, spec):
+    def _build_slide(cls, spec, template_engine=None):
         slide_ids.append(spec.id)
+        template_engines.append(template_engine)
         return fake_slides[len(slide_ids) - 1]
 
     monkeypatch.setattr(
@@ -433,6 +438,7 @@ def test_presentation_builder_from_config_sets_templates_and_builds_slides(monke
 
     assert template_calls == [["./templates"]]
     assert slide_ids == ["slide_1", "slide_2"]
+    assert template_engines == [fake_engine, fake_engine]
     assert presentation.provider is fake_provider
     assert presentation.name == "Demo"
     assert presentation.slides == fake_slides

--- a/tests/test_runtime_workflows_phase4.py
+++ b/tests/test_runtime_workflows_phase4.py
@@ -172,7 +172,8 @@ def test_build_command_non_dry_run_processes_results_and_sorts(tmp_path, monkeyp
         "https://example.com/a",
         "https://example.com/z",
     ]
-    assert sorted(row["region"] for row in result) == ["eu", "us"]
+    assert "region" not in result[0]
+    assert sorted(row["variant_index"] for row in result) == [1, 2]
     assert all(row["ownership_transfer_attempted"] is False for row in result)
     assert all(row["ownership_transfer_succeeded"] is None for row in result)
 

--- a/tests/test_secret_hygiene.py
+++ b/tests/test_secret_hygiene.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.check_secret_hygiene import scan_paths
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_secret_hygiene_rejects_tracked_credential_filenames(tmp_path: Path) -> None:
+    credentials = _write(
+        tmp_path / "google-credentials.json",
+        '{"type": "service_account", "private_key": "fake"}',
+    )
+
+    findings = scan_paths([credentials], root=tmp_path)
+
+    assert any(
+        "tracked credential/key filename" in finding.reason for finding in findings
+    )
+
+
+def test_secret_hygiene_rejects_private_keys_and_provider_tokens(
+    tmp_path: Path,
+) -> None:
+    private_key = "-----BEGIN " "PRIVATE KEY-----abc-----END " "PRIVATE KEY-----"
+    client_secret = "GOCSPX-" + ("a" * 32)
+    api_key = "sk-proj-" + ("b" * 32)
+    config = _write(
+        tmp_path / "config.yml",
+        "\n".join(
+            [
+                f'private_key: "{private_key}"',
+                f'client_secret: "{client_secret}"',
+                f"api_key: '{api_key}'",
+            ]
+        ),
+    )
+
+    findings = scan_paths([config], root=tmp_path)
+    reasons = {finding.reason for finding in findings}
+
+    assert "private key block" in reasons
+    assert "Google OAuth client secret" in reasons
+    assert "OpenAI API key" in reasons
+
+
+def test_secret_hygiene_allows_documented_placeholders(tmp_path: Path) -> None:
+    config = _write(
+        tmp_path / "example.yml",
+        "\n".join(
+            [
+                'credentials: "/absolute/path/service-account.json"',
+                'client_secret: "secret-value"',
+                'api_key: "<provider-api-key>"',
+                'refresh_token: "${REFRESH_TOKEN}"',
+            ]
+        ),
+    )
+
+    assert scan_paths([config], root=tmp_path) == []

--- a/tests/test_template_build_scope.py
+++ b/tests/test_template_build_scope.py
@@ -90,7 +90,7 @@ def test_concurrent_builds_keep_template_paths_isolated(tmp_path, monkeypatch):
     monkeypatch.setattr(
         builder_module,
         "Presentation",
-        lambda **kwargs: SimpleNamespace(**kwargs),
+        SimpleNamespace,
     )
     monkeypatch.setattr(charts_module, "PlotlyGraphObjects", _ConcurrentFakePlotlyChart)
 
@@ -163,8 +163,8 @@ def test_custom_chart_get_template_engine_uses_build_scoped_engine(tmp_path):
             self.uploaded = image_data
             return ("https://example.com/chart.png", "file-1")
 
-        def insert_chart_to_slide(self, *args: Any) -> None:
-            del args
+        def insert_chart_to_slide(self, *_args: Any) -> None:
+            pass
 
     provider = _Provider()
     presentation = Presentation.model_construct(

--- a/tests/test_template_build_scope.py
+++ b/tests/test_template_build_scope.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+
+import slideflow.presentations.builder as builder_module
+import slideflow.presentations.charts as charts_module
+from slideflow.builtins.template_engine import (
+    TemplateEngine,
+    create_template_engine,
+    get_template_engine,
+)
+from slideflow.presentations.base import Presentation, Slide
+from slideflow.presentations.config import PresentationConfig
+
+
+def _write_named_template(templates_dir, label: str) -> None:
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    (templates_dir / "shared.yml").write_text(
+        "name: Shared Template\n"
+        "description: Same template name in isolated directories\n"
+        "parameters: []\n"
+        "template:\n"
+        "  traces:\n"
+        '    - type: "bar"\n'
+        f'      name: "{label}"\n'
+        '      x: "$x"\n'
+        '      y: "$y"\n',
+        encoding="utf-8",
+    )
+
+
+class _FakePlotlyChart:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    def generate_chart_image(self, df: pd.DataFrame) -> bytes:
+        del df
+        return str(self.kwargs["traces"][0]["name"]).encode()
+
+
+def test_template_charts_use_explicit_engine_for_same_template_name(
+    tmp_path, monkeypatch
+):
+    templates_a = tmp_path / "a"
+    templates_b = tmp_path / "b"
+    _write_named_template(templates_a, "from-a")
+    _write_named_template(templates_b, "from-b")
+    monkeypatch.setattr(charts_module, "PlotlyGraphObjects", _FakePlotlyChart)
+
+    chart_a = charts_module.TemplateChart(
+        template_name="shared",
+        template_config={},
+        template_engine=TemplateEngine([templates_a]),
+    )
+    chart_b = charts_module.TemplateChart(
+        template_name="shared",
+        template_config={},
+        template_engine=TemplateEngine([templates_b]),
+    )
+
+    frame = pd.DataFrame({"x": ["one"], "y": [1]})
+
+    assert chart_a.generate_chart_image(frame) == b"from-a"
+    assert chart_b.generate_chart_image(frame) == b"from-b"
+
+
+def test_concurrent_builds_keep_template_paths_isolated(tmp_path, monkeypatch):
+    templates_a = tmp_path / "a"
+    templates_b = tmp_path / "b"
+    _write_named_template(templates_a, "from-a")
+    _write_named_template(templates_b, "from-b")
+
+    barrier = threading.Barrier(2)
+
+    class _ConcurrentFakePlotlyChart(_FakePlotlyChart):
+        def generate_chart_image(self, df: pd.DataFrame) -> bytes:
+            barrier.wait(timeout=5)
+            return super().generate_chart_image(df)
+
+    monkeypatch.setattr(
+        builder_module.ProviderFactory,
+        "create_provider",
+        staticmethod(lambda _provider_config: object()),
+    )
+    monkeypatch.setattr(
+        builder_module,
+        "Presentation",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(charts_module, "PlotlyGraphObjects", _ConcurrentFakePlotlyChart)
+
+    def _config(template_path) -> PresentationConfig:
+        return PresentationConfig.model_validate(
+            {
+                "template_paths": [str(template_path)],
+                "provider": {"type": "google_slides", "config": {}},
+                "presentation": {
+                    "name": "Demo",
+                    "slides": [
+                        {
+                            "id": "slide_1",
+                            "charts": [
+                                {
+                                    "type": "template",
+                                    "config": {
+                                        "template_name": "shared",
+                                        "template_config": {},
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+
+    def _render(config: PresentationConfig) -> bytes:
+        presentation = builder_module.PresentationBuilder.from_config(config)
+        chart = presentation.slides[0].charts[0]
+        return chart.generate_chart_image(pd.DataFrame({"x": ["one"], "y": [1]}))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_a = executor.submit(_render, _config(templates_a))
+        future_b = executor.submit(_render, _config(templates_b))
+
+    assert future_a.result(timeout=5) == b"from-a"
+    assert future_b.result(timeout=5) == b"from-b"
+
+
+def test_custom_chart_get_template_engine_uses_build_scoped_engine(tmp_path):
+    templates_dir = tmp_path / "custom"
+    _write_named_template(templates_dir, "from-custom")
+
+    def _chart_fn(df: pd.DataFrame, config: dict[str, Any], chart) -> bytes:
+        del df, config, chart
+        rendered = get_template_engine().render_template("shared", {})
+        return str(rendered["traces"][0]["name"]).encode()
+
+    chart = builder_module.PresentationBuilder._build_chart(
+        SimpleNamespace(
+            type="custom",
+            config={
+                "chart_fn": _chart_fn,
+                "chart_config": {},
+            },
+        ),
+        template_engine=create_template_engine([templates_dir]),
+    )
+
+    class _Provider:
+        def __init__(self) -> None:
+            self.uploaded: bytes | None = None
+
+        def upload_chart_image(
+            self, presentation_id: str, image_data: bytes, filename: str
+        ):
+            del presentation_id, filename
+            self.uploaded = image_data
+            return ("https://example.com/chart.png", "file-1")
+
+        def insert_chart_to_slide(self, *args: Any) -> None:
+            del args
+
+    provider = _Provider()
+    presentation = Presentation.model_construct(
+        name="Demo",
+        name_fn=None,
+        slides=[],
+        provider=provider,
+    )
+    context = SimpleNamespace(
+        presentation_id="presentation-1",
+        uploaded_file_ids=[],
+        slides_app=Presentation._to_slides_app_dimensions(720, 540),
+        page_width_pt=720,
+        page_height_pt=540,
+    )
+    slide = Slide.model_construct(
+        id="slide_1", title="Slide", replacements=[], charts=[]
+    )
+
+    presentation._process_single_chart(context, slide, chart)
+
+    assert provider.uploaded == b"from-custom"

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -73,6 +73,12 @@ def test_default_engine_can_load_packaged_builtin_templates():
     assert rendered["layout_config"]["title"] == "Revenue"
 
 
+def test_create_template_engine_can_disable_defaults():
+    engine = template_engine_module.create_template_engine(None, include_defaults=False)
+
+    assert engine.template_paths == []
+
+
 def test_local_template_precedence_overrides_packaged_builtin(tmp_path):
     custom_templates = tmp_path / "templates"
     custom_templates.mkdir(parents=True, exist_ok=True)

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,33 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -340,55 +367,52 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "48.0.1"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
-    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
-    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
-    { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
-    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
-    { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/27/728c77876f12b000820b69ae490f3c4083775e79e07827e9e60be07ad209/cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471", size = 3278498, upload-time = "2026-06-09T22:31:29.154Z" },
-    { url = "https://files.pythonhosted.org/packages/06/e3/79a612c6d7b1e6ee0edd43633d53035bec2cfb78c82b76f7864f39e36f34/cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2", size = 3798790, upload-time = "2026-06-09T22:31:56.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
-    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
-    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
-    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -396,6 +420,22 @@ name = "csscompressor"
 version = "0.9.5"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8d7ae270bb5bc437b210bb9d6d9e46630c98f4abd20c/csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05", size = 237808, upload-time = "2017-11-26T21:13:08.238Z" }
+
+[[package]]
+name = "cyclonedx-python-lib"
+version = "11.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl", hash = "sha256:3049fc83e06a059b5c5907a527625a8ed5073caab10607ed4c9e5503b590fd44", size = 528689, upload-time = "2026-06-17T11:57:47.358Z" },
+]
 
 [[package]]
 name = "daff"
@@ -670,6 +710,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/50/767448e792d41bfb6094ee317a355c1cb221dca24b2e178e2203bbea2a77/deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e", size = 634860, upload-time = "2026-03-18T17:16:33.785Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/5f/c52bd1255db763d0cdcb7084d2e90c42119cb229302c56bdf1d0aa78abd2/deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4", size = 91979, upload-time = "2026-03-18T17:16:32.171Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -1540,6 +1589,18 @@ wheels = [
 ]
 
 [[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
 name = "logistro"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2100,6 +2161,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2218,6 +2288,61 @@ wheels = [
 ]
 
 [[package]]
+name = "pip"
+version = "26.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2317,6 +2442,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -3000,6 +3137,7 @@ dev = [
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pandas-stubs" },
+    { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -3044,6 +3182,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'ai'", specifier = ">=1.0,<3.0" },
     { name = "pandas", specifier = ">=2.2,<2.4" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
+    { name = "pip-audit", marker = "extra == 'dev'" },
     { name = "plotly", specifier = ">=6.0,<7.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
@@ -3143,6 +3282,60 @@ dependencies = [
     { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/2d/8946864f716ac82dcc88d290ed613cba7a80ec75df4f553ec3ff275f486e/thrift-0.20.0.tar.gz", hash = "sha256:4dd662eadf6b8aebe8a41729527bd69adf6ceaa2a8681cbef64d1273b3e8feba", size = 62295, upload-time = "2024-03-22T22:53:08.228Z" }
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
 
 [[package]]
 name = "tqdm"

--- a/uv.lock
+++ b/uv.lock
@@ -3097,7 +3097,7 @@ wheels = [
 
 [[package]]
 name = "slideflow-presentations"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

This PR contains the Linear `Slideflow Production Hardening` milestone branch work as one commit per issue, rebased onto the updated `master` after merging the ready Dependabot PRs.

It hardens dependency audit coverage, workflow linting, generated chart image ACL/cleanup behavior, release provenance and publishing gates, secret redaction, dbt `compile: false`, Google sharing/auth defaults, template/data/chart concurrency boundaries, Dependabot/default-branch security-alert reconciliation policy, repository secret scanning controls, optional connector CI type-check compatibility, and docs/config/workflow accuracy.

## Linear issues / commits

- JOE-310 `f4aa83e` Harden dependency audit and all-extras `pip-audit`.
- JOE-312 `005edc0` Add blocking workflow lint gate.
- JOE-308 `04b1425` Secure generated chart image ACLs and cleanup reporting.
- JOE-309 `2f3da2c` Reconcile release provenance and version/tag ancestry.
- JOE-317 `ea0d8f1` Gate release publishing on full CI/docs/optional/live validation.
- JOE-311 `932af62` Redact build outputs, CLI errors, logs, and workflow JSON.
- JOE-313 `dcec0f2` Honor dbt `compile: false`.
- JOE-318 `e8b7403` Tighten Google sharing/auth validation defaults.
- JOE-314 `8e76857` Scope template engines per build.
- JOE-315 `4f02ba4` Isolate data cache frames and unblock waiters.
- JOE-316 `818b953` Isolate chart export timeout handling per render scope.
- JOE-324 `d489c20` Document dependency-alert closure policy and Dependabot disposition.
- JOE-325 `2dc8c90` Enable GitHub secret scanning/push protection and add credential hygiene gates.
- JOE-319 `fdb7552` Refresh docs/workflow truth and fail fast on Sheets dry-run misuse.
- JOE-335 `f8de0f6` Fix Databricks optional import typing for the CI matrix.

`3eb135b` is the rebased release `v0.0.7` provenance context commit that makes the release tag ancestry explicit for JOE-309.

## Dependabot and security-alert disposition

Ready Dependabot PRs were reviewed and merged before this branch was rebased:

- #260 `pyjwt 2.13.0` for alerts #21-#25: merged.
- #261 `cryptography 48.0.1` for alert #26: merged.
- #262 `msgpack 1.2.1` for alert #27: merged.
- #264 `actions/checkout 6 -> 7`: merged.

Default-branch verification after those merges:

- `gh api '/repos/joe-broadhead/slideflow/dependabot/alerts?state=open' --paginate` returns `[]`.
- A temporary `origin/master` worktree synced all optional extras successfully and `pip-audit` reported no known vulnerabilities.

Remaining open Dependabot PRs are not merge-ready and were left open:

- #258 `dbt-databricks >=1.10,<1.13`: CI fails in Python test jobs and optional connectors.
- #259 `google-genai >=1.0,<3.0`: CI fails in Python test jobs and optional connectors.
- #263 `numpy >=2.0,<2.6`: CI fails in Python test jobs and optional connectors.

Repository secret scanning and push protection are enabled. The secret-scanning alerts endpoint previously returned `0` open alerts. Non-provider patterns and validity checks remain disabled at the repo setting layer, with `scripts/ci/check_secret_hygiene.py` and `detect-secrets` documented as local/CI controls.

## Local validation after rebase

The rebased branch was validated locally before force-push:

- `uv lock --check`
- `uv pip check`
- `actionlint`
- `uv run python -m mypy slideflow`
- `uvx --from black==26.3.1 black --check slideflow tests scripts`
- `uv run python -m ruff check slideflow tests scripts`
- `uv run python scripts/ci/check_secret_hygiene.py`
- `uv run mkdocs build --strict`
- `uv run bash scripts/ci/run_quickstart_smoke.sh`
- `uv run pre-commit run --all-files`
- `uv run pip-audit --progress-spinner off`
- `uv run pytest -q -m "not integration and not e2e" --cov=slideflow --cov-branch --cov-report=term --cov-fail-under=82` (490 passed, 3 skipped, 3 deselected, 84.24% coverage)
- `uv run pytest -q -m integration` (2 passed)
- `uv run pytest -q -m e2e` (1 passed)
- optional connector import smoke for dbt/databricks/git/bigquery/duckdb
- optional connector/dbt subset (76 passed)
- `git diff --check`
- `python /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local` on restored `JOE-309` patch: clean, no accepted/actionable findings

PR #265 checks are green on head `2f3da2c`:

- dependency-audit
- workflow-lint
- Analyze (Python) / CodeQL
- docs build
- static-security
- test (3.12)
- test (3.13)
- optional-connectors
- build-dist
