### PR TITLE
JOE-365 support Google WIF credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Google Slides, Docs, and Sheets providers now support service-account JSON,
+  external-account / Workload Identity Federation JSON, `GOOGLE_APPLICATION_CREDENTIALS`,
+  and runtime Application Default Credentials through the shared Google auth
+  loader.
 - Google Slides and Google Docs generated-artifact sharing now defaults to
   `share_role: reader`. Set `provider.config.share_role: writer` explicitly
   if recipients need edit access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 - Google Slides, Docs, and Sheets providers now support service-account JSON,
-  external-account / Workload Identity Federation JSON, `GOOGLE_APPLICATION_CREDENTIALS`,
-  and runtime Application Default Credentials through the shared Google auth
-  loader.
+  environment-supplied external-account / Workload Identity Federation JSON,
+  `GOOGLE_APPLICATION_CREDENTIALS`, and runtime Application Default Credentials
+  through the shared Google auth loader.
 - Google Slides and Google Docs generated-artifact sharing now defaults to
   `share_role: reader`. Set `provider.config.share_role: writer` explicitly
   if recipients need edit access.

--- a/README.md
+++ b/README.md
@@ -120,12 +120,13 @@ To create your first output, you\'ll need:
     - Google Sheets target (`spreadsheet_id`) or destination folder for workbook creation.
 2.  **Your Data:** Have your data ready in a CSV file, or have your Databricks credentials configured.
 3.  **A YAML Configuration File:** This is where you\'ll define your output artifact. See the [Configuration](#-configuration) section for more details.
-4.  **Google Cloud Credentials:** You'll need a Google Cloud service account with access to the required Google APIs (Slides/Docs/Sheets + Drive as needed). Provide credentials with one of:
+4.  **Google Cloud Credentials:** You'll need a Google identity with access to the required Google APIs (Slides/Docs/Sheets + Drive as needed). That identity can come from a service-account key, Workload Identity Federation, or runtime Application Default Credentials. Provide credentials with one of:
 
-    -   Set the `credentials` field in your `config.yml` to the path of an untracked JSON credentials file.
-    -   Set `GOOGLE_DOCS_CREDENTIALS` (for `google_docs`), `GOOGLE_SHEETS_CREDENTIALS` (for `google_sheets`), or `GOOGLE_SLIDEFLOW_CREDENTIALS` (shared fallback) to a path or secret-manager-injected raw JSON.
+    -   Set the `credentials` field in your `config.yml` to an untracked service-account JSON file or raw service-account JSON.
+    -   Set `GOOGLE_DOCS_CREDENTIALS` (for `google_docs`), `GOOGLE_SHEETS_CREDENTIALS` (for `google_sheets`), or `GOOGLE_SLIDEFLOW_CREDENTIALS` (shared fallback) to a path or secret-manager-injected raw service-account or external-account JSON.
+    -   Set `GOOGLE_APPLICATION_CREDENTIALS` to an ADC-compatible credentials file, or run in an environment where ADC is already available.
 
-    Do not commit raw service-account JSON, OAuth client secrets, refresh tokens, or `.env` files.
+    Do not commit raw credential JSON, OAuth client secrets, refresh tokens, or `.env` files.
 
 Once you have these, you can run the `build` command:
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -77,9 +77,10 @@ Credential precedence for `google_slides`:
 3. `GOOGLE_APPLICATION_CREDENTIALS`
 4. Runtime Application Default Credentials
 
-`credentials` and credential environment variables may contain a path to
-service-account JSON, a path to external-account / Workload Identity Federation
-JSON, or raw JSON payload.
+`provider.config.credentials` may contain service-account JSON as a file path
+or raw JSON payload. Use `GOOGLE_SLIDEFLOW_CREDENTIALS`,
+`GOOGLE_APPLICATION_CREDENTIALS`, or runtime ADC for external-account / Workload
+Identity Federation credentials.
 
 For provider setup and operational behavior, see [Google Slides Provider](providers/google-slides.md).
 
@@ -111,9 +112,10 @@ Credential precedence for `google_docs`:
 4. `GOOGLE_APPLICATION_CREDENTIALS`
 5. Runtime Application Default Credentials
 
-`credentials` and credential environment variables may contain a path to
-service-account JSON, a path to external-account / Workload Identity Federation
-JSON, or raw JSON payload.
+`provider.config.credentials` may contain service-account JSON as a file path
+or raw JSON payload. Use `GOOGLE_DOCS_CREDENTIALS`,
+`GOOGLE_SLIDEFLOW_CREDENTIALS`, `GOOGLE_APPLICATION_CREDENTIALS`, or runtime ADC
+for external-account / Workload Identity Federation credentials.
 
 For provider setup and marker behavior, see [Google Docs Provider](providers/google-docs.md).
 
@@ -136,9 +138,10 @@ Credential precedence for `google_sheets`:
 4. `GOOGLE_APPLICATION_CREDENTIALS`
 5. Runtime Application Default Credentials
 
-`credentials` and credential environment variables may contain a path to
-service-account JSON, a path to external-account / Workload Identity Federation
-JSON, or raw JSON payload.
+`provider.config.credentials` may contain service-account JSON as a file path
+or raw JSON payload. Use `GOOGLE_SHEETS_CREDENTIALS`,
+`GOOGLE_SLIDEFLOW_CREDENTIALS`, `GOOGLE_APPLICATION_CREDENTIALS`, or runtime ADC
+for external-account / Workload Identity Federation credentials.
 
 ## `workbook` (Google Sheets pipelines)
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -70,6 +70,17 @@ Supported values:
 | `requests_per_second` | `float` | no | API rate limit override |
 | `strict_cleanup` | `bool` | no | Fail if temporary chart image cleanup fails |
 
+Credential precedence for `google_slides`:
+
+1. `provider.config.credentials`
+2. `GOOGLE_SLIDEFLOW_CREDENTIALS`
+3. `GOOGLE_APPLICATION_CREDENTIALS`
+4. Runtime Application Default Credentials
+
+`credentials` and credential environment variables may contain a path to
+service-account JSON, a path to external-account / Workload Identity Federation
+JSON, or raw JSON payload.
+
 For provider setup and operational behavior, see [Google Slides Provider](providers/google-slides.md).
 
 ### `provider.config` for `google_docs`
@@ -97,6 +108,12 @@ Credential precedence for `google_docs`:
 1. `provider.config.credentials`
 2. `GOOGLE_DOCS_CREDENTIALS`
 3. `GOOGLE_SLIDEFLOW_CREDENTIALS`
+4. `GOOGLE_APPLICATION_CREDENTIALS`
+5. Runtime Application Default Credentials
+
+`credentials` and credential environment variables may contain a path to
+service-account JSON, a path to external-account / Workload Identity Federation
+JSON, or raw JSON payload.
 
 For provider setup and marker behavior, see [Google Docs Provider](providers/google-docs.md).
 
@@ -116,6 +133,12 @@ Credential precedence for `google_sheets`:
 1. `provider.config.credentials`
 2. `GOOGLE_SHEETS_CREDENTIALS`
 3. `GOOGLE_SLIDEFLOW_CREDENTIALS`
+4. `GOOGLE_APPLICATION_CREDENTIALS`
+5. Runtime Application Default Credentials
+
+`credentials` and credential environment variables may contain a path to
+service-account JSON, a path to external-account / Workload Identity Federation
+JSON, or raw JSON payload.
 
 ## `workbook` (Google Sheets pipelines)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,10 +35,13 @@ SlideFlow accepts credentials via:
 2. `GOOGLE_DOCS_CREDENTIALS` environment variable (for `google_docs`)
 3. `GOOGLE_SHEETS_CREDENTIALS` environment variable (for `google_sheets`)
 4. `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable (shared fallback)
+5. `GOOGLE_APPLICATION_CREDENTIALS` for ADC / Workload Identity Federation files
+6. Runtime Application Default Credentials
 
 Environment credential values support either:
 
 - Path to service-account JSON file
+- Path to external-account / Workload Identity Federation JSON file
 - Raw JSON string content injected by a secret manager or GitHub Secrets
 
 Example:
@@ -47,12 +50,16 @@ Example:
 export GOOGLE_SLIDEFLOW_CREDENTIALS=/absolute/path/service-account.json
 export GOOGLE_DOCS_CREDENTIALS=/absolute/path/service-account.json
 export GOOGLE_SHEETS_CREDENTIALS=/absolute/path/service-account.json
+export GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/external-account.json
 ```
 
 For production service-account and Shared Drive setup, follow the end-to-end
 guide: [Google Service Accounts & Shared Drives](google-service-accounts-shared-drives.md).
 Do not commit raw service-account JSON, OAuth client secrets, refresh tokens, or
 `.env` files.
+For keyless CI/CD, prefer a Google Workload Identity Federation auth step that
+sets `GOOGLE_APPLICATION_CREDENTIALS` or runtime ADC instead of storing a
+long-lived service-account key.
 
 ## Create a template deck
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ source .venv/bin/activate
 
 SlideFlow accepts credentials via:
 
-1. `provider.config.credentials` in YAML as a path to an untracked file
+1. `provider.config.credentials` in YAML for service-account JSON
 2. `GOOGLE_DOCS_CREDENTIALS` environment variable (for `google_docs`)
 3. `GOOGLE_SHEETS_CREDENTIALS` environment variable (for `google_sheets`)
 4. `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable (shared fallback)
@@ -43,6 +43,10 @@ Environment credential values support either:
 - Path to service-account JSON file
 - Path to external-account / Workload Identity Federation JSON file
 - Raw JSON string content injected by a secret manager or GitHub Secrets
+
+Keep external-account / Workload Identity Federation configs in trusted
+environment or ADC sources. `provider.config.credentials` accepts
+service-account JSON, but not external-account JSON from repository YAML.
 
 Example:
 

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -17,16 +17,17 @@ It reuses `presentation.slides[]` from the core schema:
    service account key, Workload Identity Federation, or runtime ADC identity.
 3. Share the template document (and destination Drive folders) with that identity.
 4. Provide credentials via:
-   - `provider.config.credentials` in YAML as a path to an untracked file, or
+   - `provider.config.credentials` in YAML as service-account JSON or a path to an untracked service-account file, or
    - `GOOGLE_DOCS_CREDENTIALS`, or
    - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback), or
    - `GOOGLE_APPLICATION_CREDENTIALS`, or
    - runtime Application Default Credentials.
 
-`provider.config.credentials`, `GOOGLE_DOCS_CREDENTIALS`, and
-`GOOGLE_SLIDEFLOW_CREDENTIALS` accept service-account JSON or external-account /
-Workload Identity Federation JSON as a file path or raw JSON payload. Do not
-commit raw credential JSON or `.env` files.
+`GOOGLE_DOCS_CREDENTIALS` and `GOOGLE_SLIDEFLOW_CREDENTIALS` accept
+service-account JSON or external-account / Workload Identity Federation JSON as
+a file path or raw JSON payload. Use those environment sources,
+`GOOGLE_APPLICATION_CREDENTIALS`, or runtime ADC for WIF. Do not commit raw
+credential JSON or `.env` files.
 
 For production Shared Drive setup and service-account bootstrap commands, see
 [Google Service Accounts & Shared Drives](../google-service-accounts-shared-drives.md).

--- a/docs/providers/google-docs.md
+++ b/docs/providers/google-docs.md
@@ -13,14 +13,20 @@ It reuses `presentation.slides[]` from the core schema:
 1. Enable APIs in your Google Cloud project:
    - Google Docs API
    - Google Drive API
-2. Create a service account.
-3. Share the template document (and destination Drive folders) with that service account.
+2. Create or select the Google identity SlideFlow will run as. This can be a
+   service account key, Workload Identity Federation, or runtime ADC identity.
+3. Share the template document (and destination Drive folders) with that identity.
 4. Provide credentials via:
    - `provider.config.credentials` in YAML as a path to an untracked file, or
    - `GOOGLE_DOCS_CREDENTIALS`, or
-   - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback).
+   - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback), or
+   - `GOOGLE_APPLICATION_CREDENTIALS`, or
+   - runtime Application Default Credentials.
 
-Do not commit raw service-account JSON or `.env` files.
+`provider.config.credentials`, `GOOGLE_DOCS_CREDENTIALS`, and
+`GOOGLE_SLIDEFLOW_CREDENTIALS` accept service-account JSON or external-account /
+Workload Identity Federation JSON as a file path or raw JSON payload. Do not
+commit raw credential JSON or `.env` files.
 
 For production Shared Drive setup and service-account bootstrap commands, see
 [Google Service Accounts & Shared Drives](../google-service-accounts-shared-drives.md).

--- a/docs/providers/google-sheets.md
+++ b/docs/providers/google-sheets.md
@@ -10,15 +10,21 @@ schema with tab-level write definitions and optional AI summary rules.
 1. Enable APIs in your Google Cloud project:
    - Google Sheets API
    - Google Drive API
-2. Create a service account.
+2. Create or select the Google identity SlideFlow will run as. This can be a
+   service account key, Workload Identity Federation, or runtime ADC identity.
 3. Share destination Drive folders (and existing target sheet, if reusing one)
-   with that service account.
+   with that identity.
 4. Provide credentials via:
    - `provider.config.credentials` as a path to an untracked file, or
    - `GOOGLE_SHEETS_CREDENTIALS`, or
-   - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback).
+   - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback), or
+   - `GOOGLE_APPLICATION_CREDENTIALS`, or
+   - runtime Application Default Credentials.
 
-Do not commit raw service-account JSON or `.env` files.
+`provider.config.credentials`, `GOOGLE_SHEETS_CREDENTIALS`, and
+`GOOGLE_SLIDEFLOW_CREDENTIALS` accept service-account JSON or external-account /
+Workload Identity Federation JSON as a file path or raw JSON payload. Do not
+commit raw credential JSON or `.env` files.
 
 ## Provider Config
 

--- a/docs/providers/google-sheets.md
+++ b/docs/providers/google-sheets.md
@@ -15,16 +15,17 @@ schema with tab-level write definitions and optional AI summary rules.
 3. Share destination Drive folders (and existing target sheet, if reusing one)
    with that identity.
 4. Provide credentials via:
-   - `provider.config.credentials` as a path to an untracked file, or
+   - `provider.config.credentials` as service-account JSON or a path to an untracked service-account file, or
    - `GOOGLE_SHEETS_CREDENTIALS`, or
    - `GOOGLE_SLIDEFLOW_CREDENTIALS` (fallback), or
    - `GOOGLE_APPLICATION_CREDENTIALS`, or
    - runtime Application Default Credentials.
 
-`provider.config.credentials`, `GOOGLE_SHEETS_CREDENTIALS`, and
-`GOOGLE_SLIDEFLOW_CREDENTIALS` accept service-account JSON or external-account /
-Workload Identity Federation JSON as a file path or raw JSON payload. Do not
-commit raw credential JSON or `.env` files.
+`GOOGLE_SHEETS_CREDENTIALS` and `GOOGLE_SLIDEFLOW_CREDENTIALS` accept
+service-account JSON or external-account / Workload Identity Federation JSON as
+a file path or raw JSON payload. Use those environment sources,
+`GOOGLE_APPLICATION_CREDENTIALS`, or runtime ADC for WIF. Do not commit raw
+credential JSON or `.env` files.
 
 ## Provider Config
 

--- a/docs/providers/google-slides.md
+++ b/docs/providers/google-slides.md
@@ -12,15 +12,15 @@ It can create a blank deck or copy a template, insert chart images, run text/tab
    service account key, Workload Identity Federation, or runtime ADC identity.
 3. Share the template deck (and destination Drive folder) with that identity.
 4. Supply credentials via either:
-   - `provider.config.credentials` in YAML as a path to an untracked file, or
+   - `provider.config.credentials` in YAML as service-account JSON or a path to an untracked service-account file, or
    - `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable, or
    - `GOOGLE_APPLICATION_CREDENTIALS`, or
    - runtime Application Default Credentials.
 
-`provider.config.credentials` and `GOOGLE_SLIDEFLOW_CREDENTIALS` accept
-service-account JSON or external-account / Workload Identity Federation JSON as
-a file path or raw JSON payload. Do not commit raw credential JSON or `.env`
-files.
+`GOOGLE_SLIDEFLOW_CREDENTIALS` accepts service-account JSON or external-account
+/ Workload Identity Federation JSON as a file path or raw JSON payload. Use
+that environment source, `GOOGLE_APPLICATION_CREDENTIALS`, or runtime ADC for
+WIF. Do not commit raw credential JSON or `.env` files.
 
 For production Shared Drive setup and command-by-command service-account
 bootstrap, see [Google Service Accounts & Shared Drives](../google-service-accounts-shared-drives.md).

--- a/docs/providers/google-slides.md
+++ b/docs/providers/google-slides.md
@@ -8,13 +8,19 @@ It can create a blank deck or copy a template, insert chart images, run text/tab
 1. Enable APIs in your Google Cloud project:
    - Google Slides API
    - Google Drive API
-2. Create a service account.
-3. Share the template deck (and destination Drive folder) with that service account email.
+2. Create or select the Google identity SlideFlow will run as. This can be a
+   service account key, Workload Identity Federation, or runtime ADC identity.
+3. Share the template deck (and destination Drive folder) with that identity.
 4. Supply credentials via either:
    - `provider.config.credentials` in YAML as a path to an untracked file, or
-   - `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable.
+   - `GOOGLE_SLIDEFLOW_CREDENTIALS` environment variable, or
+   - `GOOGLE_APPLICATION_CREDENTIALS`, or
+   - runtime Application Default Credentials.
 
-Do not commit raw service-account JSON or `.env` files.
+`provider.config.credentials` and `GOOGLE_SLIDEFLOW_CREDENTIALS` accept
+service-account JSON or external-account / Workload Identity Federation JSON as
+a file path or raw JSON payload. Do not commit raw credential JSON or `.env`
+files.
 
 For production Shared Drive setup and command-by-command service-account
 bootstrap, see [Google Service Accounts & Shared Drives](../google-service-accounts-shared-drives.md).
@@ -56,7 +62,8 @@ provider:
     strict_cleanup: false
 ```
 
-If you use `GOOGLE_SLIDEFLOW_CREDENTIALS`, you can omit `config.credentials`.
+If you use `GOOGLE_SLIDEFLOW_CREDENTIALS`, `GOOGLE_APPLICATION_CREDENTIALS`, or
+runtime ADC, you can omit `config.credentials`.
 
 Field behavior:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,15 +9,52 @@ For Google provider auth, SlideFlow reads credentials from:
    - `GOOGLE_DOCS_CREDENTIALS` (`google_docs`)
    - `GOOGLE_SHEETS_CREDENTIALS` (`google_sheets`)
 3. `GOOGLE_SLIDEFLOW_CREDENTIALS` (shared fallback)
+4. `GOOGLE_APPLICATION_CREDENTIALS` (ADC file path)
+5. Application Default Credentials from the runtime environment
 
 Credential value can be:
 
 - Path to service-account JSON
+- Path to external-account / Workload Identity Federation JSON
 - Raw JSON payload
+- Runtime ADC credentials, when no explicit credential source is configured
 
 Recommended: use environment variables in CI and avoid storing secrets in repo
 files. If you use raw JSON, inject it through a secret manager or GitHub
 Secrets-backed environment variable; do not paste it into checked-in YAML.
+For keyless CI/CD, prefer Workload Identity Federation through
+`GOOGLE_APPLICATION_CREDENTIALS` or runtime ADC over long-lived key JSON.
+
+## Keyless CI/CD with Workload Identity Federation
+
+In GitHub Actions, use OIDC to obtain short-lived Google credentials and let
+SlideFlow discover them through ADC:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/<project-number>/locations/global/workloadIdentityPools/<pool-id>/providers/<provider-id>"
+          service_account: "slideflow-runtime@<project-id>.iam.gserviceaccount.com"
+          create_credentials_file: true
+
+      - run: slideflow build config.yml
+```
+
+The auth action exports `GOOGLE_APPLICATION_CREDENTIALS` for the generated
+external-account credentials file. The impersonated service account or ADC
+identity still needs normal Google Drive ACLs on templates, destination folders,
+Shared Drives, and any reused Sheets workbooks.
 
 ## Credential hygiene policy
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,9 +15,14 @@ For Google provider auth, SlideFlow reads credentials from:
 Credential value can be:
 
 - Path to service-account JSON
-- Path to external-account / Workload Identity Federation JSON
-- Raw JSON payload
+- Path to external-account / Workload Identity Federation JSON from trusted env/ADC sources
+- Raw JSON payload from trusted env sources
 - Runtime ADC credentials, when no explicit credential source is configured
+
+`provider.config.credentials` accepts service-account JSON only. External-account
+/ Workload Identity Federation JSON is active credential configuration, so keep
+it in trusted environment variables, `GOOGLE_APPLICATION_CREDENTIALS`, or
+runtime ADC rather than repository YAML.
 
 Recommended: use environment variables in CI and avoid storing secrets in repo
 files. If you use raw JSON, inject it through a secret manager or GitHub

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,6 +79,8 @@ Run live template + chart rendering tests locally:
 ```bash
 export SLIDEFLOW_RUN_LIVE=1
 export GOOGLE_SLIDEFLOW_CREDENTIALS=/absolute/path/to/service-account.json
+# or, for ADC/WIF:
+# export GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/external-account.json
 export SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID=<drive-folder-id>
 # optional override for chart image uploads:
 export SLIDEFLOW_LIVE_DRIVE_FOLDER_ID=<drive-folder-id>
@@ -103,6 +105,8 @@ Run live Google Docs tests locally:
 ```bash
 export SLIDEFLOW_RUN_LIVE=1
 export GOOGLE_DOCS_CREDENTIALS=/absolute/path/to/service-account.json
+# or, for ADC/WIF:
+# export GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/external-account.json
 export SLIDEFLOW_LIVE_DOCUMENT_FOLDER_ID=<drive-folder-id>
 # optional override for chart image uploads:
 export SLIDEFLOW_LIVE_DRIVE_FOLDER_ID=<drive-folder-id>
@@ -123,6 +127,8 @@ Run live Google Sheets tests locally:
 ```bash
 export SLIDEFLOW_RUN_LIVE=1
 export GOOGLE_SHEETS_CREDENTIALS=/absolute/path/to/service-account.json
+# or, for ADC/WIF:
+# export GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/external-account.json
 export SLIDEFLOW_LIVE_SHEETS_FOLDER_ID=<drive-folder-id>
 # optional override:
 export SLIDEFLOW_LIVE_DRIVE_FOLDER_ID=<drive-folder-id>

--- a/slideflow/cli/commands/validate.py
+++ b/slideflow/cli/commands/validate.py
@@ -40,7 +40,6 @@ from typing import Annotated, Any, Dict, List, Optional, Set
 
 import typer
 import yaml  # type: ignore[import-untyped]
-from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 
 from slideflow.cli.commands._registry import resolve_registry_paths
@@ -55,7 +54,7 @@ from slideflow.cli.theme import (
 from slideflow.presentations.builder import PresentationBuilder
 from slideflow.presentations.config import PresentationConfig
 from slideflow.utilities import ConfigLoader
-from slideflow.utilities.auth import handle_google_credentials
+from slideflow.utilities.auth import load_google_credentials
 from slideflow.utilities.error_messages import redacted_error_line
 
 _GOOGLE_SLIDES_CONTRACT_FIELDS = (
@@ -108,11 +107,11 @@ def _build_readonly_google_contract_client(
     )
 
     if provider_type == "google_slides":
-        loaded_credentials = handle_google_credentials(credentials_input)
-        credentials = Credentials.from_service_account_info(
-            loaded_credentials,
+        loaded_credentials = load_google_credentials(
+            credentials_input,
             scopes=list(_GOOGLE_SLIDES_CONTRACT_SCOPES),
         )
+        credentials = loaded_credentials.credentials
         slides_service = build("slides", "v1", credentials=credentials)
         return _GoogleContractCheckClient(
             provider_type="google_slides",
@@ -121,14 +120,12 @@ def _build_readonly_google_contract_client(
         )
 
     if provider_type == "google_docs":
-        loaded_credentials = handle_google_credentials(
+        loaded_credentials = load_google_credentials(
             credentials_input,
+            scopes=list(_GOOGLE_DOCS_CONTRACT_SCOPES),
             env_var_names=["GOOGLE_DOCS_CREDENTIALS", "GOOGLE_SLIDEFLOW_CREDENTIALS"],
         )
-        credentials = Credentials.from_service_account_info(
-            loaded_credentials,
-            scopes=list(_GOOGLE_DOCS_CONTRACT_SCOPES),
-        )
+        credentials = loaded_credentials.credentials
         docs_service = build("docs", "v1", credentials=credentials)
         marker_prefix = (
             provider_config.get("section_marker_prefix", "{{SECTION:")

--- a/slideflow/presentations/providers/google_docs.py
+++ b/slideflow/presentations/providers/google_docs.py
@@ -7,7 +7,6 @@ those marker-defined sections.
 
 from __future__ import annotations
 
-import os
 import re
 import threading
 import time
@@ -15,7 +14,6 @@ from bisect import bisect_left
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
-from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from pydantic import Field, field_validator
@@ -32,10 +30,12 @@ from slideflow.presentations.providers.google_drive_ownership import (
     normalize_transfer_owner_email,
     transfer_drive_file_ownership,
 )
-from slideflow.utilities.auth import handle_google_credentials
+from slideflow.utilities.auth import (
+    describe_google_credentials_source,
+    load_google_credentials,
+)
 from slideflow.utilities.exceptions import RenderingError
 from slideflow.utilities.google_api import (
-    build_service_account_credentials,
     execute_rate_limited_request,
     slideflow_google_request_builder,
     upload_png_to_drive,
@@ -174,17 +174,16 @@ class GoogleDocsProvider(PresentationProvider):
         self._uploaded_chart_image_ids_by_url: Dict[str, str] = {}
         self._chart_image_cleanup_failed_ids: List[str] = []
 
-        loaded_credentials = handle_google_credentials(
+        loaded_credentials = load_google_credentials(
             config.credentials,
+            scopes=self.SCOPES,
             env_var_names=[
                 Environment.GOOGLE_DOCS_CREDENTIALS,
                 Environment.GOOGLE_SLIDEFLOW_CREDENTIALS,
             ],
         )
-
-        credentials = build_service_account_credentials(
-            loaded_credentials, self.SCOPES, credentials_cls=Credentials
-        )
+        self._google_credentials_source = loaded_credentials.source_type
+        credentials = loaded_credentials.credentials
 
         self.docs_service = build(
             "docs",
@@ -205,16 +204,25 @@ class GoogleDocsProvider(PresentationProvider):
         return execute_rate_limited_request(request, self.rate_limiter, num_retries=3)
 
     def run_preflight_checks(self) -> List[Tuple[str, bool, str]]:
-        has_credentials = bool(self.config.credentials) or bool(
-            os.getenv(Environment.GOOGLE_DOCS_CREDENTIALS)
-            or os.getenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS)
+        credentials_source = getattr(
+            self,
+            "_google_credentials_source",
+            describe_google_credentials_source(
+                self.config.credentials,
+                [
+                    Environment.GOOGLE_DOCS_CREDENTIALS,
+                    Environment.GOOGLE_SLIDEFLOW_CREDENTIALS,
+                ],
+                include_adc=False,
+            ),
         )
+        has_credentials = credentials_source != "missing"
         checks: List[Tuple[str, bool, str]] = [
             (
                 "google_docs_credentials_present",
                 has_credentials,
                 (
-                    "Credentials found in config or supported environment variables"
+                    f"Credentials source: {credentials_source}"
                     if has_credentials
                     else "Missing credentials in config and environment"
                 ),

--- a/slideflow/presentations/providers/google_slides.py
+++ b/slideflow/presentations/providers/google_slides.py
@@ -15,9 +15,10 @@ The Google Slides provider includes:
     - Comprehensive error handling and API operation logging
 
 Authentication:
-    The provider uses Google service account credentials for authentication,
-    requiring appropriate scopes for Google Slides, Google Drive, and file
-    operations. Credentials must be provided via a service account JSON file.
+    The provider uses Google auth credentials for authentication, requiring
+    appropriate scopes for Google Slides, Google Drive, and file operations.
+    Credentials can come from service-account JSON, Workload Identity
+    Federation / external-account JSON, or Application Default Credentials.
 
 Required Scopes:
     - https://www.googleapis.com/auth/presentations: For Slides API access
@@ -65,12 +66,10 @@ Example:
     >>> print(f"View presentation: {url}")
 """
 
-import os
 import threading
 import time
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
-from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from pydantic import Field, field_validator
@@ -88,9 +87,11 @@ from slideflow.presentations.providers.google_drive_ownership import (
     transfer_drive_file_ownership,
 )
 from slideflow.presentations.rate_limiter import get_google_api_rate_limiter
-from slideflow.utilities.auth import handle_google_credentials
+from slideflow.utilities.auth import (
+    describe_google_credentials_source,
+    load_google_credentials,
+)
 from slideflow.utilities.google_api import (
-    build_service_account_credentials,
     execute_rate_limited_request,
     slideflow_google_request_builder,
     upload_png_to_drive,
@@ -118,7 +119,7 @@ class GoogleSlidesProviderConfig(PresentationProviderConfig):
 
     Attributes:
         provider_type: Always "google_slides" for this provider.
-        credentials: Path to Google service account credentials JSON file.
+        credentials: Google credentials as a file path or raw JSON payload.
         template_id: Optional Google Slides template ID to copy from when creating presentations.
         drive_folder_id: Optional Google Drive folder ID for organizing uploaded chart images.
         presentation_folder_id: Optional Google Drive folder ID for organizing created presentations.
@@ -139,7 +140,7 @@ class GoogleSlidesProviderConfig(PresentationProviderConfig):
     provider_type: Literal["google_slides"] = "google_slides"
     credentials: Optional[str] = Field(
         None,
-        description="Google service account credentials as a file path or a JSON string.",
+        description="Google credentials as a file path or a JSON string.",
     )
     template_id: Optional[str] = Field(
         None, description="Google Slides template ID to copy from"
@@ -211,7 +212,7 @@ class GoogleSlidesProvider(PresentationProvider):
     and permission management.
 
     Authentication:
-        Uses Google service account credentials with OAuth2 for authentication.
+        Uses Google OAuth2 credentials from explicit config/env sources or ADC.
         Requires appropriate IAM permissions and API scopes for both Slides and
         Drive APIs.
 
@@ -252,7 +253,7 @@ class GoogleSlidesProvider(PresentationProvider):
         """Initialize Google Slides provider with authentication.
 
         Sets up authenticated Google API service clients for both Slides and Drive
-        APIs using the provided service account credentials.
+        APIs using the configured Google credentials.
 
         Args:
             config: GoogleSlidesProviderConfig containing authentication and
@@ -267,12 +268,12 @@ class GoogleSlidesProvider(PresentationProvider):
         self._uploaded_chart_image_ids_by_url: Dict[str, str] = {}
         self._chart_image_cleanup_failed_ids: List[str] = []
 
-        # Initialize Google API services
-        loaded_credentials = handle_google_credentials(config.credentials)
-
-        credentials = build_service_account_credentials(
-            loaded_credentials, self.SCOPES, credentials_cls=Credentials
+        loaded_credentials = load_google_credentials(
+            config.credentials,
+            scopes=self.SCOPES,
         )
+        self._google_credentials_source = loaded_credentials.source_type
+        credentials = loaded_credentials.credentials
 
         self.slides_service = build(
             "slides",
@@ -317,15 +318,22 @@ class GoogleSlidesProvider(PresentationProvider):
 
     def run_preflight_checks(self) -> List[Tuple[str, bool, str]]:
         """Run Google provider preflight checks used by CLI doctor/build."""
-        has_credentials = bool(self.config.credentials) or bool(
-            os.getenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS)
+        credentials_source = getattr(
+            self,
+            "_google_credentials_source",
+            describe_google_credentials_source(
+                self.config.credentials,
+                [Environment.GOOGLE_SLIDEFLOW_CREDENTIALS],
+                include_adc=False,
+            ),
         )
+        has_credentials = credentials_source != "missing"
         checks: List[Tuple[str, bool, str]] = [
             (
                 "google_credentials_present",
                 has_credentials,
                 (
-                    "Credentials found in config or GOOGLE_SLIDEFLOW_CREDENTIALS"
+                    f"Credentials source: {credentials_source}"
                     if has_credentials
                     else "Missing credentials in config and environment"
                 ),
@@ -875,7 +883,7 @@ class GoogleSlidesProvider(PresentationProvider):
                     logger.warning(
                         f"Presentation {presentation_id} created, but failed to move to folder "
                         f"'{destination_folder_id}'. Please check if the folder exists "
-                        f"and the service account has permissions. Error: {e}"
+                        f"and the configured Google identity has permissions. Error: {e}"
                     )
 
             duration = time.time() - start_time

--- a/slideflow/utilities/auth.py
+++ b/slideflow/utilities/auth.py
@@ -110,6 +110,8 @@ def _load_google_credentials_from_mapping(
     google_auth: Any,
     payload: dict[str, Any],
     scopes: Optional[Sequence[str]],
+    *,
+    allow_generic_loader: bool,
 ) -> tuple[Any, Optional[str]]:
     credential_type = str(payload.get("type", "")).strip()
     if credential_type == "service_account":
@@ -124,9 +126,17 @@ def _load_google_credentials_from_mapping(
         )
         return credentials, project_id if isinstance(project_id, str) else None
 
+    if not allow_generic_loader:
+        raise AuthenticationError(
+            "Non-service-account Google credential JSON contains active "
+            "credential configuration and must be supplied through trusted "
+            "environment credentials, such as GOOGLE_APPLICATION_CREDENTIALS "
+            "or provider credential environment variables."
+        )
+
     # google-auth's generic loader is the supported cross-type path for
-    # external_account/WIF variants. The source is Slideflow config/env, not
-    # untrusted user-submitted payload.
+    # external_account/WIF variants. It is only enabled for trusted runtime
+    # sources such as environment variables and ADC files, not repository YAML.
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
@@ -143,6 +153,8 @@ def _load_google_credentials_from_file(
     google_auth: Any,
     filename: str,
     scopes: Optional[Sequence[str]],
+    *,
+    allow_generic_loader: bool,
 ) -> tuple[Any, Optional[str]]:
     try:
         with open(filename, "r", encoding="utf-8") as credential_file:
@@ -153,7 +165,12 @@ def _load_google_credentials_from_file(
     if not isinstance(payload, dict):
         raise AuthenticationError("Credentials file must contain a JSON object.")
 
-    return _load_google_credentials_from_mapping(google_auth, payload, scopes)
+    return _load_google_credentials_from_mapping(
+        google_auth,
+        payload,
+        scopes,
+        allow_generic_loader=allow_generic_loader,
+    )
 
 
 def handle_google_credentials(
@@ -212,8 +229,10 @@ def load_google_credentials(
     3. ``GOOGLE_APPLICATION_CREDENTIALS`` file path
     4. ``google.auth.default``
 
-    ``google.auth`` handles both service-account and external-account payloads,
-    which enables Workload Identity Federation and keyless ADC runtimes.
+    Service-account JSON can be loaded from explicit config. Generic Google auth
+    payloads such as external-account / Workload Identity Federation JSON are
+    loaded only from trusted runtime sources such as environment variables,
+    ``GOOGLE_APPLICATION_CREDENTIALS``, or runtime ADC.
     """
 
     try:
@@ -239,12 +258,14 @@ def load_google_credentials(
         )
 
     try:
+        allow_generic_loader = source_name != "provider.config.credentials"
         if source_type == "explicit_path":
             assert source_value is not None
             loaded_credentials, project_id = _load_google_credentials_from_file(
                 google.auth,
                 source_value,
                 scopes,
+                allow_generic_loader=allow_generic_loader,
             )
         elif source_type == "explicit_json":
             try:
@@ -261,6 +282,7 @@ def load_google_credentials(
                 google.auth,
                 payload,
                 scopes,
+                allow_generic_loader=allow_generic_loader,
             )
         elif source_type == _google_auth_source_type_for_env(
             Environment.GOOGLE_APPLICATION_CREDENTIALS
@@ -270,6 +292,7 @@ def load_google_credentials(
                 google.auth,
                 source_value,
                 scopes,
+                allow_generic_loader=allow_generic_loader,
             )
         elif source_type == "adc_default":
             loaded_credentials, project_id = google.auth.default(
@@ -281,6 +304,7 @@ def load_google_credentials(
                     google.auth,
                     source_value,
                     scopes,
+                    allow_generic_loader=allow_generic_loader,
                 )
             else:
                 try:
@@ -297,6 +321,7 @@ def load_google_credentials(
                     google.auth,
                     payload,
                     scopes,
+                    allow_generic_loader=allow_generic_loader,
                 )
     except AuthenticationError:
         raise

--- a/slideflow/utilities/auth.py
+++ b/slideflow/utilities/auth.py
@@ -1,12 +1,24 @@
 import json
 import os
-from typing import Optional, Sequence
+import warnings
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
 
 from slideflow.constants import Environment
 from slideflow.utilities.exceptions import AuthenticationError
 from slideflow.utilities.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class GoogleCredentialsLoadResult:
+    """Resolved Google credentials plus non-sensitive source metadata."""
+
+    credentials: Any
+    source_type: str
+    source_name: str
+    project_id: Optional[str] = None
 
 
 def _normalize_credentials_source(value: Optional[str]) -> Optional[str]:
@@ -19,6 +31,129 @@ def _normalize_credentials_source(value: Optional[str]) -> Optional[str]:
     if trimmed.lower() == "null":
         return None
     return trimmed
+
+
+def _google_auth_source_type_for_env(env_name: str) -> str:
+    normalized = env_name.strip().lower()
+    return f"env_{normalized}"
+
+
+def _source_looks_like_file(value: str) -> bool:
+    return os.path.exists(value) and os.path.isfile(value)
+
+
+def resolve_google_credentials_source(
+    credentials: Optional[str] = None,
+    env_var_names: Optional[Sequence[str]] = None,
+    *,
+    include_adc: bool = True,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Resolve the configured Google credential source without loading secrets.
+
+    Returns ``(source_value, source_type, source_name)`` where ``source_type`` is
+    suitable for diagnostics and intentionally avoids including credential
+    payloads or local file paths.
+    """
+
+    clean_credentials = _normalize_credentials_source(credentials)
+    if clean_credentials:
+        return (
+            clean_credentials,
+            (
+                "explicit_path"
+                if _source_looks_like_file(clean_credentials)
+                else "explicit_json"
+            ),
+            "provider.config.credentials",
+        )
+
+    env_sources = list(env_var_names or [Environment.GOOGLE_SLIDEFLOW_CREDENTIALS])
+    for env_name in env_sources:
+        env_value = _normalize_credentials_source(os.getenv(env_name))
+        if env_value:
+            return env_value, _google_auth_source_type_for_env(env_name), env_name
+
+    if include_adc:
+        adc_path = _normalize_credentials_source(
+            os.getenv(Environment.GOOGLE_APPLICATION_CREDENTIALS)
+        )
+        if adc_path:
+            return (
+                adc_path,
+                _google_auth_source_type_for_env(
+                    Environment.GOOGLE_APPLICATION_CREDENTIALS
+                ),
+                Environment.GOOGLE_APPLICATION_CREDENTIALS,
+            )
+        return None, "adc_default", "google.auth.default"
+
+    return None, None, None
+
+
+def describe_google_credentials_source(
+    credentials: Optional[str] = None,
+    env_var_names: Optional[Sequence[str]] = None,
+    *,
+    include_adc: bool = True,
+) -> str:
+    """Return the non-sensitive Google credential source label."""
+
+    _, source_type, _ = resolve_google_credentials_source(
+        credentials,
+        env_var_names,
+        include_adc=include_adc,
+    )
+    return source_type or "missing"
+
+
+def _load_google_credentials_from_mapping(
+    google_auth: Any,
+    payload: dict[str, Any],
+    scopes: Optional[Sequence[str]],
+) -> tuple[Any, Optional[str]]:
+    credential_type = str(payload.get("type", "")).strip()
+    if credential_type == "service_account":
+        from google.oauth2 import service_account
+
+        credentials = service_account.Credentials.from_service_account_info(
+            payload,
+            scopes=list(scopes or []),
+        )
+        project_id = getattr(credentials, "project_id", None) or payload.get(
+            "project_id"
+        )
+        return credentials, project_id if isinstance(project_id, str) else None
+
+    # google-auth's generic loader is the supported cross-type path for
+    # external_account/WIF variants. The source is Slideflow config/env, not
+    # untrusted user-submitted payload.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The load_credentials_from_dict method is deprecated.*",
+            category=DeprecationWarning,
+        )
+        return google_auth.load_credentials_from_dict(
+            payload,
+            scopes=list(scopes or []),
+        )
+
+
+def _load_google_credentials_from_file(
+    google_auth: Any,
+    filename: str,
+    scopes: Optional[Sequence[str]],
+) -> tuple[Any, Optional[str]]:
+    try:
+        with open(filename, "r", encoding="utf-8") as credential_file:
+            payload = json.load(credential_file)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise AuthenticationError("Credentials file is not a valid JSON.") from error
+
+    if not isinstance(payload, dict):
+        raise AuthenticationError("Credentials file must contain a JSON object.")
+
+    return _load_google_credentials_from_mapping(google_auth, payload, scopes)
 
 
 def handle_google_credentials(
@@ -61,3 +196,118 @@ def handle_google_credentials(
             raise AuthenticationError(
                 "Credentials string provided was not valid"
             ) from error
+
+
+def load_google_credentials(
+    credentials: Optional[str] = None,
+    scopes: Optional[Sequence[str]] = None,
+    env_var_names: Optional[Sequence[str]] = None,
+) -> GoogleCredentialsLoadResult:
+    """Load Google credentials from explicit config, env vars, or ADC.
+
+    The precedence is:
+
+    1. ``provider.config.credentials`` as a file path or raw JSON
+    2. provider-specific credential env vars, then shared Slideflow env vars
+    3. ``GOOGLE_APPLICATION_CREDENTIALS`` file path
+    4. ``google.auth.default``
+
+    ``google.auth`` handles both service-account and external-account payloads,
+    which enables Workload Identity Federation and keyless ADC runtimes.
+    """
+
+    try:
+        import google.auth
+    except ImportError as error:  # pragma: no cover - dependency is core runtime
+        raise AuthenticationError(
+            "google-auth is required for Google provider credentials."
+        ) from error
+
+    source_value, source_type, source_name = resolve_google_credentials_source(
+        credentials,
+        env_var_names,
+        include_adc=True,
+    )
+    if source_type is None or source_name is None:
+        expected_sources = ", ".join(
+            list(env_var_names or [Environment.GOOGLE_SLIDEFLOW_CREDENTIALS])
+            + [Environment.GOOGLE_APPLICATION_CREDENTIALS, "ADC default credentials"]
+        )
+        raise AuthenticationError(
+            "Credentials not provided and no supported credential environment "
+            f"variables were set ({expected_sources})."
+        )
+
+    try:
+        if source_type == "explicit_path":
+            assert source_value is not None
+            loaded_credentials, project_id = _load_google_credentials_from_file(
+                google.auth,
+                source_value,
+                scopes,
+            )
+        elif source_type == "explicit_json":
+            try:
+                payload = json.loads(source_value or "")
+            except json.JSONDecodeError as error:
+                raise AuthenticationError(
+                    "Credentials string provided was not valid"
+                ) from error
+            if not isinstance(payload, dict):
+                raise AuthenticationError(
+                    "Credentials string must contain a JSON object."
+                )
+            loaded_credentials, project_id = _load_google_credentials_from_mapping(
+                google.auth,
+                payload,
+                scopes,
+            )
+        elif source_type == _google_auth_source_type_for_env(
+            Environment.GOOGLE_APPLICATION_CREDENTIALS
+        ):
+            assert source_value is not None
+            loaded_credentials, project_id = _load_google_credentials_from_file(
+                google.auth,
+                source_value,
+                scopes,
+            )
+        elif source_type == "adc_default":
+            loaded_credentials, project_id = google.auth.default(
+                scopes=list(scopes or [])
+            )
+        else:
+            if source_value and _source_looks_like_file(source_value):
+                loaded_credentials, project_id = _load_google_credentials_from_file(
+                    google.auth,
+                    source_value,
+                    scopes,
+                )
+            else:
+                try:
+                    payload = json.loads(source_value or "")
+                except json.JSONDecodeError as error:
+                    raise AuthenticationError(
+                        "Credentials string provided was not valid"
+                    ) from error
+                if not isinstance(payload, dict):
+                    raise AuthenticationError(
+                        "Credentials string must contain a JSON object."
+                    )
+                loaded_credentials, project_id = _load_google_credentials_from_mapping(
+                    google.auth,
+                    payload,
+                    scopes,
+                )
+    except AuthenticationError:
+        raise
+    except Exception as error_msg:
+        raise AuthenticationError(
+            f"Credentials authentication failed: {error_msg}"
+        ) from error_msg
+
+    return GoogleCredentialsLoadResult(
+        credentials=loaded_credentials,
+        source_type=source_type,
+        source_name=source_name,
+        project_id=project_id,
+    )

--- a/slideflow/workbooks/providers/google_sheets.py
+++ b/slideflow/workbooks/providers/google_sheets.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-import os
 import threading
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
-from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from pydantic import Field, field_validator
 
 from slideflow.constants import Environment, GoogleSlides
-from slideflow.utilities.auth import handle_google_credentials
+from slideflow.utilities.auth import (
+    describe_google_credentials_source,
+    load_google_credentials,
+)
 from slideflow.utilities.exceptions import RenderingError
 from slideflow.utilities.google_api import (
-    build_service_account_credentials,
     execute_rate_limited_request,
     slideflow_google_request_builder,
 )
@@ -91,17 +91,16 @@ class GoogleSheetsProvider(WorkbookProvider):
         super().__init__(config)
         self.config: GoogleSheetsProviderConfig = config
 
-        loaded_credentials = handle_google_credentials(
+        loaded_credentials = load_google_credentials(
             config.credentials,
+            scopes=self.SCOPES,
             env_var_names=[
                 Environment.GOOGLE_SHEETS_CREDENTIALS,
                 Environment.GOOGLE_SLIDEFLOW_CREDENTIALS,
             ],
         )
-
-        credentials = build_service_account_credentials(
-            loaded_credentials, self.SCOPES, credentials_cls=Credentials
-        )
+        self._google_credentials_source = loaded_credentials.source_type
+        credentials = loaded_credentials.credentials
 
         self._credentials = credentials
         self._thread_local_services = threading.local()
@@ -190,16 +189,25 @@ class GoogleSheetsProvider(WorkbookProvider):
         sheets_service = getattr(self, "sheets_service", None)
         drive_service = getattr(self, "drive_service", None)
         rate_limiter = getattr(self, "rate_limiter", None)
-        has_credentials = bool(self.config.credentials) or bool(
-            os.getenv(Environment.GOOGLE_SHEETS_CREDENTIALS)
-            or os.getenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS)
+        credentials_source = getattr(
+            self,
+            "_google_credentials_source",
+            describe_google_credentials_source(
+                self.config.credentials,
+                [
+                    Environment.GOOGLE_SHEETS_CREDENTIALS,
+                    Environment.GOOGLE_SLIDEFLOW_CREDENTIALS,
+                ],
+                include_adc=False,
+            ),
         )
+        has_credentials = credentials_source != "missing"
         return [
             (
                 "google_sheets_credentials_present",
                 has_credentials,
                 (
-                    "Credentials found in config or supported environment variables"
+                    f"Credentials source: {credentials_source}"
                     if has_credentials
                     else "Missing credentials in config and environment"
                 ),

--- a/tests/live_tests/test_live_google_docs_templates.py
+++ b/tests/live_tests/test_live_google_docs_templates.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import pytest
 import yaml  # type: ignore[import-untyped]
@@ -24,6 +24,17 @@ def _require_first_env(var_names: Iterable[str], reason: str) -> str:
     raise RuntimeError("unreachable")
 
 
+def _resolve_live_credentials(var_names: Sequence[str], reason: str) -> Optional[str]:
+    for var_name in var_names:
+        value = os.getenv(var_name)
+        if value:
+            return value
+    if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+        return None
+    pytest.skip(reason)
+    raise RuntimeError("unreachable")
+
+
 def _parse_optional_email_list(var_name: str) -> List[str]:
     raw = os.getenv(var_name, "")
     if not raw:
@@ -40,9 +51,9 @@ def live_provider() -> GoogleDocsProvider:
     if os.getenv("SLIDEFLOW_RUN_LIVE") != "1":
         pytest.skip("SLIDEFLOW_RUN_LIVE != 1; skipping live Google Docs tests.")
 
-    credentials = _require_first_env(
+    credentials = _resolve_live_credentials(
         ["GOOGLE_DOCS_CREDENTIALS", "GOOGLE_SLIDEFLOW_CREDENTIALS"],
-        "GOOGLE_DOCS_CREDENTIALS/GOOGLE_SLIDEFLOW_CREDENTIALS is not set.",
+        "GOOGLE_DOCS_CREDENTIALS/GOOGLE_SLIDEFLOW_CREDENTIALS/GOOGLE_APPLICATION_CREDENTIALS is not set.",
     )
     document_folder_id = _require_first_env(
         ["SLIDEFLOW_LIVE_DOCUMENT_FOLDER_ID", "SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID"],

--- a/tests/live_tests/test_live_google_sheets_workbooks.py
+++ b/tests/live_tests/test_live_google_sheets_workbooks.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import pytest
 import yaml  # type: ignore[import-untyped]
@@ -24,6 +24,17 @@ def _require_first_env(var_names: Iterable[str], reason: str) -> str:
     raise RuntimeError("unreachable")
 
 
+def _resolve_live_credentials(var_names: Sequence[str], reason: str) -> Optional[str]:
+    for var_name in var_names:
+        value = os.getenv(var_name)
+        if value:
+            return value
+    if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+        return None
+    pytest.skip(reason)
+    raise RuntimeError("unreachable")
+
+
 def _parse_optional_email_list(var_name: str) -> List[str]:
     raw = os.getenv(var_name, "")
     if not raw:
@@ -40,9 +51,9 @@ def live_provider() -> GoogleSheetsProvider:
     if os.getenv("SLIDEFLOW_RUN_LIVE") != "1":
         pytest.skip("SLIDEFLOW_RUN_LIVE != 1; skipping live Google Sheets tests.")
 
-    credentials = _require_first_env(
+    credentials = _resolve_live_credentials(
         ["GOOGLE_SHEETS_CREDENTIALS", "GOOGLE_SLIDEFLOW_CREDENTIALS"],
-        "GOOGLE_SHEETS_CREDENTIALS/GOOGLE_SLIDEFLOW_CREDENTIALS is not set.",
+        "GOOGLE_SHEETS_CREDENTIALS/GOOGLE_SLIDEFLOW_CREDENTIALS/GOOGLE_APPLICATION_CREDENTIALS is not set.",
     )
     workbook_folder_id = _require_first_env(
         [

--- a/tests/live_tests/test_live_google_slides_templates.py
+++ b/tests/live_tests/test_live_google_slides_templates.py
@@ -2,7 +2,7 @@ import os
 import uuid
 from math import ceil
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import pytest
 import yaml  # type: ignore[import-untyped]
@@ -32,6 +32,20 @@ def _require_env(var_name: str) -> str:
     return value
 
 
+def _resolve_live_credentials(var_names: Sequence[str]) -> Optional[str]:
+    for var_name in var_names:
+        value = os.getenv(var_name)
+        if value:
+            return value
+    if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+        return None
+    pytest.skip(
+        "GOOGLE_SLIDEFLOW_CREDENTIALS or GOOGLE_APPLICATION_CREDENTIALS is not set; "
+        "skipping live Google Slides tests."
+    )
+    raise RuntimeError("unreachable")
+
+
 def _parse_optional_email_list(var_name: str) -> List[str]:
     raw = os.getenv(var_name, "")
     if not raw:
@@ -48,7 +62,7 @@ def live_provider() -> GoogleSlidesProvider:
     if os.getenv("SLIDEFLOW_RUN_LIVE") != "1":
         pytest.skip("SLIDEFLOW_RUN_LIVE != 1; skipping live Google Slides tests.")
 
-    credentials = _require_env("GOOGLE_SLIDEFLOW_CREDENTIALS")
+    credentials = _resolve_live_credentials(["GOOGLE_SLIDEFLOW_CREDENTIALS"])
     presentation_folder_id = _require_env("SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID")
     drive_folder_id = os.getenv(
         "SLIDEFLOW_LIVE_DRIVE_FOLDER_ID", presentation_folder_id
@@ -518,7 +532,7 @@ def test_live_feature_matrix_covers_templates_plotly_and_dynamic_replacements(
         slides_payload.append(slide_payload)
 
     provider_config: Dict[str, Any] = {
-        "credentials": os.environ["GOOGLE_SLIDEFLOW_CREDENTIALS"],
+        "credentials": live_provider.config.credentials,
         "template_id": template_id,
         "presentation_folder_id": os.environ["SLIDEFLOW_LIVE_PRESENTATION_FOLDER_ID"],
         "drive_folder_id": os.getenv(

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -42,6 +42,17 @@ def _stub_presentation_validation(monkeypatch):
     )
 
 
+def _force_readonly_auth_failure(monkeypatch):
+    def _raise_auth_failure(*_args, **_kwargs):
+        raise RuntimeError("readonly auth unavailable")
+
+    monkeypatch.setattr(
+        validate_command_module,
+        "load_google_credentials",
+        _raise_auth_failure,
+    )
+
+
 def test_validate_first_error_line_handles_carriage_return_separator():
     error = RuntimeError("first line\rsecond line")
     assert validate_command_module._first_error_line(error) == "first line"
@@ -55,23 +66,16 @@ def test_validate_first_error_line_falls_back_to_exception_type_when_empty():
 def test_build_readonly_google_contract_client_slides_uses_read_scope(monkeypatch):
     captured = {}
 
-    monkeypatch.setattr(
-        validate_command_module,
-        "handle_google_credentials",
-        lambda credentials_input, **_kwargs: {"credentials_input": credentials_input},
-    )
-
-    def _fake_from_service_account_info(info, scopes):
-        captured["info"] = info
+    def _fake_load_google_credentials(credentials_input, scopes, **kwargs):
+        captured["credentials_input"] = credentials_input
         captured["scopes"] = scopes
-        return "readonly-creds"
+        captured["loader_kwargs"] = kwargs
+        return types.SimpleNamespace(credentials="readonly-creds")
 
     monkeypatch.setattr(
         validate_command_module,
-        "Credentials",
-        types.SimpleNamespace(
-            from_service_account_info=staticmethod(_fake_from_service_account_info)
-        ),
+        "load_google_credentials",
+        _fake_load_google_credentials,
     )
 
     build_calls = []
@@ -96,6 +100,8 @@ def test_build_readonly_google_contract_client_slides_uses_read_scope(monkeypatc
     assert captured["scopes"] == list(
         validate_command_module._GOOGLE_SLIDES_CONTRACT_SCOPES
     )
+    assert captured["credentials_input"] == "inline-creds"
+    assert captured["loader_kwargs"] == {}
     assert build_calls == [("slides", "v1", "readonly-creds")]
     assert client.auth_mode == "readonly"
     assert client.slides_service == "slides-service"
@@ -104,23 +110,16 @@ def test_build_readonly_google_contract_client_slides_uses_read_scope(monkeypatc
 def test_build_readonly_google_contract_client_docs_uses_read_scope(monkeypatch):
     captured = {}
 
-    monkeypatch.setattr(
-        validate_command_module,
-        "handle_google_credentials",
-        lambda credentials_input, **_kwargs: {"credentials_input": credentials_input},
-    )
-
-    def _fake_from_service_account_info(info, scopes):
-        captured["info"] = info
+    def _fake_load_google_credentials(credentials_input, scopes, **kwargs):
+        captured["credentials_input"] = credentials_input
         captured["scopes"] = scopes
-        return "readonly-creds"
+        captured["loader_kwargs"] = kwargs
+        return types.SimpleNamespace(credentials="readonly-creds")
 
     monkeypatch.setattr(
         validate_command_module,
-        "Credentials",
-        types.SimpleNamespace(
-            from_service_account_info=staticmethod(_fake_from_service_account_info)
-        ),
+        "load_google_credentials",
+        _fake_load_google_credentials,
     )
 
     build_calls = []
@@ -149,6 +148,10 @@ def test_build_readonly_google_contract_client_docs_uses_read_scope(monkeypatch)
     assert captured["scopes"] == list(
         validate_command_module._GOOGLE_DOCS_CONTRACT_SCOPES
     )
+    assert captured["credentials_input"] == "inline-creds"
+    assert captured["loader_kwargs"] == {
+        "env_var_names": ["GOOGLE_DOCS_CREDENTIALS", "GOOGLE_SLIDEFLOW_CREDENTIALS"]
+    }
     assert build_calls == [("docs", "v1", "readonly-creds")]
     assert client.auth_mode == "readonly"
     assert client.docs_service == "docs-service"
@@ -843,6 +846,7 @@ def test_build_output_json_omits_params_and_redacts_errors(tmp_path, monkeypatch
 
 def test_validate_provider_contract_check_writes_success_json(tmp_path, monkeypatch):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="slide-contract",
@@ -969,6 +973,7 @@ def test_validate_provider_contract_check_writes_success_json(tmp_path, monkeypa
 
 def test_validate_provider_contract_check_writes_failure_json(tmp_path, monkeypatch):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="slide-contract",
@@ -1071,6 +1076,7 @@ def test_validate_provider_contract_check_requires_google_provider(
     tmp_path, monkeypatch
 ):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     monkeypatch.setattr(
         validate_command_module,
@@ -1135,6 +1141,7 @@ def test_validate_provider_contract_check_merges_duplicate_slide_ids(
     tmp_path, monkeypatch
 ):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     first_slide_spec = types.SimpleNamespace(
         id="slide-contract",
@@ -1255,6 +1262,7 @@ def test_validate_provider_contract_check_merges_duplicate_slide_ids(
 
 def test_validate_provider_contract_check_google_docs_success(tmp_path, monkeypatch):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="intro",
@@ -1373,6 +1381,7 @@ def test_validate_provider_contract_check_google_docs_ignores_toc_markers(
     tmp_path, monkeypatch
 ):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="intro",
@@ -1498,6 +1507,7 @@ def test_validate_provider_contract_check_google_docs_does_not_stitch_split_mark
     tmp_path, monkeypatch
 ):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="intro",
@@ -1607,6 +1617,7 @@ def test_validate_provider_contract_check_google_docs_does_not_stitch_split_plac
     tmp_path, monkeypatch
 ):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="intro",
@@ -1716,6 +1727,7 @@ def test_validate_provider_contract_check_google_docs_missing_section_marker(
     tmp_path, monkeypatch
 ):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="intro",
@@ -1827,6 +1839,7 @@ def test_validate_provider_contract_check_google_docs_duplicate_marker(
     tmp_path, monkeypatch
 ):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="intro",
@@ -1940,6 +1953,7 @@ def test_validate_provider_contract_check_google_docs_missing_placeholder(
     tmp_path, monkeypatch
 ):
     stub_build_validate_cli_output(monkeypatch)
+    _force_readonly_auth_failure(monkeypatch)
 
     slide_spec = types.SimpleNamespace(
         id="intro",

--- a/tests/test_google_docs_provider_coverage.py
+++ b/tests/test_google_docs_provider_coverage.py
@@ -148,20 +148,17 @@ def _append_toc_copy(document: Dict[str, Any], toc_text: str) -> Dict[str, Any]:
 def test_google_docs_provider_init_success(monkeypatch):
     captured: Dict[str, Any] = {}
 
-    def _handle_credentials(_credentials, env_var_names=None):
+    def _load_credentials(_credentials, scopes, env_var_names=None):
         captured["env_var_names"] = list(env_var_names or [])
-        return {"client_email": "svc@example.com"}
+        captured["scopes"] = scopes
+        return SimpleNamespace(
+            credentials="creds", source_type="env_google_docs_credentials"
+        )
 
     monkeypatch.setattr(
         google_docs_module,
-        "handle_google_credentials",
-        _handle_credentials,
-    )
-    monkeypatch.setattr(
-        google_docs_module.Credentials,
-        "from_service_account_info",
-        lambda info, scopes: captured.update({"info": info, "scopes": scopes})
-        or "creds",
+        "load_google_credentials",
+        _load_credentials,
     )
 
     def _fake_build(service, version, credentials, **kwargs):
@@ -189,12 +186,12 @@ def test_google_docs_provider_init_success(monkeypatch):
     assert provider.docs_service == "docs:v1:creds"
     assert provider.drive_service == "drive:v3:creds"
     assert provider.rate_limiter == "rl:2.0"
-    assert captured["info"] == {"client_email": "svc@example.com"}
     assert captured["scopes"] == google_docs_module.GoogleDocsProvider.SCOPES
     assert captured["env_var_names"] == [
         Environment.GOOGLE_DOCS_CREDENTIALS,
         Environment.GOOGLE_SLIDEFLOW_CREDENTIALS,
     ]
+    assert provider._google_credentials_source == "env_google_docs_credentials"
     assert len(captured["build_calls"]) == 2
     assert all(
         callable(call["kwargs"].get("requestBuilder"))
@@ -203,15 +200,11 @@ def test_google_docs_provider_init_success(monkeypatch):
 
 
 def test_google_docs_provider_init_authentication_failure(monkeypatch):
+    def _raise_auth_error(*_args, **_kwargs):
+        raise AuthenticationError("Credentials authentication failed: bad creds")
+
     monkeypatch.setattr(
-        google_docs_module,
-        "handle_google_credentials",
-        lambda _credentials, env_var_names=None: {"invalid": True},
-    )
-    monkeypatch.setattr(
-        google_docs_module.Credentials,
-        "from_service_account_info",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad creds")),
+        google_docs_module, "load_google_credentials", _raise_auth_error
     )
 
     with pytest.raises(AuthenticationError, match="Credentials authentication failed"):
@@ -232,7 +225,23 @@ def test_google_docs_config_validates_transfer_ownership_target():
     assert config.transfer_ownership_to == "owner@example.com"
 
 
-def test_google_docs_provider_factory_registration():
+def test_google_docs_provider_factory_registration(monkeypatch):
+    monkeypatch.setattr(
+        google_docs_module,
+        "load_google_credentials",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            credentials="creds", source_type="explicit_json"
+        ),
+    )
+    monkeypatch.setattr(
+        google_docs_module,
+        "build",
+        lambda service, version, credentials, **_kwargs: (
+            f"{service}:{version}:{credentials}"
+        ),
+    )
+    monkeypatch.setattr(google_docs_module, "_get_rate_limiter", lambda _rps: object())
+
     config = ProviderConfig(
         type="google_docs",
         config={"credentials": '{"type":"service_account"}'},

--- a/tests/test_google_sheets_workbook_provider.py
+++ b/tests/test_google_sheets_workbook_provider.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Set, Tuple
 import pytest
 
 import slideflow.workbooks.providers.google_sheets as sheets_provider_module
+from slideflow.constants import Environment
 from slideflow.workbooks.config import RESERVED_METADATA_TAB
 
 
@@ -73,6 +74,53 @@ def test_google_sheets_config_normalizes_share_role():
     config = sheets_provider_module.GoogleSheetsProviderConfig(share_role=" Writer ")
 
     assert config.share_role == "writer"
+
+
+def test_google_sheets_provider_init_uses_shared_google_loader(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    def _load_credentials(_credentials, scopes, env_var_names=None):
+        captured["scopes"] = scopes
+        captured["env_var_names"] = list(env_var_names or [])
+        return SimpleNamespace(
+            credentials="creds", source_type="env_google_sheets_credentials"
+        )
+
+    def _fake_build(service, version, credentials, **kwargs):
+        captured.setdefault("build_calls", []).append(
+            {
+                "service": service,
+                "version": version,
+                "credentials": credentials,
+                "kwargs": kwargs,
+            }
+        )
+        return f"{service}:{version}:{credentials}"
+
+    monkeypatch.setattr(
+        sheets_provider_module, "load_google_credentials", _load_credentials
+    )
+    monkeypatch.setattr(sheets_provider_module, "build", _fake_build)
+    monkeypatch.setattr(
+        sheets_provider_module, "_get_rate_limiter", lambda rps: f"rl:{rps}"
+    )
+
+    provider = sheets_provider_module.GoogleSheetsProvider(
+        sheets_provider_module.GoogleSheetsProviderConfig(
+            credentials='{"type":"service_account"}', requests_per_second=2.0
+        )
+    )
+
+    assert provider.sheets_service == "sheets:v4:creds"
+    assert provider.drive_service == "drive:v3:creds"
+    assert provider.rate_limiter == "rl:2.0"
+    assert provider._google_credentials_source == "env_google_sheets_credentials"
+    assert captured["scopes"] == sheets_provider_module.GoogleSheetsProvider.SCOPES
+    assert captured["env_var_names"] == [
+        Environment.GOOGLE_SHEETS_CREDENTIALS,
+        Environment.GOOGLE_SLIDEFLOW_CREDENTIALS,
+    ]
+    assert len(captured["build_calls"]) == 2
 
 
 def test_finalize_workbook_rejects_invalid_share_role_before_api_call():

--- a/tests/test_google_slides_provider_coverage.py
+++ b/tests/test_google_slides_provider_coverage.py
@@ -27,16 +27,14 @@ def _http_error(
 def test_google_provider_init_success(monkeypatch):
     captured: Dict[str, Any] = {}
 
+    def _load_credentials(credentials, scopes, **kwargs):
+        captured["credentials_input"] = credentials
+        captured["scopes"] = scopes
+        captured["loader_kwargs"] = kwargs
+        return SimpleNamespace(credentials="creds", source_type="explicit_json")
+
     monkeypatch.setattr(
-        google_provider_module,
-        "handle_google_credentials",
-        lambda _credentials: {"client_email": "svc@example.com"},
-    )
-    monkeypatch.setattr(
-        google_provider_module.Credentials,
-        "from_service_account_info",
-        lambda info, scopes: captured.update({"info": info, "scopes": scopes})
-        or "creds",
+        google_provider_module, "load_google_credentials", _load_credentials
     )
 
     def _fake_build(service, version, credentials, **kwargs):
@@ -64,8 +62,10 @@ def test_google_provider_init_success(monkeypatch):
     assert provider.slides_service == "slides:v1:creds"
     assert provider.drive_service == "drive:v3:creds"
     assert provider.rate_limiter == "rl:2.5"
-    assert captured["info"] == {"client_email": "svc@example.com"}
     assert captured["scopes"] == google_provider_module.GoogleSlidesProvider.SCOPES
+    assert captured["credentials_input"] == '{"type":"service_account"}'
+    assert captured["loader_kwargs"] == {}
+    assert provider._google_credentials_source == "explicit_json"
     assert len(captured["build_calls"]) == 2
     assert all(
         callable(call["kwargs"].get("requestBuilder"))
@@ -74,15 +74,15 @@ def test_google_provider_init_success(monkeypatch):
 
 
 def test_google_provider_init_authentication_failure(monkeypatch):
+    cause = RuntimeError("bad creds")
+
+    def _raise_auth_error(*_args, **_kwargs):
+        raise AuthenticationError(
+            "Credentials authentication failed: bad creds"
+        ) from cause
+
     monkeypatch.setattr(
-        google_provider_module,
-        "handle_google_credentials",
-        lambda _credentials: {"invalid": True},
-    )
-    monkeypatch.setattr(
-        google_provider_module.Credentials,
-        "from_service_account_info",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("bad creds")),
+        google_provider_module, "load_google_credentials", _raise_auth_error
     )
 
     with pytest.raises(
@@ -94,7 +94,7 @@ def test_google_provider_init_authentication_failure(monkeypatch):
             )
         )
 
-    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert exc_info.value.__cause__ is cause
 
 
 def test_google_slides_config_validates_transfer_ownership_target():

--- a/tests/test_runtime_utilities.py
+++ b/tests/test_runtime_utilities.py
@@ -10,7 +10,11 @@ import slideflow.data.cache as data_cache_module
 import slideflow.presentations.rate_limiter as presentation_rate_limiter_module
 import slideflow.utilities.rate_limiter as rate_limiter_module
 from slideflow.constants import Environment
-from slideflow.utilities.auth import handle_google_credentials
+from slideflow.utilities.auth import (
+    describe_google_credentials_source,
+    handle_google_credentials,
+    load_google_credentials,
+)
 from slideflow.utilities.exceptions import AuthenticationError
 
 
@@ -483,6 +487,213 @@ def test_handle_google_credentials_validation_errors(tmp_path, monkeypatch):
         AuthenticationError, match="no supported credential environment variables"
     ):
         handle_google_credentials(None)
+
+
+def test_load_google_credentials_from_external_account_json(monkeypatch):
+    import google.auth
+
+    calls = {}
+
+    def _load_from_dict(info, scopes=None, **kwargs):
+        calls["info"] = info
+        calls["scopes"] = scopes
+        calls["kwargs"] = kwargs
+        return "credentials", "project-from-json"
+
+    monkeypatch.setattr(google.auth, "load_credentials_from_dict", _load_from_dict)
+
+    result = load_google_credentials(
+        json.dumps(
+            {
+                "type": "external_account",
+                "audience": "//iam.googleapis.com/projects/123/locations/global",
+                "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+                "token_url": "https://sts.googleapis.com/v1/token",
+                "credential_source": {"file": "/tmp/token"},
+            }
+        ),
+        scopes=["scope-a"],
+    )
+
+    assert result.credentials == "credentials"
+    assert result.project_id == "project-from-json"
+    assert result.source_type == "explicit_json"
+    assert result.source_name == "provider.config.credentials"
+    assert calls["info"]["type"] == "external_account"
+    assert calls["scopes"] == ["scope-a"]
+
+
+def test_load_google_credentials_uses_service_account_specific_loader(monkeypatch):
+    import google.auth
+    from google.oauth2 import service_account
+
+    calls = {}
+
+    class FakeCredentials:
+        project_id = "project-from-credentials"
+
+    def _from_service_account_info(info, scopes=None):
+        calls["info"] = info
+        calls["scopes"] = scopes
+        return FakeCredentials()
+
+    monkeypatch.setattr(
+        service_account.Credentials,
+        "from_service_account_info",
+        staticmethod(_from_service_account_info),
+    )
+    monkeypatch.setattr(
+        google.auth,
+        "load_credentials_from_dict",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("generic loader should not be used for service accounts")
+        ),
+    )
+
+    result = load_google_credentials(
+        json.dumps(
+            {
+                "type": "service_account",
+                "client_email": "svc@example.com",
+                "project_id": "project-from-json",
+            }
+        ),
+        scopes=["scope-sa"],
+    )
+
+    assert isinstance(result.credentials, FakeCredentials)
+    assert result.project_id == "project-from-credentials"
+    assert result.source_type == "explicit_json"
+    assert calls["info"]["client_email"] == "svc@example.com"
+    assert calls["scopes"] == ["scope-sa"]
+
+
+def test_load_google_credentials_from_explicit_file(tmp_path, monkeypatch):
+    import google.auth
+
+    creds_path = tmp_path / "external-account.json"
+    creds_path.write_text('{"type":"external_account","audience":"file"}')
+    calls = {}
+
+    def _load_from_dict(info, scopes=None, **kwargs):
+        calls["info"] = info
+        calls["scopes"] = scopes
+        calls["kwargs"] = kwargs
+        return "credentials", None
+
+    monkeypatch.setattr(google.auth, "load_credentials_from_dict", _load_from_dict)
+
+    result = load_google_credentials(str(creds_path), scopes=["scope-b"])
+
+    assert result.credentials == "credentials"
+    assert result.source_type == "explicit_path"
+    assert result.source_name == "provider.config.credentials"
+    assert calls["info"]["audience"] == "file"
+    assert calls["scopes"] == ["scope-b"]
+
+
+def test_load_google_credentials_uses_provider_env_before_shared_env(monkeypatch):
+    import google.auth
+
+    docs_payload = {"type": "external_account", "audience": "docs"}
+    shared_payload = {"type": "external_account", "audience": "shared"}
+    calls = {}
+
+    monkeypatch.setenv(Environment.GOOGLE_DOCS_CREDENTIALS, json.dumps(docs_payload))
+    monkeypatch.setenv(
+        Environment.GOOGLE_SLIDEFLOW_CREDENTIALS, json.dumps(shared_payload)
+    )
+
+    def _load_from_dict(info, scopes=None, **kwargs):
+        calls["info"] = info
+        calls["scopes"] = scopes
+        return "credentials", None
+
+    monkeypatch.setattr(google.auth, "load_credentials_from_dict", _load_from_dict)
+
+    result = load_google_credentials(
+        None,
+        scopes=["scope-c"],
+        env_var_names=[
+            Environment.GOOGLE_DOCS_CREDENTIALS,
+            Environment.GOOGLE_SLIDEFLOW_CREDENTIALS,
+        ],
+    )
+
+    assert calls["info"] == docs_payload
+    assert calls["scopes"] == ["scope-c"]
+    assert result.source_type == "env_google_docs_credentials"
+    assert result.source_name == Environment.GOOGLE_DOCS_CREDENTIALS
+
+
+def test_load_google_credentials_uses_google_application_credentials(
+    tmp_path, monkeypatch
+):
+    import google.auth
+
+    creds_path = tmp_path / "wif.json"
+    creds_path.write_text('{"type":"external_account","audience":"gac"}')
+    calls = {}
+    monkeypatch.delenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS, raising=False)
+    monkeypatch.setenv(Environment.GOOGLE_APPLICATION_CREDENTIALS, str(creds_path))
+
+    def _load_from_dict(info, scopes=None, **kwargs):
+        calls["info"] = info
+        calls["scopes"] = scopes
+        return "credentials", "project-from-file"
+
+    monkeypatch.setattr(google.auth, "load_credentials_from_dict", _load_from_dict)
+
+    result = load_google_credentials(None, scopes=["scope-d"])
+
+    assert result.credentials == "credentials"
+    assert result.project_id == "project-from-file"
+    assert result.source_type == "env_google_application_credentials"
+    assert result.source_name == Environment.GOOGLE_APPLICATION_CREDENTIALS
+    assert calls["info"]["audience"] == "gac"
+    assert calls["scopes"] == ["scope-d"]
+
+
+def test_load_google_credentials_falls_back_to_adc_default(monkeypatch):
+    import google.auth
+
+    calls = {}
+    monkeypatch.delenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS, raising=False)
+    monkeypatch.delenv(Environment.GOOGLE_APPLICATION_CREDENTIALS, raising=False)
+
+    def _default(scopes=None, **kwargs):
+        calls["scopes"] = scopes
+        calls["kwargs"] = kwargs
+        return "credentials", "adc-project"
+
+    monkeypatch.setattr(google.auth, "default", _default)
+
+    result = load_google_credentials(None, scopes=["scope-e"])
+
+    assert result.credentials == "credentials"
+    assert result.project_id == "adc-project"
+    assert result.source_type == "adc_default"
+    assert result.source_name == "google.auth.default"
+    assert calls["scopes"] == ["scope-e"]
+
+
+def test_describe_google_credentials_source_reports_non_sensitive_source(
+    tmp_path, monkeypatch
+):
+    creds_path = tmp_path / "creds.json"
+    creds_path.write_text("{}")
+
+    assert describe_google_credentials_source(str(creds_path)) == "explicit_path"
+    assert describe_google_credentials_source("{}") == "explicit_json"
+
+    monkeypatch.setenv(Environment.GOOGLE_DOCS_CREDENTIALS, "{}")
+    assert (
+        describe_google_credentials_source(
+            None,
+            [Environment.GOOGLE_DOCS_CREDENTIALS],
+        )
+        == "env_google_docs_credentials"
+    )
 
 
 def test_rate_limiter_validates_rates():

--- a/tests/test_runtime_utilities.py
+++ b/tests/test_runtime_utilities.py
@@ -489,10 +489,18 @@ def test_handle_google_credentials_validation_errors(tmp_path, monkeypatch):
         handle_google_credentials(None)
 
 
-def test_load_google_credentials_from_external_account_json(monkeypatch):
+def test_load_google_credentials_from_env_external_account_json(monkeypatch):
     import google.auth
 
     calls = {}
+    payload = {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/projects/123/locations/global",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": {"file": "/tmp/token"},
+    }
+    monkeypatch.setenv(Environment.GOOGLE_SLIDEFLOW_CREDENTIALS, json.dumps(payload))
 
     def _load_from_dict(info, scopes=None, **kwargs):
         calls["info"] = info
@@ -503,24 +511,39 @@ def test_load_google_credentials_from_external_account_json(monkeypatch):
     monkeypatch.setattr(google.auth, "load_credentials_from_dict", _load_from_dict)
 
     result = load_google_credentials(
-        json.dumps(
-            {
-                "type": "external_account",
-                "audience": "//iam.googleapis.com/projects/123/locations/global",
-                "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-                "token_url": "https://sts.googleapis.com/v1/token",
-                "credential_source": {"file": "/tmp/token"},
-            }
-        ),
+        None,
         scopes=["scope-a"],
     )
 
     assert result.credentials == "credentials"
     assert result.project_id == "project-from-json"
-    assert result.source_type == "explicit_json"
-    assert result.source_name == "provider.config.credentials"
+    assert result.source_type == "env_google_slideflow_credentials"
+    assert result.source_name == Environment.GOOGLE_SLIDEFLOW_CREDENTIALS
     assert calls["info"]["type"] == "external_account"
     assert calls["scopes"] == ["scope-a"]
+
+
+def test_load_google_credentials_rejects_external_account_from_provider_config(
+    tmp_path, monkeypatch
+):
+    import google.auth
+
+    payload = json.dumps({"type": "external_account", "audience": "repo-config"})
+    monkeypatch.setattr(
+        google.auth,
+        "load_credentials_from_dict",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("generic loader should not accept provider config")
+        ),
+    )
+
+    with pytest.raises(AuthenticationError, match="Non-service-account"):
+        load_google_credentials(payload, scopes=["scope-blocked"])
+
+    creds_path = tmp_path / "external-account.json"
+    creds_path.write_text(payload)
+    with pytest.raises(AuthenticationError, match="Non-service-account"):
+        load_google_credentials(str(creds_path), scopes=["scope-blocked"])
 
 
 def test_load_google_credentials_uses_service_account_specific_loader(monkeypatch):
@@ -568,27 +591,45 @@ def test_load_google_credentials_uses_service_account_specific_loader(monkeypatc
     assert calls["scopes"] == ["scope-sa"]
 
 
-def test_load_google_credentials_from_explicit_file(tmp_path, monkeypatch):
+def test_load_google_credentials_from_explicit_service_account_file(
+    tmp_path, monkeypatch
+):
     import google.auth
+    from google.oauth2 import service_account
 
-    creds_path = tmp_path / "external-account.json"
-    creds_path.write_text('{"type":"external_account","audience":"file"}')
+    creds_path = tmp_path / "service-account.json"
+    creds_path.write_text(
+        '{"type":"service_account","client_email":"svc@example.com","project_id":"file-project"}'
+    )
     calls = {}
 
-    def _load_from_dict(info, scopes=None, **kwargs):
+    class FakeCredentials:
+        project_id = "file-project"
+
+    def _from_service_account_info(info, scopes=None):
         calls["info"] = info
         calls["scopes"] = scopes
-        calls["kwargs"] = kwargs
-        return "credentials", None
+        return FakeCredentials()
 
-    monkeypatch.setattr(google.auth, "load_credentials_from_dict", _load_from_dict)
+    monkeypatch.setattr(
+        service_account.Credentials,
+        "from_service_account_info",
+        staticmethod(_from_service_account_info),
+    )
+    monkeypatch.setattr(
+        google.auth,
+        "load_credentials_from_dict",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("generic loader should not be used for service accounts")
+        ),
+    )
 
     result = load_google_credentials(str(creds_path), scopes=["scope-b"])
 
-    assert result.credentials == "credentials"
+    assert isinstance(result.credentials, FakeCredentials)
     assert result.source_type == "explicit_path"
     assert result.source_name == "provider.config.credentials"
-    assert calls["info"]["audience"] == "file"
+    assert calls["info"]["client_email"] == "svc@example.com"
     assert calls["scopes"] == ["scope-b"]
 
 


### PR DESCRIPTION
## Summary

- Add a shared Google credential loader for service-account JSON, external-account / Workload Identity Federation JSON, GOOGLE_APPLICATION_CREDENTIALS, and runtime ADC.
- Wire Google Slides, Docs, Sheets, and read-only provider contract validation through the shared loader.
- Report non-sensitive credential source labels in provider preflight/doctor output.
- Update docs, changelog, and focused auth/provider tests.

## Validation

- uv run python -m ruff check slideflow tests scripts
- uv run python -m mypy slideflow
- uvx --from black==26.3.1 black --check slideflow tests scripts
- uv run mkdocs build --strict
- uv run pytest -q -m "not integration and not e2e" --cov=slideflow --cov-branch --cov-report=term --cov-fail-under=82
- uv run pytest -q -m integration
- uv run pytest -q -m e2e
