### PR TITLE
Add PowerPoint PPTX provider

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -44,6 +44,7 @@ jobs:
             --extra bigquery \
             --extra duckdb \
             --extra redshift \
+            --extra powerpoint \
             --locked
 
       - name: Run pip-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install project and test dependencies (locked)
         run: |
           uv lock --check
-          uv sync --extra dev --extra ai --locked
+          uv sync --extra dev --extra ai --extra powerpoint --locked
 
       - name: Validate dependency resolution
         run: |
@@ -137,7 +137,7 @@ jobs:
       - name: Install optional connector dependencies (locked)
         run: |
           uv lock --check
-          uv sync --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --extra redshift --locked
+          uv sync --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --extra redshift --extra powerpoint --locked
 
       - name: Validate dependency resolution
         run: |
@@ -151,6 +151,7 @@ jobs:
           import git  # noqa: F401
           import google.cloud.bigquery  # noqa: F401
           import duckdb  # noqa: F401
+          import pptx  # noqa: F401
           import redshift_connector  # noqa: F401
           import dbt.adapters.redshift  # noqa: F401
           print("Optional connector extras importability check passed.")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install project and test dependencies (locked)
         run: |
           uv lock --check
-          uv sync --extra dev --extra ai --locked
+          uv sync --extra dev --extra ai --extra powerpoint --locked
 
       - name: Validate dependency resolution
         run: |
@@ -126,7 +126,7 @@ jobs:
       - name: Install optional connector dependencies (locked)
         run: |
           uv lock --check
-          uv sync --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --extra redshift --locked
+          uv sync --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --extra redshift --extra powerpoint --locked
 
       - name: Validate dependency resolution
         run: |
@@ -140,6 +140,7 @@ jobs:
           import git  # noqa: F401
           import google.cloud.bigquery  # noqa: F401
           import duckdb  # noqa: F401
+          import pptx  # noqa: F401
           import redshift_connector  # noqa: F401
           import dbt.adapters.redshift  # noqa: F401
           print("Optional connector extras importability check passed.")
@@ -207,6 +208,8 @@ jobs:
             --extra dbt \
             --extra bigquery \
             --extra duckdb \
+            --extra redshift \
+            --extra powerpoint \
             --locked
 
       - name: Run pip-audit

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ SlideFlow was built to solve a simple problem: automating the tedious process of
 -   **Multiple Output Providers:**
     -   `google_slides`: Build slide decks from template slides.
     -   `google_docs`: Build marker-anchored documents for newsletter/report workflows.
+    -   `powerpoint`: Build native local `.pptx` decks from PowerPoint templates.
     -   `google_sheets`: Build workbook outputs with tab-level replace/append semantics.
 -   **Optional Source Citations:**
     -   Emit deterministic source provenance (`model` and/or `execution`) into output artifacts.
@@ -109,6 +110,9 @@ pip install "slideflow-presentations[dbt]"
 pip install "slideflow-presentations[bigquery]"
 pip install "slideflow-presentations[duckdb]"
 pip install "slideflow-presentations[redshift]"
+
+# Native local PPTX output
+pip install "slideflow-presentations[powerpoint]"
 ```
 
 ---

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -5,7 +5,7 @@
 - `CI` (`.github/workflows/ci.yml`)
   - runs blocking GitHub workflow linting with `actionlint`
   - enforces lock freshness with `uv lock --check`
-  - installs project + dev deps with locked resolution (`uv sync --extra dev --extra ai --locked`)
+  - installs project + dev deps with locked resolution (`uv sync --extra dev --extra ai --extra powerpoint --locked`)
   - runs `uv pip check`
   - runs pre-commit on Python 3.12, including `detect-secrets` and
     `scripts/ci/check_secret_hygiene.py`
@@ -31,7 +31,7 @@
   - publishes to PyPI first
   - creates tag + GitHub release only after publish succeeds
 - `Audit` (`.github/workflows/audit.yml`)
-  - installs the locked project environment with `dev`, `ai`, `databricks`, `dbt`, `bigquery`, `duckdb`, and `redshift` extras
+  - installs the locked project environment with `dev`, `ai`, `databricks`, `dbt`, `bigquery`, `duckdb`, `redshift`, and `powerpoint` extras
   - runs blocking `pip-audit` from that locked environment
   - runs `bandit`
   - uploads audit reports as artifacts
@@ -79,7 +79,7 @@
 ## Required local checks before PR
 
 ```bash
-uv sync --extra docs --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --extra redshift --locked
+uv sync --extra docs --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --extra redshift --extra powerpoint --locked
 source .venv/bin/activate
 uv lock --check
 uv pip check

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -33,8 +33,8 @@ Options:
 | Option | Description |
 | --- | --- |
 | `-r`, `--registry` | One or more Python registry files |
-| `-f`, `--params-path` | Optional CSV used for provider contract checks (`template_id` column) |
-| `--provider-contract-check` | Validate provider template contracts (`google_slides`: slide IDs/placeholders, `google_docs`: section markers/placeholders) |
+| `-f`, `--params-path` | Optional CSV used for provider contract checks (`template_id` for Google providers, `template_path` for PowerPoint) |
+| `--provider-contract-check` | Validate provider template contracts (`google_slides`: slide IDs/placeholders, `google_docs`: section markers/placeholders, `powerpoint`: slide IDs/placeholders) |
 | `--provider-contract-full-auth-fallback` | Allow contract validation to instantiate the full Google provider if read-only auth initialization fails; omitted by default |
 | `--output-json` | Write machine-readable validation summary JSON |
 
@@ -59,6 +59,8 @@ Provider contract behavior:
 
 - `google_slides`: validates slide IDs and placeholders in template decks.
 - `google_docs`: validates section markers and placeholders in template docs.
+- `powerpoint`: validates one-based slide indexes or native slide IDs and
+  placeholders in local `.pptx` templates.
 - Contract checks use Google read-only scopes by default and fail closed on
   read-only auth initialization errors unless
   `--provider-contract-full-auth-fallback` is explicitly passed.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -9,7 +9,7 @@ presentation:
   slides: [...]
 
 provider:
-  type: "google_slides" # or "google_docs" (use "google_sheets" with workbook schema)
+  type: "google_slides" # or "google_docs" / "powerpoint" (use "google_sheets" with workbook schema)
   config: {...}
 
 citations: {...} # optional source provenance output
@@ -20,7 +20,7 @@ registry: ["./registry.py"] # optional
 
 Use one of:
 
-- `presentation:` + `provider.type: google_slides|google_docs` with `slideflow validate/build`
+- `presentation:` + `provider.type: google_slides|google_docs|powerpoint` with `slideflow validate/build`
 - `workbook:` + `provider.type: google_sheets` with `slideflow sheets validate/build/doctor`
 
 ## `presentation`
@@ -37,7 +37,7 @@ Use one of:
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `id` | `str` | yes | `google_slides`: target slide object ID, `google_docs`: target section marker id |
+| `id` | `str` | yes | `google_slides`: target slide object ID, `google_docs`: target section marker id, `powerpoint`: one-based slide index or native slide ID |
 | `title` | `str` | no | Metadata only |
 | `replacements` | `list` | no | `text`, `table`, `ai_text` specs |
 | `charts` | `list` | no | `plotly_go`, `template`, `custom` specs |
@@ -50,6 +50,7 @@ Supported values:
 
 - `google_slides`
 - `google_docs`
+- `powerpoint`
 - `google_sheets` (for `workbook:` pipelines via `slideflow sheets ...`)
 
 ### `provider.config` for `google_slides`
@@ -118,6 +119,25 @@ or raw JSON payload. Use `GOOGLE_DOCS_CREDENTIALS`,
 for external-account / Workload Identity Federation credentials.
 
 For provider setup and marker behavior, see [Google Docs Provider](providers/google-docs.md).
+
+### `provider.config` for `powerpoint`
+
+Install the optional extra first:
+
+```bash
+pip install "slideflow-presentations[powerpoint]"
+```
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `template_path` | `str` | yes | Path to the source `.pptx` template |
+| `output_dir` | `str` | no | Destination directory for generated `.pptx` files; defaults to current directory |
+| `slide_id_mode` | `str` | no | `auto` (default), `index`, or `native` |
+| `read_only_template` | `bool` | no | Defaults to `true`; prevents writes to `template_path` |
+| `file_collision_strategy` | `str` | no | `fail` (default), `overwrite`, or `suffix` |
+| `strict_cleanup` | `bool` | no | Fail if temporary in-memory chart image cleanup fails |
+
+For provider setup and behavior, see [PowerPoint Provider](providers/powerpoint.md).
 
 ### `provider.config` for `google_sheets`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,8 @@
   - Google Sheets API enabled (if using `google_sheets` provider)
   - Google Drive API enabled
 - A service account with access to your target template deck/document/spreadsheet and Drive folders
+- For local PowerPoint output, a `.pptx` template and the optional
+  `slideflow-presentations[powerpoint]` extra.
 
 ## Install
 
@@ -72,6 +74,7 @@ Create a template and decide provider mode:
 - `google_slides`: Google Slides template deck with placeholder text and target slide IDs.
 - `google_docs`: Google Docs template with explicit section markers (for example `{{SECTION:intro}}`).
 - `google_sheets`: Google Sheets workbook output (`workbook:` schema with tab write rules).
+- `powerpoint`: local `.pptx` template with placeholders in text boxes or table cells.
 
 You will need:
 
@@ -79,6 +82,7 @@ You will need:
 - `google_slides`: slide IDs for each slide you modify
 - `google_docs`: marker ids that match `presentation.slides[].id`
 - `google_sheets`: either `spreadsheet_id` (reuse) or `drive_folder_id` (create destination)
+- `powerpoint`: `template_path` and either one-based slide indexes or native slide IDs.
 
 ## Minimal config
 

--- a/docs/providers/powerpoint.md
+++ b/docs/providers/powerpoint.md
@@ -1,0 +1,121 @@
+# PowerPoint Provider
+
+The `powerpoint` provider renders SlideFlow output into native local `.pptx`
+files. It uses an existing PowerPoint template, applies replacements and chart
+insertions, and saves the generated deck to `output_dir`.
+
+## Install
+
+PowerPoint support is optional:
+
+```bash
+pip install "slideflow-presentations[powerpoint]"
+```
+
+For local development:
+
+```bash
+uv sync --extra dev --extra ai --extra powerpoint --locked
+```
+
+## Template Design
+
+Use a stable `.pptx` template:
+
+- Put placeholders directly in text boxes or table cells, for example `{{TITLE}}`.
+- Use one-based slide indexes (`"1"`, `"2"`) for simple configs, or native
+  PowerPoint `slide_id` values when you need IDs that survive slide reordering.
+- Reserve chart regions with enough room for your configured `x`, `y`, `width`,
+  and `height` values. Positioning values are interpreted as points.
+
+## Provider Config
+
+```yaml
+provider:
+  type: "powerpoint"
+  config:
+    template_path: "./templates/report.pptx"
+    output_dir: "./dist"
+    slide_id_mode: "auto" # auto | index | native
+    read_only_template: true
+    file_collision_strategy: "fail" # fail | overwrite | suffix
+    strict_cleanup: false
+```
+
+Field behavior:
+
+- `template_path`: required path to the source `.pptx` file.
+- `output_dir`: destination directory for generated `.pptx` files.
+- `slide_id_mode`:
+  - `auto` (default): numeric slide IDs resolve as one-based indexes first,
+    then native PowerPoint `slide_id` values.
+  - `index`: only one-based slide indexes are accepted.
+  - `native`: only native PowerPoint slide IDs are accepted.
+- `read_only_template`: prevents writes to `template_path`; keep this `true`
+  for production runs.
+- `file_collision_strategy`:
+  - `fail` (default): fail if the output path already exists.
+  - `overwrite`: replace an existing output file.
+  - `suffix`: write `Deck-1.pptx`, `Deck-2.pptx`, etc. when needed.
+- `strict_cleanup`: applies to temporary in-memory chart image cleanup.
+
+## Example
+
+```yaml
+provider:
+  type: "powerpoint"
+  config:
+    template_path: "./templates/monthly-report.pptx"
+    output_dir: "./build"
+    file_collision_strategy: "suffix"
+
+presentation:
+  name: "Monthly Report"
+  slides:
+    - id: "1"
+      replacements:
+        - type: "text"
+          config:
+            placeholder: "{{TITLE}}"
+            replacement: "June Revenue"
+      charts:
+        - type: "plotly_go"
+          config:
+            title: "Revenue"
+            x: 72
+            y: 144
+            width: 432
+            height: 252
+            traces:
+              - type: "bar"
+                x: ["North", "South"]
+                y: [120, 98]
+```
+
+## Contract Validation
+
+Use provider contract checks before build:
+
+```bash
+slideflow validate config.yml --provider-contract-check
+```
+
+Contract checks open the local `.pptx` template and validate:
+
+- configured slide IDs against `slide_id_mode`
+- configured replacement placeholders in slide text boxes
+- configured replacement placeholders in table cells
+
+For variant builds, pass a params CSV with a `template_path` column:
+
+```bash
+slideflow validate config.yml --provider-contract-check --params-path variants.csv
+```
+
+## Current Scope
+
+- Native `.pptx` output is supported.
+- Sharing is a no-op because artifacts are local files.
+- Citations are not rendered into speaker notes in V1 because `python-pptx`
+  does not expose a stable public speaker-notes API.
+- LibreOffice/PDF conversion is intentionally out of scope for this provider.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
       - Google Sheets Provider: providers/google-sheets.md
       - Google Docs Provider: providers/google-docs.md
       - Google Slides Provider: providers/google-slides.md
+      - PowerPoint Provider: providers/powerpoint.md
       - Data Connectors: data-connectors.md
       - DBT Migration: dbt-migration.md
       - Data Transforms: data-transforms.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dbt = ["dbt-core>=1.10,<1.12", "dbt-databricks>=1.10,<1.13", "gitpython>=3.1.41,
 bigquery = ["google-cloud-bigquery>=3.41.0,<4.0", "dbt-bigquery>=1.11.1,<1.12"]
 duckdb = ["duckdb>=1.5.3,<2.0", "dbt-duckdb>=1.9,<1.12"]
 redshift = ["redshift-connector>=2.1.8,<2.2", "dbt-redshift>=1.10,<1.12"]
+powerpoint = ["python-pptx>=1.0.0,<2.0"]
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.7.6",

--- a/slideflow/cli/commands/validate.py
+++ b/slideflow/cli/commands/validate.py
@@ -303,7 +303,7 @@ def _read_powerpoint_template_paths_from_params(params_path: Path) -> List[Path]
             "Provide at least one template_path row."
         )
 
-    return sorted(template_paths, key=lambda path: str(path))
+    return sorted(template_paths, key=str)
 
 
 def _resolve_powerpoint_template_paths_for_contract_check(

--- a/slideflow/cli/commands/validate.py
+++ b/slideflow/cli/commands/validate.py
@@ -282,6 +282,50 @@ def _resolve_template_ids_for_contract_check(
     )
 
 
+def _read_powerpoint_template_paths_from_params(params_path: Path) -> List[Path]:
+    """Read unique PowerPoint template paths from params CSV."""
+    template_paths: Set[Path] = set()
+
+    with params_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if "template_path" not in (reader.fieldnames or []):
+            raise ValueError(
+                f"Missing 'template_path' column in params file: {params_path}"
+            )
+        for row in reader:
+            template_path = (row.get("template_path") or "").strip()
+            if template_path:
+                template_paths.add(Path(template_path).expanduser())
+
+    if not template_paths:
+        raise ValueError(
+            f"No template_path values found in params file: {params_path}. "
+            "Provide at least one template_path row."
+        )
+
+    return sorted(template_paths, key=lambda path: str(path))
+
+
+def _resolve_powerpoint_template_paths_for_contract_check(
+    presentation_config: PresentationConfig, params_path: Optional[Path]
+) -> List[Path]:
+    """Resolve PowerPoint template paths from params CSV or provider config."""
+    if params_path is not None:
+        return _read_powerpoint_template_paths_from_params(params_path)
+
+    provider_config = getattr(presentation_config.provider, "config", {})
+    if isinstance(provider_config, dict):
+        template_path = provider_config.get("template_path")
+        if isinstance(template_path, (str, Path)) and str(template_path).strip():
+            return [Path(template_path).expanduser()]
+
+    raise ValueError(
+        "No PowerPoint template paths available for provider contract check. "
+        "Provide --params-path with a 'template_path' column or set "
+        "provider.config.template_path."
+    )
+
+
 def _extract_slide_text_map(presentation_payload: Dict[str, Any]) -> Dict[str, str]:
     """Extract concatenated text content for each slide object ID."""
     slide_text_map: Dict[str, str] = {}
@@ -561,6 +605,140 @@ def _extract_google_docs_sections(
     return {"sections": sections, "duplicate_markers": duplicate_markers}
 
 
+def _iter_pptx_text_frames(shapes: Any) -> Any:
+    """Yield text frames from PowerPoint shapes, including table cells/groups."""
+    for shape in shapes:
+        if getattr(shape, "has_text_frame", False):
+            yield shape.text_frame
+
+        if getattr(shape, "has_table", False):
+            for row in shape.table.rows:
+                for cell in row.cells:
+                    yield cell.text_frame
+
+        child_shapes = getattr(shape, "shapes", None)
+        if child_shapes is not None:
+            yield from _iter_pptx_text_frames(child_shapes)
+
+
+def _extract_pptx_slide_text(slide: Any) -> str:
+    chunks: List[str] = []
+    for text_frame in _iter_pptx_text_frames(slide.shapes):
+        for paragraph in text_frame.paragraphs:
+            chunks.append(paragraph.text)
+    return "\n".join(chunks)
+
+
+def _resolve_pptx_contract_slide_text(
+    slides: List[Any], slide_id: str, slide_id_mode: str
+) -> Optional[str]:
+    """Resolve a configured PowerPoint slide ID to extracted slide text."""
+    if slide_id_mode in {"auto", "index"}:
+        try:
+            one_based_index = int(str(slide_id).strip())
+        except ValueError:
+            one_based_index = -1
+        if 1 <= one_based_index <= len(slides):
+            return _extract_pptx_slide_text(slides[one_based_index - 1])
+        if slide_id_mode == "index":
+            return None
+
+    if slide_id_mode in {"auto", "native"}:
+        for slide in slides:
+            if str(getattr(slide, "slide_id", "")) == str(slide_id):
+                return _extract_pptx_slide_text(slide)
+
+    return None
+
+
+def _run_powerpoint_provider_contract_check(
+    presentation_config: PresentationConfig,
+    params_path: Optional[Path],
+) -> Dict[str, Any]:
+    """Validate configured slide IDs/placeholders against local PPTX templates."""
+    try:
+        from pptx import Presentation as PptxPresentation
+    except ImportError as error:
+        raise ValueError(
+            "PowerPoint provider contract checks require python-pptx. "
+            "Install with slideflow-presentations[powerpoint]."
+        ) from error
+
+    template_paths = _resolve_powerpoint_template_paths_for_contract_check(
+        presentation_config, params_path
+    )
+    expected_contract = _collect_expected_contract(presentation_config)
+    provider_config = getattr(presentation_config.provider, "config", {})
+    slide_id_mode = (
+        provider_config.get("slide_id_mode", "auto")
+        if isinstance(provider_config, dict)
+        else "auto"
+    )
+    if slide_id_mode not in {"auto", "index", "native"}:
+        slide_id_mode = "auto"
+
+    issues: List[Dict[str, Any]] = []
+    checked_templates = 0
+
+    for template_path in template_paths:
+        template_ref = str(template_path)
+        try:
+            presentation = PptxPresentation(str(template_path))
+            slides = list(presentation.slides)
+            checked_templates += 1
+        except Exception as error:
+            issues.append(
+                {
+                    "type": "template_fetch_failed",
+                    "template_id": template_ref,
+                    "slide_id": None,
+                    "placeholder": None,
+                    "detail": _first_error_line(error),
+                }
+            )
+            continue
+
+        for slide_id, placeholders in expected_contract.items():
+            slide_text = _resolve_pptx_contract_slide_text(
+                slides=slides,
+                slide_id=slide_id,
+                slide_id_mode=str(slide_id_mode),
+            )
+            if slide_text is None:
+                issues.append(
+                    {
+                        "type": "missing_slide",
+                        "template_id": template_ref,
+                        "slide_id": slide_id,
+                        "placeholder": None,
+                        "detail": "Slide id is not present in PowerPoint template",
+                    }
+                )
+                continue
+
+            for placeholder in sorted(placeholders):
+                if placeholder not in slide_text:
+                    issues.append(
+                        {
+                            "type": "missing_placeholder",
+                            "template_id": template_ref,
+                            "slide_id": slide_id,
+                            "placeholder": placeholder,
+                            "detail": "Placeholder not found on slide text",
+                        }
+                    )
+
+    return {
+        "enabled": True,
+        "provider_type": presentation_config.provider.type,
+        "auth_mode": "local",
+        "checked_templates": checked_templates,
+        "template_ids": [str(path) for path in template_paths],
+        "checked_slides": sorted(expected_contract.keys()),
+        "issues": issues,
+    }
+
+
 def _run_google_docs_provider_contract_check(
     presentation_config: PresentationConfig,
     contract_client: Any,
@@ -702,14 +880,20 @@ def validate_command(
         typer.Option(
             "--params-path",
             "-f",
-            help="Optional CSV file used for provider contract checks (expects template_id column)",
+            help=(
+                "Optional CSV file used for provider contract checks "
+                "(template_id for Google providers, template_path for PowerPoint)"
+            ),
         ),
     ] = None,
     provider_contract_check: Annotated[
         bool,
         typer.Option(
             "--provider-contract-check",
-            help="Run provider-aware contract checks (Google Slides or Google Docs templates)",
+            help=(
+                "Run provider-aware contract checks "
+                "(Google Slides, Google Docs, or PowerPoint templates)"
+            ),
         ),
     ] = False,
     provider_contract_full_auth_fallback: Annotated[
@@ -748,8 +932,9 @@ def validate_command(
         params_path: Optional CSV path for provider contract checks. Must include
             a `template_id` column when used.
         provider_contract_check: When true, runs provider-aware contract checks
-            for Google Slides (slide IDs/placeholders) and Google Docs
-            (section markers/placeholders).
+            for Google Slides (slide IDs/placeholders), Google Docs
+            (section markers/placeholders), and PowerPoint (slide
+            indexes/native IDs/placeholders).
         provider_contract_full_auth_fallback: When true, allows contract checks
             to instantiate the full provider if least-privilege read-only auth
             initialization fails.
@@ -832,28 +1017,35 @@ def validate_command(
 
         if provider_contract_check:
             provider_type = presentation_config.provider.type
-            if provider_type not in ("google_slides", "google_docs"):
+            if provider_type not in ("google_slides", "google_docs", "powerpoint"):
                 raise ValueError(
                     "Provider contract check is currently only supported for "
-                    "provider types 'google_slides' and 'google_docs'."
+                    "provider types 'google_slides', 'google_docs', and 'powerpoint'."
                 )
 
-            contract_client = _create_google_contract_check_client(
-                presentation_config,
-                allow_full_auth_fallback=provider_contract_full_auth_fallback,
-            )
+            if provider_type == "powerpoint":
+                provider_contract_summary = _run_powerpoint_provider_contract_check(
+                    presentation_config=presentation_config,
+                    params_path=params_path,
+                )
+            else:
+                contract_client = _create_google_contract_check_client(
+                    presentation_config,
+                    allow_full_auth_fallback=provider_contract_full_auth_fallback,
+                )
             if provider_type == "google_slides":
                 provider_contract_summary = _run_google_provider_contract_check(
                     presentation_config=presentation_config,
                     contract_client=contract_client,
                     params_path=params_path,
                 )
-            else:
+            elif provider_type == "google_docs":
                 provider_contract_summary = _run_google_docs_provider_contract_check(
                     presentation_config=presentation_config,
                     contract_client=contract_client,
                     params_path=params_path,
                 )
+            assert provider_contract_summary is not None
             if provider_contract_summary["issues"]:
                 raise ProviderContractValidationError(
                     "Provider contract validation failed. "

--- a/slideflow/cli/commands/validate.py
+++ b/slideflow/cli/commands/validate.py
@@ -55,6 +55,7 @@ from slideflow.presentations.builder import PresentationBuilder
 from slideflow.presentations.config import PresentationConfig
 from slideflow.utilities import ConfigLoader
 from slideflow.utilities.auth import load_google_credentials
+from slideflow.utilities.config import render_params
 from slideflow.utilities.error_messages import redacted_error_line
 
 _GOOGLE_SLIDES_CONTRACT_FIELDS = (
@@ -282,48 +283,118 @@ def _resolve_template_ids_for_contract_check(
     )
 
 
-def _read_powerpoint_template_paths_from_params(params_path: Path) -> List[Path]:
-    """Read unique PowerPoint template paths from params CSV."""
-    template_paths: Set[Path] = set()
-
+def _read_params_rows(params_path: Path) -> List[Dict[str, str]]:
+    """Read params CSV rows as string mappings."""
     with params_path.open("r", encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
-        if "template_path" not in (reader.fieldnames or []):
-            raise ValueError(
-                f"Missing 'template_path' column in params file: {params_path}"
-            )
-        for row in reader:
-            template_path = (row.get("template_path") or "").strip()
-            if template_path:
-                template_paths.add(Path(template_path).expanduser())
+        return [{key: value or "" for key, value in row.items()} for row in reader]
 
-    if not template_paths:
+
+def _render_powerpoint_provider_configs_from_params(
+    presentation_config: PresentationConfig, params_path: Path
+) -> List[Dict[str, Any]]:
+    provider_config = getattr(presentation_config.provider, "config", {})
+    if not isinstance(provider_config, dict):
+        provider_config = {}
+
+    rendered_configs = [
+        render_params(provider_config, row) for row in _read_params_rows(params_path)
+    ]
+    rendered_dicts = [
+        _normalize_powerpoint_provider_config(config)
+        for config in rendered_configs
+        if isinstance(config, dict)
+    ]
+    if not rendered_dicts:
         raise ValueError(
-            f"No template_path values found in params file: {params_path}. "
-            "Provide at least one template_path row."
+            f"No parameter rows found in params file: {params_path}. "
+            "Provide at least one row."
         )
+    return rendered_dicts
 
-    return sorted(template_paths, key=str)
+
+def _normalize_powerpoint_provider_config(
+    provider_config: Dict[str, Any],
+) -> Dict[str, Any]:
+    template_path = provider_config.get("template_path")
+    if isinstance(template_path, str):
+        return {**provider_config, "template_path": template_path.strip()}
+    return provider_config
+
+
+def _powerpoint_slide_id_mode(provider_config: Dict[str, Any]) -> str:
+    slide_id_mode = str(provider_config.get("slide_id_mode", "auto"))
+    if slide_id_mode not in {"auto", "index", "native"}:
+        return "auto"
+    return slide_id_mode
+
+
+def _resolve_powerpoint_contract_targets(
+    presentation_config: PresentationConfig, params_path: Optional[Path]
+) -> List[tuple[Path, str]]:
+    if params_path is not None:
+        provider_configs = _render_powerpoint_provider_configs_from_params(
+            presentation_config, params_path
+        )
+    else:
+        provider_config = getattr(presentation_config.provider, "config", {})
+        provider_configs = [
+            provider_config if isinstance(provider_config, dict) else {}
+        ]
+
+    targets: List[tuple[Path, str]] = []
+    seen: Set[tuple[Path, str]] = set()
+    for provider_config in provider_configs:
+        template_path = provider_config.get("template_path")
+        if not isinstance(template_path, (str, Path)) or not str(template_path).strip():
+            continue
+        target = (
+            Path(str(template_path).strip()).expanduser(),
+            _powerpoint_slide_id_mode(provider_config),
+        )
+        if target not in seen:
+            seen.add(target)
+            targets.append(target)
+
+    return targets
 
 
 def _resolve_powerpoint_template_paths_for_contract_check(
     presentation_config: PresentationConfig, params_path: Optional[Path]
 ) -> List[Path]:
     """Resolve PowerPoint template paths from params CSV or provider config."""
-    if params_path is not None:
-        return _read_powerpoint_template_paths_from_params(params_path)
-
-    provider_config = getattr(presentation_config.provider, "config", {})
-    if isinstance(provider_config, dict):
-        template_path = provider_config.get("template_path")
-        if isinstance(template_path, (str, Path)) and str(template_path).strip():
-            return [Path(template_path).expanduser()]
+    targets = _resolve_powerpoint_contract_targets(presentation_config, params_path)
+    if targets:
+        return sorted({template_path for template_path, _mode in targets}, key=str)
 
     raise ValueError(
         "No PowerPoint template paths available for provider contract check. "
         "Provide --params-path with a 'template_path' column or set "
         "provider.config.template_path."
     )
+
+
+def _validate_provider_specific_config(
+    presentation_config: PresentationConfig,
+    *,
+    provider_contract_check: bool,
+    params_path: Optional[Path],
+) -> None:
+    """Validate provider config, resolving PowerPoint contract template params."""
+    from slideflow.presentations.providers.factory import ProviderFactory
+
+    provider_type = presentation_config.provider.type
+    provider_config = presentation_config.provider.config
+    config_class = ProviderFactory.get_config_class(provider_type)
+
+    if provider_type == "powerpoint" and provider_contract_check and params_path:
+        for rendered_config in _render_powerpoint_provider_configs_from_params(
+            presentation_config, params_path
+        ):
+            config_class(**rendered_config)
+        return
+
+    config_class(**provider_config)
 
 
 def _extract_slide_text_map(presentation_payload: Dict[str, Any]) -> Dict[str, str]:
@@ -664,23 +735,21 @@ def _run_powerpoint_provider_contract_check(
             "Install with slideflow-presentations[powerpoint]."
         ) from error
 
-    template_paths = _resolve_powerpoint_template_paths_for_contract_check(
+    contract_targets = _resolve_powerpoint_contract_targets(
         presentation_config, params_path
     )
+    if not contract_targets:
+        raise ValueError(
+            "No PowerPoint template paths available for provider contract check. "
+            "Provide --params-path with params that render "
+            "provider.config.template_path or set provider.config.template_path."
+        )
     expected_contract = _collect_expected_contract(presentation_config)
-    provider_config = getattr(presentation_config.provider, "config", {})
-    slide_id_mode = (
-        provider_config.get("slide_id_mode", "auto")
-        if isinstance(provider_config, dict)
-        else "auto"
-    )
-    if slide_id_mode not in {"auto", "index", "native"}:
-        slide_id_mode = "auto"
 
     issues: List[Dict[str, Any]] = []
     checked_templates = 0
 
-    for template_path in template_paths:
+    for template_path, slide_id_mode in contract_targets:
         template_ref = str(template_path)
         try:
             presentation = PptxPresentation(str(template_path))
@@ -733,7 +802,12 @@ def _run_powerpoint_provider_contract_check(
         "provider_type": presentation_config.provider.type,
         "auth_mode": "local",
         "checked_templates": checked_templates,
-        "template_ids": [str(path) for path in template_paths],
+        "template_ids": [
+            str(path)
+            for path in _resolve_powerpoint_template_paths_for_contract_check(
+                presentation_config, params_path
+            )
+        ],
         "checked_slides": sorted(expected_contract.keys()),
         "issues": issues,
     }
@@ -1004,11 +1078,11 @@ def validate_command(
 
         presentation_config = PresentationConfig(**loader.config)
 
-        # Validate provider-specific configuration
-        from slideflow.presentations.providers.factory import ProviderFactory
-
-        ProviderFactory.get_config_class(presentation_config.provider.type)(
-            **presentation_config.provider.config
+        # Validate provider-specific configuration.
+        _validate_provider_specific_config(
+            presentation_config,
+            provider_contract_check=provider_contract_check,
+            params_path=params_path,
         )
 
         # Validate chart/replacement specs deeply so unresolved function refs fail validation.

--- a/slideflow/presentations/__init__.py
+++ b/slideflow/presentations/__init__.py
@@ -157,6 +157,7 @@ from slideflow.presentations.positioning import (
 )
 from slideflow.presentations.providers.google_docs import GoogleDocsProvider
 from slideflow.presentations.providers.google_slides import GoogleSlidesProvider
+from slideflow.presentations.providers.powerpoint import PowerPointProvider
 
 __all__ = [
     # Base classes
@@ -181,6 +182,7 @@ __all__ = [
     "PresentationBuilder",
     "GoogleSlidesProvider",
     "GoogleDocsProvider",
+    "PowerPointProvider",
     # Positioning utilities
     "compute_chart_dimensions",
     "safe_eval_expression",

--- a/slideflow/presentations/base.py
+++ b/slideflow/presentations/base.py
@@ -97,7 +97,7 @@ class _RenderContext:
     total_replacements: int = 0
     uploaded_file_ids: List[str] = field(default_factory=list)
     failed_cleanup_ids: List[str] = field(default_factory=list)
-    original_error: Optional[Exception] = None
+    original_error: Optional[BaseException] = None
     ownership_transfer_attempted: bool = False
     ownership_transfer_succeeded: Optional[bool] = None
     ownership_transfer_target: Optional[str] = None
@@ -594,7 +594,13 @@ class Presentation(BaseModel):
         """Create render context after provider preflight and presentation creation."""
         self._run_provider_preflight()
         presentation_id = self.provider.create_presentation(self.name)
-        page_width_pt, page_height_pt = self._resolve_page_dimensions(presentation_id)
+        try:
+            page_width_pt, page_height_pt = self._resolve_page_dimensions(
+                presentation_id
+            )
+        except BaseException:
+            self._abort_provider_presentation_id(presentation_id)
+            raise
 
         return _RenderContext(
             presentation_id=presentation_id,
@@ -953,6 +959,23 @@ class Presentation(BaseModel):
                     "Ownership transfer failed: " f"{context.ownership_transfer_error}"
                 ) from transfer_error
 
+    def _abort_provider_presentation_id(self, presentation_id: str) -> None:
+        abort_presentation = getattr(self.provider, "abort_presentation", None)
+        if not callable(abort_presentation):
+            return
+
+        try:
+            abort_presentation(presentation_id)
+        except Exception as abort_error:
+            logger.warning(
+                "Provider abort hook failed for presentation '%s': %s",
+                presentation_id,
+                redacted_error_line(abort_error),
+            )
+
+    def _abort_provider_presentation(self, context: _RenderContext) -> None:
+        self._abort_provider_presentation_id(context.presentation_id)
+
     def _build_presentation_result(
         self, context: _RenderContext, citation_summary: CitationSummary
     ) -> PresentationResult:
@@ -1042,6 +1065,7 @@ class Presentation(BaseModel):
         """Render the complete presentation with all content and styling."""
         context: Optional[_RenderContext] = None
         cleanup_attempted = False
+        render_completed = False
         try:
             context = self._create_render_context(start_time=time.time())
             self._prefetch_data_sources()
@@ -1053,14 +1077,21 @@ class Presentation(BaseModel):
             self._apply_ownership_transfer(context)
             cleanup_attempted = True
             self._cleanup_uploaded_chart_images(context)
-            return self._build_presentation_result(context, citation_summary)
-        except Exception as error:
+            result = self._build_presentation_result(context, citation_summary)
+            render_completed = True
+            return result
+        except BaseException as error:
             if context is not None:
                 context.original_error = error
             raise
         finally:
-            if context is not None and not cleanup_attempted:
-                self._cleanup_uploaded_chart_images(context)
+            if context is not None:
+                try:
+                    if not cleanup_attempted:
+                        self._cleanup_uploaded_chart_images(context)
+                finally:
+                    if not render_completed:
+                        self._abort_provider_presentation(context)
 
     def get_slide(self, slide_id: str) -> Optional[Slide]:
         """Retrieve a slide by its unique identifier.

--- a/slideflow/presentations/providers/__init__.py
+++ b/slideflow/presentations/providers/__init__.py
@@ -43,9 +43,13 @@ Example:
 
 Available Providers:
     - GoogleSlidesProvider: For Google Slides presentation creation and management
+    - GoogleDocsProvider: For Google Docs document creation and management
+    - PowerPointProvider: For local native PPTX artifact creation
 
 Available Configurations:
     - GoogleSlidesProviderConfig: Configuration for Google Slides provider
+    - GoogleDocsProviderConfig: Configuration for Google Docs provider
+    - PowerPointProviderConfig: Configuration for PowerPoint provider
 
 Result Classes:
     - ProviderPresentationResult: Result from presentation operations
@@ -70,6 +74,10 @@ from slideflow.presentations.providers.google_slides import (
     GoogleSlidesProvider,
     GoogleSlidesProviderConfig,
 )
+from slideflow.presentations.providers.powerpoint import (
+    PowerPointProvider,
+    PowerPointProviderConfig,
+)
 
 __all__ = [
     "PresentationProvider",
@@ -80,5 +88,7 @@ __all__ = [
     "GoogleSlidesProviderConfig",
     "GoogleDocsProvider",
     "GoogleDocsProviderConfig",
+    "PowerPointProvider",
+    "PowerPointProviderConfig",
     "ProviderFactory",
 ]

--- a/slideflow/presentations/providers/base.py
+++ b/slideflow/presentations/providers/base.py
@@ -228,6 +228,15 @@ class PresentationProvider(ABC):
         """
         _ = presentation_id
 
+    def abort_presentation(self, presentation_id: str) -> None:
+        """Release provider-specific resources after an unsuccessful render.
+
+        Providers that reserve local paths, create temporary remote artifacts, or
+        hold other render-scoped resources can override this hook. Implementations
+        should be best-effort and idempotent.
+        """
+        _ = presentation_id
+
     def render_citations(
         self,
         presentation_id: str,

--- a/slideflow/presentations/providers/factory.py
+++ b/slideflow/presentations/providers/factory.py
@@ -47,6 +47,10 @@ from slideflow.presentations.providers.google_slides import (
     GoogleSlidesProvider,
     GoogleSlidesProviderConfig,
 )
+from slideflow.presentations.providers.powerpoint import (
+    PowerPointProvider,
+    PowerPointProviderConfig,
+)
 from slideflow.utilities.exceptions import ConfigurationError
 
 provider_registry = create_class_registry(
@@ -58,6 +62,8 @@ provider_registry.register_class("google_slides", GoogleSlidesProvider)
 config_registry.register_class("google_slides", GoogleSlidesProviderConfig)
 provider_registry.register_class("google_docs", GoogleDocsProvider)
 config_registry.register_class("google_docs", GoogleDocsProviderConfig)
+provider_registry.register_class("powerpoint", PowerPointProvider)
+config_registry.register_class("powerpoint", PowerPointProviderConfig)
 
 
 class ProviderFactory:

--- a/slideflow/presentations/providers/powerpoint.py
+++ b/slideflow/presentations/providers/powerpoint.py
@@ -8,7 +8,10 @@ into the destination deck.
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
+import stat
 import uuid
 from io import BytesIO
 from pathlib import Path
@@ -34,6 +37,7 @@ logger = get_logger(__name__)
 
 EMU_PER_POINT = 12700
 MEMORY_IMAGE_URL_PREFIX = "slideflow-pptx://chart/"
+AUXILIARY_STEM_MAX_LENGTH = 80
 
 
 def _require_python_pptx() -> Any:
@@ -47,6 +51,15 @@ def _require_python_pptx() -> Any:
 
 def _normalize_path(value: Path | str) -> Path:
     return Path(value).expanduser()
+
+
+def _nearest_existing_parent(path: Path) -> Optional[Path]:
+    current = path if path.exists() else path.parent
+    while not current.exists():
+        if current == current.parent:
+            return None
+        current = current.parent
+    return current
 
 
 def _safe_output_stem(name: str) -> str:
@@ -123,6 +136,7 @@ class PowerPointProvider(PresentationProvider):
         self._pptx_factory = _require_python_pptx()
         self._presentations: Dict[str, Any] = {}
         self._presentation_paths: Dict[str, Path] = {}
+        self._presentation_locks: Dict[str, Path] = {}
         self._chart_images: Dict[str, bytes] = {}
 
     def run_preflight_checks(self) -> List[Tuple[str, bool, str]]:
@@ -160,15 +174,20 @@ class PowerPointProvider(PresentationProvider):
         )
 
         output_dir = self.config.output_dir
-        output_parent = output_dir if output_dir.exists() else output_dir.parent
+        output_parent = _nearest_existing_parent(output_dir)
+        output_parent_ok = (
+            output_parent is not None
+            and output_parent.is_dir()
+            and os.access(output_parent, os.W_OK)
+        )
         checks.append(
             (
                 "output_dir_writable",
-                output_parent.exists() and output_parent.is_dir(),
+                output_parent_ok,
                 (
                     f"Output directory is available: {output_dir}"
                     if output_dir.exists()
-                    else f"Output parent is available: {output_parent}"
+                    else f"Output directory can be created under: {output_parent}"
                 ),
             )
         )
@@ -182,21 +201,30 @@ class PowerPointProvider(PresentationProvider):
         if not template_path.is_file():
             raise ConfigurationError(f"PowerPoint template not found: {template_path}")
 
-        output_path = self._resolve_output_path(name)
+        output_path, output_lock_path = self._resolve_output_path(name)
         if (
             output_path.resolve() == template_path.resolve()
             and self.config.read_only_template
         ):
+            if output_lock_path is not None:
+                self._release_output_lock(output_lock_path)
             raise ConfigurationError(
                 "PowerPoint output path resolves to template_path while "
                 "read_only_template is true"
             )
 
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        presentation = self._pptx_factory(str(template_path))
+        try:
+            presentation = self._pptx_factory(str(template_path))
+        except BaseException:
+            if output_lock_path is not None:
+                self._release_output_lock(output_lock_path)
+            raise
+
         presentation_id = str(output_path)
         self._presentations[presentation_id] = presentation
         self._presentation_paths[presentation_id] = output_path
+        if output_lock_path is not None:
+            self._presentation_locks[presentation_id] = output_lock_path
         return presentation_id
 
     def upload_chart_image(
@@ -286,7 +314,32 @@ class PowerPointProvider(PresentationProvider):
         """Save the generated PPTX artifact to disk."""
         presentation = self._get_presentation(presentation_id)
         output_path = self._presentation_paths[presentation_id]
-        presentation.save(str(output_path))
+        output_lock_path = self._presentation_locks.get(presentation_id)
+        temp_path = self._temp_path_for(output_path)
+        existing_mode = self._existing_file_mode(output_path)
+
+        try:
+            if output_lock_path is not None and output_path.exists():
+                raise ConfigurationError(
+                    f"PowerPoint output appeared after reservation: {output_path}"
+                )
+            if existing_mode is not None:
+                with temp_path.open("xb"):
+                    pass
+                temp_path.chmod(existing_mode)
+            presentation.save(str(temp_path))
+            if existing_mode is not None:
+                temp_path.chmod(existing_mode)
+            temp_path.replace(output_path)
+        finally:
+            temp_path.unlink(missing_ok=True)
+            self._release_presentation_lock(presentation_id)
+
+    def abort_presentation(self, presentation_id: str) -> None:
+        """Release a reserved output path after an unsuccessful render."""
+        self._release_presentation_lock(presentation_id)
+        self._presentations.pop(presentation_id, None)
+        self._presentation_paths.pop(presentation_id, None)
 
     def render_citations(
         self,
@@ -312,41 +365,108 @@ class PowerPointProvider(PresentationProvider):
         """Delete an in-memory chart image token."""
         self._chart_images.pop(file_id, None)
 
-    def _resolve_output_path(self, name: str) -> Path:
+    def _resolve_output_path(self, name: str) -> Tuple[Path, Optional[Path]]:
         output_dir = self.config.output_dir
         output_path = output_dir / f"{_safe_output_stem(name)}.pptx"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if output_path.exists():
+        if self.config.file_collision_strategy == "overwrite":
+            if (
+                output_path.resolve() == self.config.template_path.resolve()
+                and self.config.read_only_template
+            ):
+                raise ConfigurationError(
+                    "Refusing to overwrite template_path while "
+                    "read_only_template is true"
+                )
+            return output_path, None
+
+        try:
+            return output_path, self._reserve_output_lock(output_path)
+        except FileExistsError:
             if self.config.file_collision_strategy == "fail":
                 raise ConfigurationError(
                     f"PowerPoint output already exists: {output_path}"
-                )
-            if self.config.file_collision_strategy == "overwrite":
-                if (
-                    output_path.resolve() == self.config.template_path.resolve()
-                    and self.config.read_only_template
-                ):
-                    raise ConfigurationError(
-                        "Refusing to overwrite template_path while "
-                        "read_only_template is true"
-                    )
-                return output_path
-            return self._suffix_output_path(output_path)
+                ) from None
 
-        return output_path
+        return self._suffix_output_path(output_path)
 
     @staticmethod
-    def _suffix_output_path(output_path: Path) -> Path:
+    def _suffix_output_path(output_path: Path) -> Tuple[Path, Path]:
         stem = output_path.stem
         suffix = output_path.suffix
         parent = output_path.parent
         for index in range(1, 10_000):
             candidate = parent / f"{stem}-{index}{suffix}"
-            if not candidate.exists():
-                return candidate
+            try:
+                return candidate, PowerPointProvider._reserve_output_lock(candidate)
+            except FileExistsError:
+                continue
         raise ConfigurationError(
             f"Could not find available suffixed output path for {output_path}"
         )
+
+    @staticmethod
+    def _lock_path_for(output_path: Path) -> Path:
+        return output_path.with_name(
+            f"{PowerPointProvider._auxiliary_name_prefix(output_path)}.lock"
+        )
+
+    @staticmethod
+    def _temp_path_for(output_path: Path) -> Path:
+        return output_path.with_name(
+            f"{PowerPointProvider._auxiliary_name_prefix(output_path)}."
+            f"{uuid.uuid4().hex}.tmp"
+        )
+
+    @staticmethod
+    def _auxiliary_name_prefix(output_path: Path) -> str:
+        stem = output_path.stem[:AUXILIARY_STEM_MAX_LENGTH].rstrip(" .")
+        stem = stem or "presentation"
+        digest = hashlib.sha256(output_path.name.encode("utf-8")).hexdigest()[:16]
+        return f".{stem}.{digest}"
+
+    @staticmethod
+    def _existing_file_mode(output_path: Path) -> Optional[int]:
+        try:
+            return stat.S_IMODE(output_path.stat().st_mode)
+        except FileNotFoundError:
+            return None
+
+    @staticmethod
+    def _reserve_output_lock(output_path: Path) -> Path:
+        if output_path.exists():
+            raise FileExistsError(output_path)
+
+        lock_path = PowerPointProvider._lock_path_for(output_path)
+        try:
+            with lock_path.open("xb"):
+                pass
+        except FileExistsError:
+            raise
+        except OSError as error:
+            raise ConfigurationError(
+                f"Could not reserve PowerPoint output path {output_path}: {error}"
+            ) from error
+
+        if output_path.exists():
+            PowerPointProvider._release_output_lock(lock_path)
+            raise FileExistsError(output_path)
+        return lock_path
+
+    def _release_presentation_lock(self, presentation_id: str) -> None:
+        lock_path = self._presentation_locks.pop(presentation_id, None)
+        if lock_path is not None:
+            self._release_output_lock(lock_path)
+
+    @staticmethod
+    def _release_output_lock(lock_path: Path) -> None:
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError as error:
+            logger.warning(
+                "Could not release PowerPoint output lock %s: %s", lock_path, error
+            )
 
     def _get_presentation(self, presentation_id: str) -> Any:
         try:
@@ -443,15 +563,20 @@ class PowerPointProvider(PresentationProvider):
     def _replace_text_frame(text_frame: Any, placeholder: str, replacement: str) -> int:
         replacements = 0
         for paragraph in text_frame.paragraphs:
+            original_paragraph_text = paragraph.text
+            original_count = original_paragraph_text.count(placeholder)
+            paragraph_replacements = 0
             for run in paragraph.runs:
                 if placeholder not in run.text:
                     continue
-                replacements += run.text.count(placeholder)
+                paragraph_replacements += run.text.count(placeholder)
                 run.text = run.text.replace(placeholder, replacement)
 
-            paragraph_text = paragraph.text
-            if placeholder in paragraph_text:
-                replacements += paragraph_text.count(placeholder)
-                paragraph.text = paragraph_text.replace(placeholder, replacement)
+            replacements += paragraph_replacements
+            if original_count > paragraph_replacements:
+                replacements += original_count - paragraph_replacements
+                paragraph.text = original_paragraph_text.replace(
+                    placeholder, replacement
+                )
 
         return replacements

--- a/slideflow/presentations/providers/powerpoint.py
+++ b/slideflow/presentations/providers/powerpoint.py
@@ -1,0 +1,457 @@
+"""PowerPoint presentation provider for local PPTX output.
+
+The provider renders Slideflow presentations into native ``.pptx`` files using
+``python-pptx``. It mirrors the presentation provider interface used by cloud
+providers while keeping generated chart images in memory until they are inserted
+into the destination deck.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
+from urllib.request import urlopen
+
+from pydantic import Field, field_validator
+
+from slideflow.constants import GoogleSlides
+from slideflow.presentations.providers.base import (
+    PresentationProvider,
+    PresentationProviderConfig,
+)
+from slideflow.utilities.exceptions import ConfigurationError, RenderingError
+from slideflow.utilities.logging import get_logger
+
+try:  # pragma: no cover - exercised in environments without the optional extra.
+    from pptx import Presentation as PptxPresentation
+except ImportError:  # pragma: no cover
+    PptxPresentation = None  # type: ignore[assignment]
+
+logger = get_logger(__name__)
+
+EMU_PER_POINT = 12700
+MEMORY_IMAGE_URL_PREFIX = "slideflow-pptx://chart/"
+
+
+def _require_python_pptx() -> Any:
+    if PptxPresentation is None:
+        raise ConfigurationError(
+            "PowerPoint provider requires the optional dependency "
+            "'python-pptx'. Install with slideflow-presentations[powerpoint]."
+        )
+    return PptxPresentation
+
+
+def _normalize_path(value: Path | str) -> Path:
+    return Path(value).expanduser()
+
+
+def _safe_output_stem(name: str) -> str:
+    stem = re.sub(r"[^A-Za-z0-9._ -]+", "_", name).strip(" ._")
+    stem = re.sub(r"\s+", " ", stem)
+    return stem or "presentation"
+
+
+def _points_to_emu(value: float) -> int:
+    return int(round(value * EMU_PER_POINT))
+
+
+def _emu_to_points(value: int) -> int:
+    return int(round(value / EMU_PER_POINT))
+
+
+class PowerPointProviderConfig(PresentationProviderConfig):
+    """Configuration for the local PowerPoint PPTX provider."""
+
+    provider_type: Literal["powerpoint"] = "powerpoint"
+    template_path: Path = Field(..., description="Path to the source .pptx template")
+    output_dir: Path = Field(
+        Path("."),
+        description="Directory where generated .pptx files are written.",
+    )
+    slide_id_mode: Literal["auto", "index", "native"] = Field(
+        "auto",
+        description=(
+            "How presentation.slides[].id resolves slides: one-based index, "
+            "native PowerPoint slide_id, or auto (index then native)."
+        ),
+    )
+    read_only_template: bool = Field(
+        True,
+        description="Prevent writes to the configured template_path.",
+    )
+    file_collision_strategy: Literal["fail", "overwrite", "suffix"] = Field(
+        "fail",
+        description="Behavior when the generated .pptx path already exists.",
+    )
+    strict_cleanup: bool = Field(
+        False,
+        description="Fail rendering when temporary in-memory chart cleanup fails.",
+    )
+    share_with: List[str] = Field(
+        default_factory=list,
+        description="Accepted for provider compatibility; sharing is a no-op.",
+    )
+    share_role: str = Field(
+        GoogleSlides.PERMISSION_READER,
+        description="Accepted for provider compatibility; sharing is a no-op.",
+    )
+
+    @field_validator("template_path")
+    @classmethod
+    def _validate_template_path(cls, value: Path | str) -> Path:
+        path = _normalize_path(value)
+        if path.suffix.lower() != ".pptx":
+            raise ValueError("template_path must point to a .pptx file")
+        return path
+
+    @field_validator("output_dir")
+    @classmethod
+    def _validate_output_dir(cls, value: Path | str) -> Path:
+        return _normalize_path(value)
+
+
+class PowerPointProvider(PresentationProvider):
+    """Local PowerPoint provider that renders native ``.pptx`` artifacts."""
+
+    def __init__(self, config: PowerPointProviderConfig):
+        super().__init__(config)
+        self.config: PowerPointProviderConfig = config
+        self._pptx_factory = _require_python_pptx()
+        self._presentations: Dict[str, Any] = {}
+        self._presentation_paths: Dict[str, Path] = {}
+        self._chart_images: Dict[str, bytes] = {}
+
+    def run_preflight_checks(self) -> List[Tuple[str, bool, str]]:
+        """Run local PPTX provider preflight checks for doctor/build."""
+        checks: List[Tuple[str, bool, str]] = [
+            (
+                "python_pptx_import",
+                PptxPresentation is not None,
+                (
+                    "python-pptx import succeeded"
+                    if PptxPresentation is not None
+                    else "Install slideflow-presentations[powerpoint]"
+                ),
+            )
+        ]
+
+        template_path = self.config.template_path
+        checks.append(
+            (
+                "template_path_exists",
+                template_path.is_file(),
+                (
+                    f"Found template at {template_path}"
+                    if template_path.is_file()
+                    else f"Template file not found: {template_path}"
+                ),
+            )
+        )
+        checks.append(
+            (
+                "template_path_is_pptx",
+                template_path.suffix.lower() == ".pptx",
+                f"Template suffix is '{template_path.suffix or '<none>'}'",
+            )
+        )
+
+        output_dir = self.config.output_dir
+        output_parent = output_dir if output_dir.exists() else output_dir.parent
+        checks.append(
+            (
+                "output_dir_writable",
+                output_parent.exists() and output_parent.is_dir(),
+                (
+                    f"Output directory is available: {output_dir}"
+                    if output_dir.exists()
+                    else f"Output parent is available: {output_parent}"
+                ),
+            )
+        )
+        return checks
+
+    def create_presentation(self, name: str, template_id: Optional[str] = None) -> str:
+        """Create a local PPTX artifact from the configured template."""
+        template_path = _normalize_path(template_id or self.config.template_path)
+        if template_path.suffix.lower() != ".pptx":
+            raise ConfigurationError("PowerPoint template must be a .pptx file")
+        if not template_path.is_file():
+            raise ConfigurationError(f"PowerPoint template not found: {template_path}")
+
+        output_path = self._resolve_output_path(name)
+        if (
+            output_path.resolve() == template_path.resolve()
+            and self.config.read_only_template
+        ):
+            raise ConfigurationError(
+                "PowerPoint output path resolves to template_path while "
+                "read_only_template is true"
+            )
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        presentation = self._pptx_factory(str(template_path))
+        presentation_id = str(output_path)
+        self._presentations[presentation_id] = presentation
+        self._presentation_paths[presentation_id] = output_path
+        return presentation_id
+
+    def upload_chart_image(
+        self, presentation_id: str, image_data: bytes, filename: str
+    ) -> Tuple[str, str]:
+        """Store chart image bytes in memory for later insertion."""
+        self._get_presentation(presentation_id)
+        token = uuid.uuid4().hex
+        image_url = f"{MEMORY_IMAGE_URL_PREFIX}{token}/{Path(filename).name}"
+        self._chart_images[token] = bytes(image_data)
+        return image_url, token
+
+    def insert_chart_to_slide(
+        self,
+        presentation_id: str,
+        slide_id: str,
+        image_url: str,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+    ) -> None:
+        """Insert a chart image into a PowerPoint slide."""
+        if width <= 0 or height <= 0:
+            raise RenderingError("Chart width and height must be greater than zero")
+
+        slide = self._resolve_slide(presentation_id, slide_id)
+        image_stream = self._open_image_stream(image_url)
+        slide.shapes.add_picture(
+            image_stream,
+            _points_to_emu(x),
+            _points_to_emu(y),
+            width=_points_to_emu(width),
+            height=_points_to_emu(height),
+        )
+
+    def replace_text_in_slide(
+        self, presentation_id: str, slide_id: str, placeholder: str, replacement: str
+    ) -> int:
+        """Replace placeholder text in text frames and table cells on one slide."""
+        if not placeholder:
+            return 0
+
+        slide = self._resolve_slide(presentation_id, slide_id)
+        replacements = 0
+        for text_frame in self._iter_text_frames(slide.shapes):
+            replacements += self._replace_text_frame(
+                text_frame=text_frame,
+                placeholder=placeholder,
+                replacement=replacement,
+            )
+        return replacements
+
+    def share_presentation(
+        self,
+        presentation_id: str,
+        emails: List[str],
+        role: str = GoogleSlides.PERMISSION_READER,
+    ) -> None:
+        """No-op sharing hook for local PPTX output."""
+        self._get_presentation(presentation_id)
+        if emails:
+            logger.warning(
+                "PowerPoint provider does not support sharing; generated PPTX "
+                "remains local (requested role=%s, recipients=%s)",
+                role,
+                ", ".join(emails),
+            )
+
+    def get_presentation_url(self, presentation_id: str) -> str:
+        """Return a file URL for the generated PPTX artifact."""
+        output_path = self._presentation_paths.get(
+            presentation_id, Path(presentation_id)
+        )
+        return output_path.resolve().as_uri()
+
+    def get_presentation_page_size(
+        self, presentation_id: str
+    ) -> Optional[Tuple[int, int]]:
+        """Return slide dimensions in points."""
+        presentation = self._get_presentation(presentation_id)
+        return _emu_to_points(int(presentation.slide_width)), _emu_to_points(
+            int(presentation.slide_height)
+        )
+
+    def finalize_presentation(self, presentation_id: str) -> None:
+        """Save the generated PPTX artifact to disk."""
+        presentation = self._get_presentation(presentation_id)
+        output_path = self._presentation_paths[presentation_id]
+        presentation.save(str(output_path))
+
+    def render_citations(
+        self,
+        presentation_id: str,
+        citations_by_scope: Dict[str, List[Dict[str, Any]]],
+        location: str,
+    ) -> None:
+        """Render source citations into PowerPoint speaker notes when possible.
+
+        ``python-pptx`` does not expose a stable public API for notes pages, so
+        PPTX citations are intentionally not rendered in V1.
+        """
+        self._get_presentation(presentation_id)
+        if citations_by_scope:
+            logger.warning(
+                "PowerPoint provider does not render citations yet "
+                "(location=%s, scopes=%d)",
+                location,
+                len(citations_by_scope),
+            )
+
+    def delete_chart_image(self, file_id: str) -> None:
+        """Delete an in-memory chart image token."""
+        self._chart_images.pop(file_id, None)
+
+    def _resolve_output_path(self, name: str) -> Path:
+        output_dir = self.config.output_dir
+        output_path = output_dir / f"{_safe_output_stem(name)}.pptx"
+
+        if output_path.exists():
+            if self.config.file_collision_strategy == "fail":
+                raise ConfigurationError(
+                    f"PowerPoint output already exists: {output_path}"
+                )
+            if self.config.file_collision_strategy == "overwrite":
+                if (
+                    output_path.resolve() == self.config.template_path.resolve()
+                    and self.config.read_only_template
+                ):
+                    raise ConfigurationError(
+                        "Refusing to overwrite template_path while "
+                        "read_only_template is true"
+                    )
+                return output_path
+            return self._suffix_output_path(output_path)
+
+        return output_path
+
+    @staticmethod
+    def _suffix_output_path(output_path: Path) -> Path:
+        stem = output_path.stem
+        suffix = output_path.suffix
+        parent = output_path.parent
+        for index in range(1, 10_000):
+            candidate = parent / f"{stem}-{index}{suffix}"
+            if not candidate.exists():
+                return candidate
+        raise ConfigurationError(
+            f"Could not find available suffixed output path for {output_path}"
+        )
+
+    def _get_presentation(self, presentation_id: str) -> Any:
+        try:
+            return self._presentations[presentation_id]
+        except KeyError as error:
+            raise RenderingError(
+                f"Unknown PowerPoint presentation id: {presentation_id}"
+            ) from error
+
+    def _resolve_slide(self, presentation_id: str, slide_id: str) -> Any:
+        presentation = self._get_presentation(presentation_id)
+        slides = list(presentation.slides)
+
+        if self.config.slide_id_mode in {"auto", "index"}:
+            slide = self._slide_by_one_based_index(slides, slide_id)
+            if slide is not None:
+                return slide
+            if self.config.slide_id_mode == "index":
+                raise RenderingError(
+                    f"PowerPoint slide index '{slide_id}' is not present "
+                    f"(slide count: {len(slides)})"
+                )
+
+        if self.config.slide_id_mode in {"auto", "native"}:
+            for slide in slides:
+                if str(getattr(slide, "slide_id", "")) == str(slide_id):
+                    return slide
+
+        raise RenderingError(
+            f"PowerPoint slide id '{slide_id}' was not found using "
+            f"slide_id_mode='{self.config.slide_id_mode}'"
+        )
+
+    @staticmethod
+    def _slide_by_one_based_index(slides: List[Any], slide_id: str) -> Optional[Any]:
+        try:
+            index = int(str(slide_id).strip())
+        except ValueError:
+            return None
+        if index < 1 or index > len(slides):
+            return None
+        return slides[index - 1]
+
+    def _open_image_stream(self, image_url: str) -> BytesIO:
+        token = self._extract_memory_image_token(image_url)
+        if token is not None:
+            try:
+                return BytesIO(self._chart_images[token])
+            except KeyError as error:
+                raise RenderingError(
+                    f"PowerPoint chart image token is no longer available: {token}"
+                ) from error
+
+        if image_url.startswith(("http://", "https://")):
+            try:
+                with urlopen(image_url, timeout=15) as response:  # nosec B310
+                    return BytesIO(response.read())
+            except Exception as error:
+                raise RenderingError(
+                    f"Failed to download chart image for PowerPoint insertion: {error}"
+                ) from error
+
+        local_path = Path(image_url).expanduser()
+        if local_path.is_file():
+            return BytesIO(local_path.read_bytes())
+
+        raise RenderingError(
+            "PowerPoint chart image URL must be an uploaded memory token, "
+            "HTTP(S) URL, or readable local file path"
+        )
+
+    @staticmethod
+    def _extract_memory_image_token(image_url: str) -> Optional[str]:
+        if not image_url.startswith(MEMORY_IMAGE_URL_PREFIX):
+            return None
+        remainder = image_url[len(MEMORY_IMAGE_URL_PREFIX) :]
+        return remainder.split("/", 1)[0] or None
+
+    def _iter_text_frames(self, shapes: Iterable[Any]) -> Iterable[Any]:
+        for shape in shapes:
+            if getattr(shape, "has_text_frame", False):
+                yield shape.text_frame
+
+            if getattr(shape, "has_table", False):
+                for row in shape.table.rows:
+                    for cell in row.cells:
+                        yield cell.text_frame
+
+            child_shapes = getattr(shape, "shapes", None)
+            if child_shapes is not None:
+                yield from self._iter_text_frames(child_shapes)
+
+    @staticmethod
+    def _replace_text_frame(text_frame: Any, placeholder: str, replacement: str) -> int:
+        replacements = 0
+        for paragraph in text_frame.paragraphs:
+            for run in paragraph.runs:
+                if placeholder not in run.text:
+                    continue
+                replacements += run.text.count(placeholder)
+                run.text = run.text.replace(placeholder, replacement)
+
+            paragraph_text = paragraph.text
+            if placeholder in paragraph_text:
+                replacements += paragraph_text.count(placeholder)
+                paragraph.text = paragraph_text.replace(placeholder, replacement)
+
+        return replacements

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -971,6 +971,150 @@ def test_validate_provider_contract_check_writes_success_json(tmp_path, monkeypa
     ]
 
 
+def test_validate_powerpoint_provider_contract_check_success(tmp_path, monkeypatch):
+    pptx_module = pytest.importorskip("pptx")
+    stub_build_validate_cli_output(monkeypatch)
+
+    template_path = tmp_path / "template.pptx"
+    prs = pptx_module.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_textbox(100000, 100000, 3000000, 500000).text = "Hello {{NAME}}"
+    prs.save(template_path)
+
+    slide_spec = types.SimpleNamespace(
+        id="1",
+        replacements=[types.SimpleNamespace(config={"placeholder": "{{NAME}}"})],
+        charts=[],
+    )
+    monkeypatch.setattr(
+        validate_command_module,
+        "PresentationConfig",
+        lambda **_: types.SimpleNamespace(
+            provider=types.SimpleNamespace(
+                type="powerpoint",
+                config={
+                    "template_path": str(template_path),
+                    "output_dir": str(tmp_path),
+                },
+            ),
+            presentation=types.SimpleNamespace(name="Demo", slides=[slide_spec]),
+        ),
+    )
+    monkeypatch.setattr(
+        provider_factory_module.ProviderFactory,
+        "get_config_class",
+        staticmethod(lambda _provider_type: (lambda **_cfg: None)),
+    )
+    monkeypatch.setattr(
+        validate_command_module.PresentationBuilder,
+        "_build_slide",
+        staticmethod(lambda _spec: None),
+    )
+
+    class FakeLoader:
+        def __init__(self, yaml_path: Path, registry_paths):
+            self.config = _minimal_loader_config()
+
+    monkeypatch.setattr(validate_command_module, "ConfigLoader", FakeLoader)
+
+    config_file = tmp_path / "config.yaml"
+    output_file = tmp_path / "validate-powerpoint-contract.json"
+    config_file.write_text(
+        "provider:\n"
+        "  type: powerpoint\n"
+        "  config:\n"
+        f"    template_path: {template_path}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n"
+    )
+
+    validate_command_module.validate_command(
+        config_file=config_file,
+        registry_paths=None,
+        output_json=output_file,
+        params_path=None,
+        provider_contract_check=True,
+    )
+
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["status"] == "success"
+    assert payload["provider_contract"]["auth_mode"] == "local"
+    assert payload["provider_contract"]["template_ids"] == [str(template_path)]
+
+
+def test_validate_powerpoint_provider_contract_check_failure(tmp_path, monkeypatch):
+    pptx_module = pytest.importorskip("pptx")
+    stub_build_validate_cli_output(monkeypatch)
+
+    template_path = tmp_path / "template.pptx"
+    prs = pptx_module.Presentation()
+    prs.slides.add_slide(prs.slide_layouts[6])
+    prs.save(template_path)
+
+    slide_spec = types.SimpleNamespace(
+        id="1",
+        replacements=[types.SimpleNamespace(config={"placeholder": "{{NAME}}"})],
+        charts=[],
+    )
+    monkeypatch.setattr(
+        validate_command_module,
+        "PresentationConfig",
+        lambda **_: types.SimpleNamespace(
+            provider=types.SimpleNamespace(
+                type="powerpoint",
+                config={
+                    "template_path": str(template_path),
+                    "output_dir": str(tmp_path),
+                },
+            ),
+            presentation=types.SimpleNamespace(name="Demo", slides=[slide_spec]),
+        ),
+    )
+    monkeypatch.setattr(
+        provider_factory_module.ProviderFactory,
+        "get_config_class",
+        staticmethod(lambda _provider_type: (lambda **_cfg: None)),
+    )
+    monkeypatch.setattr(
+        validate_command_module.PresentationBuilder,
+        "_build_slide",
+        staticmethod(lambda _spec: None),
+    )
+
+    class FakeLoader:
+        def __init__(self, yaml_path: Path, registry_paths):
+            self.config = _minimal_loader_config()
+
+    monkeypatch.setattr(validate_command_module, "ConfigLoader", FakeLoader)
+
+    config_file = tmp_path / "config.yaml"
+    output_file = tmp_path / "validate-powerpoint-contract-failed.json"
+    config_file.write_text(
+        "provider:\n"
+        "  type: powerpoint\n"
+        "  config:\n"
+        f"    template_path: {template_path}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n"
+    )
+
+    with pytest.raises(validate_command_module.typer.Exit) as exc_info:
+        validate_command_module.validate_command(
+            config_file=config_file,
+            registry_paths=None,
+            output_json=output_file,
+            params_path=None,
+            provider_contract_check=True,
+        )
+
+    assert exc_info.value.code == 1
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["status"] == "error"
+    assert payload["provider_contract"]["issues"][0]["type"] == "missing_placeholder"
+
+
 def test_validate_provider_contract_check_writes_failure_json(tmp_path, monkeypatch):
     stub_build_validate_cli_output(monkeypatch)
     _force_readonly_auth_failure(monkeypatch)
@@ -1132,7 +1276,7 @@ def test_validate_provider_contract_check_requires_google_provider(
     payload = json.loads(output_file.read_text(encoding="utf-8"))
     assert payload["status"] == "error"
     assert (
-        "provider types 'google_slides' and 'google_docs'"
+        "provider types 'google_slides', 'google_docs', and 'powerpoint'"
         in payload["error"]["message"]
     )
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1043,6 +1043,203 @@ def test_validate_powerpoint_provider_contract_check_success(tmp_path, monkeypat
     assert payload["provider_contract"]["template_ids"] == [str(template_path)]
 
 
+def test_validate_powerpoint_provider_contract_check_uses_params_template_path(
+    tmp_path, monkeypatch
+):
+    pptx_module = pytest.importorskip("pptx")
+    stub_build_validate_cli_output(monkeypatch)
+
+    template_path = tmp_path / "template.pptx"
+    prs = pptx_module.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_textbox(100000, 100000, 3000000, 500000).text = "Hello {{NAME}}"
+    prs.save(template_path)
+
+    slide_spec = types.SimpleNamespace(
+        id="1",
+        replacements=[types.SimpleNamespace(config={"placeholder": "{{NAME}}"})],
+        charts=[],
+    )
+    monkeypatch.setattr(
+        validate_command_module,
+        "PresentationConfig",
+        lambda **_: types.SimpleNamespace(
+            provider=types.SimpleNamespace(
+                type="powerpoint",
+                config={
+                    "template_path": "{template_path}",
+                    "output_dir": str(tmp_path),
+                },
+            ),
+            presentation=types.SimpleNamespace(name="Demo", slides=[slide_spec]),
+        ),
+    )
+    monkeypatch.setattr(
+        validate_command_module.PresentationBuilder,
+        "_build_slide",
+        staticmethod(lambda _spec: None),
+    )
+
+    class FakeLoader:
+        def __init__(self, yaml_path: Path, registry_paths):
+            self.config = _minimal_loader_config()
+
+    monkeypatch.setattr(validate_command_module, "ConfigLoader", FakeLoader)
+
+    config_file = tmp_path / "config.yaml"
+    params_path = tmp_path / "params.csv"
+    output_file = tmp_path / "validate-powerpoint-contract-params.json"
+    config_file.write_text(
+        "provider:\n"
+        "  type: powerpoint\n"
+        "  config:\n"
+        "    template_path: {template_path}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n"
+    )
+    params_path.write_text("template_path\n" f"{template_path}\n")
+
+    validate_command_module.validate_command(
+        config_file=config_file,
+        registry_paths=None,
+        output_json=output_file,
+        params_path=params_path,
+        provider_contract_check=True,
+    )
+
+    payload = json.loads(output_file.read_text(encoding="utf-8"))
+    assert payload["status"] == "success"
+    assert payload["provider_contract"]["template_ids"] == [str(template_path)]
+
+
+def test_validate_powerpoint_provider_config_rejects_misspelled_template_path_param(
+    tmp_path,
+):
+    template_path = tmp_path / "template.pptx"
+    params_path = tmp_path / "params.csv"
+    params_path.write_text("template_path\n" f"{template_path}\n")
+    presentation_config = types.SimpleNamespace(
+        provider=types.SimpleNamespace(
+            type="powerpoint",
+            config={
+                "template_path": "{template_pth}",
+                "output_dir": str(tmp_path),
+            },
+        )
+    )
+
+    with pytest.raises(ValueError, match="template_path must point to a .pptx file"):
+        validate_command_module._validate_provider_specific_config(
+            presentation_config,
+            provider_contract_check=True,
+            params_path=params_path,
+        )
+
+
+def test_validate_powerpoint_provider_config_renders_template_path_params(tmp_path):
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    template_path = templates_dir / "template.pptx"
+    params_path = tmp_path / "params.csv"
+    params_path.write_text("template_dir,template_name\n" f"{templates_dir},template\n")
+    presentation_config = types.SimpleNamespace(
+        provider=types.SimpleNamespace(
+            type="powerpoint",
+            config={
+                "template_path": "{template_dir}/{template_name}.pptx",
+                "output_dir": str(tmp_path),
+            },
+        )
+    )
+
+    validate_command_module._validate_provider_specific_config(
+        presentation_config,
+        provider_contract_check=True,
+        params_path=params_path,
+    )
+
+    assert (
+        validate_command_module._resolve_powerpoint_template_paths_for_contract_check(
+            presentation_config,
+            params_path,
+        )
+        == [template_path]
+    )
+
+
+def test_validate_powerpoint_provider_config_strips_rendered_template_path(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    params_path = tmp_path / "params.csv"
+    params_path.write_text("template_path\n" f" {template_path} \n")
+    presentation_config = types.SimpleNamespace(
+        provider=types.SimpleNamespace(
+            type="powerpoint",
+            config={
+                "template_path": "{template_path}",
+                "output_dir": str(tmp_path),
+            },
+        )
+    )
+
+    validate_command_module._validate_provider_specific_config(
+        presentation_config,
+        provider_contract_check=True,
+        params_path=params_path,
+    )
+
+    assert (
+        validate_command_module._resolve_powerpoint_template_paths_for_contract_check(
+            presentation_config,
+            params_path,
+        )
+        == [template_path]
+    )
+
+
+def test_validate_powerpoint_contract_check_uses_rendered_slide_id_mode(
+    tmp_path,
+):
+    pptx_module = pytest.importorskip("pptx")
+    template_path = tmp_path / "template.pptx"
+    prs = pptx_module.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.shapes.add_textbox(100000, 100000, 3000000, 500000).text = "Hello {{NAME}}"
+    native_slide_id = slide.slide_id
+    prs.save(template_path)
+    params_path = tmp_path / "params.csv"
+    params_path.write_text("template_path,slide_id_mode\n" f"{template_path},index\n")
+    presentation_config = types.SimpleNamespace(
+        provider=types.SimpleNamespace(
+            type="powerpoint",
+            config={
+                "template_path": "{template_path}",
+                "slide_id_mode": "{slide_id_mode}",
+                "output_dir": str(tmp_path),
+            },
+        ),
+        presentation=types.SimpleNamespace(
+            slides=[
+                types.SimpleNamespace(
+                    id=str(native_slide_id),
+                    replacements=[
+                        types.SimpleNamespace(config={"placeholder": "{{NAME}}"})
+                    ],
+                    charts=[],
+                )
+            ]
+        ),
+    )
+
+    summary = validate_command_module._run_powerpoint_provider_contract_check(
+        presentation_config,
+        params_path,
+    )
+
+    assert summary["issues"][0]["type"] == "missing_slide"
+    assert summary["issues"][0]["slide_id"] == str(native_slide_id)
+
+
 def test_validate_powerpoint_provider_contract_check_failure(tmp_path, monkeypatch):
     pptx_module = pytest.importorskip("pptx")
     stub_build_validate_cli_output(monkeypatch)

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -257,6 +257,34 @@ def test_provider_checks_success(monkeypatch, tmp_path):
     assert by_name["provider:quota"]["ok"] is False
 
 
+def test_provider_checks_powerpoint_success(tmp_path):
+    pptx_module = pytest.importorskip("pptx")
+    template_path = tmp_path / "template.pptx"
+    prs = pptx_module.Presentation()
+    prs.slides.add_slide(prs.slide_layouts[6])
+    prs.save(template_path)
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "provider:\n"
+        "  type: powerpoint\n"
+        "  config:\n"
+        f"    template_path: {template_path}\n"
+        f"    output_dir: {tmp_path}\n"
+        "presentation:\n"
+        "  name: Demo\n"
+        "  slides: []\n",
+        encoding="utf-8",
+    )
+
+    checks = doctor_module._provider_checks(config_file, registry_paths=None)
+    by_name = {check["name"]: check for check in checks}
+
+    assert by_name["provider_init"]["ok"] is True
+    assert by_name["provider:python_pptx_import"]["ok"] is True
+    assert by_name["provider:template_path_exists"]["ok"] is True
+
+
 def test_provider_checks_converts_exceptions_to_failed_check(monkeypatch, tmp_path):
     config_file = tmp_path / "config.yaml"
     config_file.write_text("provider: {type: google_slides, config: {}}\n")

--- a/tests/test_powerpoint_provider.py
+++ b/tests/test_powerpoint_provider.py
@@ -1,0 +1,206 @@
+from pathlib import Path
+
+import pytest
+
+from slideflow.presentations.base import Presentation, Slide
+from slideflow.presentations.config import ProviderConfig
+from slideflow.presentations.providers.factory import ProviderFactory
+from slideflow.presentations.providers.powerpoint import (
+    MEMORY_IMAGE_URL_PREFIX,
+    PowerPointProvider,
+    PowerPointProviderConfig,
+)
+from slideflow.utilities.exceptions import ConfigurationError, RenderingError
+
+pptx = pytest.importorskip("pptx")
+PIL_Image = pytest.importorskip("PIL.Image")
+
+
+def _png_bytes(color: str = "red") -> bytes:
+    from io import BytesIO
+
+    stream = BytesIO()
+    PIL_Image.new("RGB", (32, 24), color).save(stream, format="PNG")
+    return stream.getvalue()
+
+
+def _make_template(path: Path) -> tuple[int, int]:
+    prs = pptx.Presentation()
+    blank_layout = prs.slide_layouts[6]
+
+    first_slide = prs.slides.add_slide(blank_layout)
+    textbox = first_slide.shapes.add_textbox(100000, 100000, 3000000, 500000)
+    paragraph = textbox.text_frame.paragraphs[0]
+    paragraph.text = ""
+    paragraph.add_run().text = "{{NA"
+    paragraph.add_run().text = "ME}}"
+
+    table_shape = first_slide.shapes.add_table(1, 1, 100000, 800000, 3000000, 500000)
+    table_shape.table.cell(0, 0).text = "Metric: {{METRIC}}"
+
+    second_slide = prs.slides.add_slide(blank_layout)
+    second_slide.shapes.add_textbox(100000, 100000, 3000000, 500000).text = (
+        "Native {{SECOND}}"
+    )
+    first_native_id = first_slide.slide_id
+    second_native_id = second_slide.slide_id
+
+    prs.save(path)
+    return first_native_id, second_native_id
+
+
+def test_powerpoint_config_rejects_non_pptx_template():
+    with pytest.raises(ValueError, match="template_path must point to a .pptx file"):
+        PowerPointProviderConfig(template_path="template.ppt")
+
+
+def test_powerpoint_provider_factory_registration(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+
+    provider = ProviderFactory.create_provider(
+        ProviderConfig(
+            type="powerpoint",
+            config={"template_path": template_path, "output_dir": tmp_path},
+        )
+    )
+
+    assert isinstance(provider, PowerPointProvider)
+    assert "powerpoint" in ProviderFactory.get_available_providers()
+
+
+def test_powerpoint_provider_replaces_text_in_runs_and_table_cells(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="suffix",
+        )
+    )
+    presentation_id = provider.create_presentation("Deck")
+
+    assert provider.replace_text_in_slide(presentation_id, "1", "{{NAME}}", "Acme") == 1
+    assert (
+        provider.replace_text_in_slide(presentation_id, "1", "{{METRIC}}", "Revenue")
+        == 1
+    )
+
+    slide = provider._resolve_slide(presentation_id, "1")
+    slide_text = "\n".join(
+        paragraph.text
+        for text_frame in provider._iter_text_frames(slide.shapes)
+        for paragraph in text_frame.paragraphs
+    )
+    assert "Acme" in slide_text
+    assert "Revenue" in slide_text
+
+
+def test_powerpoint_provider_resolves_native_slide_ids(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _first_native_id, second_native_id = _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            slide_id_mode="native",
+        )
+    )
+    presentation_id = provider.create_presentation("Deck")
+
+    assert (
+        provider.replace_text_in_slide(
+            presentation_id, str(second_native_id), "{{SECOND}}", "Slide"
+        )
+        == 1
+    )
+    with pytest.raises(RenderingError, match="was not found"):
+        provider.replace_text_in_slide(presentation_id, "2", "{{SECOND}}", "Slide")
+
+
+def test_powerpoint_provider_inserts_memory_chart_and_saves_pptx(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="suffix",
+            share_with=["team@example.com"],
+        )
+    )
+    presentation_id = provider.create_presentation("Deck")
+    image_url, file_id = provider.upload_chart_image(
+        presentation_id, _png_bytes(), "chart.png"
+    )
+
+    assert image_url.startswith(MEMORY_IMAGE_URL_PREFIX)
+    provider.insert_chart_to_slide(presentation_id, "1", image_url, 24, 36, 96, 72)
+    provider.delete_chart_image(file_id)
+    provider.finalize_presentation(presentation_id)
+
+    output_path = Path(presentation_id)
+    assert output_path.is_file()
+    rendered = pptx.Presentation(str(output_path))
+    assert len(rendered.slides[0].shapes) >= 3
+    assert provider.get_presentation_url(presentation_id).startswith("file://")
+
+
+def test_powerpoint_provider_suffixes_existing_output(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    existing_output = tmp_path / "Deck.pptx"
+    existing_output.write_bytes(b"existing")
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="suffix",
+        )
+    )
+
+    presentation_id = provider.create_presentation("Deck")
+
+    assert Path(presentation_id).name == "Deck-1.pptx"
+
+
+def test_powerpoint_provider_fails_on_existing_output_by_default(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    (tmp_path / "Deck.pptx").write_bytes(b"existing")
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+
+    with pytest.raises(ConfigurationError, match="already exists"):
+        provider.create_presentation("Deck")
+
+
+def test_powerpoint_render_smoke_creates_valid_pptx(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="suffix",
+        )
+    )
+    presentation = Presentation(
+        name="Rendered Deck",
+        slides=[
+            Slide(
+                id="1",
+                replacements=[],
+                charts=[],
+            )
+        ],
+        provider=provider,
+    )
+
+    result = presentation.render()
+
+    assert Path(result.presentation_id).is_file()
+    assert result.presentation_url.startswith("file://")
+    assert pptx.Presentation(result.presentation_id).slides

--- a/tests/test_powerpoint_provider.py
+++ b/tests/test_powerpoint_provider.py
@@ -1,3 +1,4 @@
+import stat
 from pathlib import Path
 
 import pytest
@@ -54,6 +55,20 @@ def test_powerpoint_config_rejects_non_pptx_template():
         PowerPointProviderConfig(template_path="template.ppt")
 
 
+def test_powerpoint_config_rejects_unresolved_template_path_param():
+    with pytest.raises(ValueError, match="template_path must point to a .pptx file"):
+        PowerPointProviderConfig(template_path="{template_path}")
+
+
+@pytest.mark.parametrize(
+    "template_path",
+    ["{template_dir}/report.pdf", "templates/{quarter}.ppt"],
+)
+def test_powerpoint_config_rejects_parameterized_static_non_pptx_suffix(template_path):
+    with pytest.raises(ValueError, match="template_path must point to a .pptx file"):
+        PowerPointProviderConfig(template_path=template_path)
+
+
 def test_powerpoint_provider_factory_registration(tmp_path):
     template_path = tmp_path / "template.pptx"
     _make_template(template_path)
@@ -67,6 +82,21 @@ def test_powerpoint_provider_factory_registration(tmp_path):
 
     assert isinstance(provider, PowerPointProvider)
     assert "powerpoint" in ProviderFactory.get_available_providers()
+
+
+def test_powerpoint_provider_preflight_accepts_creatable_nested_output_dir(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path / "missing" / "nested",
+        )
+    )
+
+    checks = dict((name, ok) for name, ok, _detail in provider.run_preflight_checks())
+
+    assert checks["output_dir_writable"] is True
 
 
 def test_powerpoint_provider_replaces_text_in_runs_and_table_cells(tmp_path):
@@ -95,6 +125,68 @@ def test_powerpoint_provider_replaces_text_in_runs_and_table_cells(tmp_path):
     )
     assert "Acme" in slide_text
     assert "Revenue" in slide_text
+
+
+def test_powerpoint_provider_does_not_reprocess_replacement_placeholder_text(
+    tmp_path,
+):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="suffix",
+        )
+    )
+    presentation_id = provider.create_presentation("Deck")
+
+    replacements = provider.replace_text_in_slide(
+        presentation_id, "2", "{{SECOND}}", "{{SECOND}} Inc"
+    )
+
+    slide = provider._resolve_slide(presentation_id, "2")
+    slide_text = "\n".join(
+        paragraph.text
+        for text_frame in provider._iter_text_frames(slide.shapes)
+        for paragraph in text_frame.paragraphs
+    )
+    assert replacements == 1
+    assert "{{SECOND}} Inc" in slide_text
+    assert "{{SECOND}} Inc Inc" not in slide_text
+
+
+def test_powerpoint_provider_replaces_mixed_run_and_split_placeholders(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    prs = pptx.Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    textbox = slide.shapes.add_textbox(100000, 100000, 3000000, 500000)
+    paragraph = textbox.text_frame.paragraphs[0]
+    paragraph.text = ""
+    paragraph.add_run().text = "{{NAME}} and {{NA"
+    paragraph.add_run().text = "ME}}"
+    prs.save(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="suffix",
+        )
+    )
+    presentation_id = provider.create_presentation("Deck")
+
+    replacements = provider.replace_text_in_slide(
+        presentation_id, "1", "{{NAME}}", "Acme"
+    )
+
+    slide = provider._resolve_slide(presentation_id, "1")
+    slide_text = "\n".join(
+        paragraph.text
+        for text_frame in provider._iter_text_frames(slide.shapes)
+        for paragraph in text_frame.paragraphs
+    )
+    assert replacements == 2
+    assert "Acme and Acme" in slide_text
 
 
 def test_powerpoint_provider_resolves_native_slide_ids(tmp_path):
@@ -165,6 +257,126 @@ def test_powerpoint_provider_suffixes_existing_output(tmp_path):
     assert Path(presentation_id).name == "Deck-1.pptx"
 
 
+def test_powerpoint_provider_reserves_suffix_paths_before_finalize(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    first_provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="suffix",
+        )
+    )
+    second_provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="suffix",
+        )
+    )
+
+    first_id = first_provider.create_presentation("Deck")
+    second_id = second_provider.create_presentation("Deck")
+
+    assert Path(first_id).name == "Deck.pptx"
+    assert Path(second_id).name == "Deck-1.pptx"
+    assert not Path(first_id).exists()
+    assert not Path(second_id).exists()
+
+    first_provider.finalize_presentation(first_id)
+    second_provider.finalize_presentation(second_id)
+
+    assert Path(first_id).is_file()
+    assert Path(second_id).is_file()
+
+
+def test_powerpoint_provider_uses_bounded_auxiliary_paths_for_long_names(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+    long_name = "A" * 220
+
+    presentation_id = provider.create_presentation(long_name)
+    lock_files = list(tmp_path.glob(".*.lock"))
+
+    assert len(lock_files) == 1
+    assert len(lock_files[0].name.encode("utf-8")) < 255
+
+    provider.finalize_presentation(presentation_id)
+
+    assert len(Path(presentation_id).name.encode("utf-8")) < 255
+    assert Path(presentation_id).is_file()
+    assert not lock_files[0].exists()
+
+
+def test_powerpoint_provider_fail_strategy_reserves_path_before_finalize(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    first_provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+    second_provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+
+    first_provider.create_presentation("Deck")
+
+    with pytest.raises(ConfigurationError, match="already exists"):
+        second_provider.create_presentation("Deck")
+
+
+def test_powerpoint_provider_releases_reserved_path_on_abort(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    first_provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+    second_provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+
+    first_id = first_provider.create_presentation("Deck")
+
+    assert not Path(first_id).exists()
+    with pytest.raises(ConfigurationError, match="already exists"):
+        second_provider.create_presentation("Deck")
+
+    first_provider.abort_presentation(first_id)
+    second_id = second_provider.create_presentation("Deck")
+
+    assert Path(second_id) == tmp_path / "Deck.pptx"
+
+
+def test_powerpoint_provider_releases_reserved_path_on_template_load_interrupt(
+    tmp_path,
+):
+    class TemplateLoadInterrupted(BaseException):
+        pass
+
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+
+    def interrupt_template_load(_template_path):
+        raise TemplateLoadInterrupted()
+
+    provider._pptx_factory = interrupt_template_load
+
+    with pytest.raises(TemplateLoadInterrupted):
+        provider.create_presentation("Deck")
+
+    retry_provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+    retry_id = retry_provider.create_presentation("Deck")
+
+    assert Path(retry_id) == tmp_path / "Deck.pptx"
+
+
 def test_powerpoint_provider_fails_on_existing_output_by_default(tmp_path):
     template_path = tmp_path / "template.pptx"
     _make_template(template_path)
@@ -175,6 +387,94 @@ def test_powerpoint_provider_fails_on_existing_output_by_default(tmp_path):
 
     with pytest.raises(ConfigurationError, match="already exists"):
         provider.create_presentation("Deck")
+
+
+def test_powerpoint_provider_overwrite_preserves_existing_file_until_finalize(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    output_path = tmp_path / "Deck.pptx"
+    original_bytes = b"existing deck bytes"
+    output_path.write_bytes(original_bytes)
+    output_path.chmod(0o600)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="overwrite",
+        )
+    )
+
+    presentation_id = provider.create_presentation("Deck")
+
+    assert Path(presentation_id) == output_path
+    assert output_path.read_bytes() == original_bytes
+
+    provider.finalize_presentation(presentation_id)
+
+    assert output_path.read_bytes() != original_bytes
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
+    assert pptx.Presentation(str(output_path)).slides
+
+
+def test_powerpoint_provider_applies_existing_mode_before_temp_save(tmp_path):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    output_path = tmp_path / "Deck.pptx"
+    output_path.write_bytes(b"existing deck bytes")
+    output_path.chmod(0o600)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(
+            template_path=template_path,
+            output_dir=tmp_path,
+            file_collision_strategy="overwrite",
+        )
+    )
+    presentation_id = provider.create_presentation("Deck")
+    observed_modes = []
+
+    class FakePresentation:
+        @staticmethod
+        def save(path: str) -> None:
+            temp_path = Path(path)
+            observed_modes.append(stat.S_IMODE(temp_path.stat().st_mode))
+            temp_path.write_bytes(b"updated deck bytes")
+
+    provider._presentations[presentation_id] = FakePresentation()
+
+    provider.finalize_presentation(presentation_id)
+
+    assert observed_modes == [0o600]
+    assert output_path.read_bytes() == b"updated deck bytes"
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o600
+
+
+def test_powerpoint_render_failure_releases_output_reservation(tmp_path, monkeypatch):
+    template_path = tmp_path / "template.pptx"
+    _make_template(template_path)
+    provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+    presentation = Presentation(
+        name="Deck",
+        slides=[Slide(id="1", replacements=[], charts=[])],
+        provider=provider,
+    )
+
+    def fail_finalize(_presentation_id):
+        raise RuntimeError("finalize failed")
+
+    monkeypatch.setattr(provider, "finalize_presentation", fail_finalize)
+
+    with pytest.raises(RuntimeError, match="finalize failed"):
+        presentation.render()
+
+    assert not (tmp_path / "Deck.pptx").exists()
+    retry_provider = PowerPointProvider(
+        PowerPointProviderConfig(template_path=template_path, output_dir=tmp_path)
+    )
+    retry_id = retry_provider.create_presentation("Deck")
+
+    assert Path(retry_id) == tmp_path / "Deck.pptx"
 
 
 def test_powerpoint_render_smoke_creates_valid_pptx(tmp_path):

--- a/tests/test_presentation_render.py
+++ b/tests/test_presentation_render.py
@@ -44,6 +44,9 @@ class FakeProvider:
         self.page_size = None
         self.preflight_checks = []
         self.finalize_calls = []
+        self.abort_calls = []
+        self.fail_finalize = False
+        self.fail_page_size = False
 
     def create_presentation(self, _name):
         return "presentation-1"
@@ -88,6 +91,8 @@ class FakeProvider:
             raise RuntimeError("cleanup failed")
 
     def get_presentation_page_size(self, _presentation_id):
+        if self.fail_page_size:
+            raise RuntimeError("page size failed")
         return self.page_size
 
     def run_preflight_checks(self):
@@ -95,6 +100,11 @@ class FakeProvider:
 
     def finalize_presentation(self, presentation_id):
         self.finalize_calls.append(presentation_id)
+        if self.fail_finalize:
+            raise RuntimeError("finalize failed")
+
+    def abort_presentation(self, presentation_id):
+        self.abort_calls.append(presentation_id)
 
 
 def _build_presentation(provider):
@@ -184,6 +194,46 @@ def test_render_fails_fast_when_provider_preflight_fails():
 
     with pytest.raises(RenderingError, match="Provider preflight checks failed"):
         presentation.render()
+
+
+def test_render_aborts_provider_on_failure_after_creation():
+    provider = FakeProvider(strict_cleanup=False, fail_cleanup=False)
+    provider.fail_finalize = True
+    presentation, _chart = _build_presentation(provider)
+
+    with pytest.raises(RuntimeError, match="finalize failed"):
+        presentation.render()
+
+    assert provider.abort_calls == ["presentation-1"]
+
+
+def test_render_aborts_provider_when_context_creation_fails_after_creation():
+    provider = FakeProvider(strict_cleanup=False, fail_cleanup=False)
+    provider.fail_page_size = True
+    presentation, _chart = _build_presentation(provider)
+
+    with pytest.raises(RuntimeError, match="page size failed"):
+        presentation.render()
+
+    assert provider.abort_calls == ["presentation-1"]
+
+
+def test_render_aborts_provider_on_base_exception_after_creation():
+    class RenderInterrupted(BaseException):
+        pass
+
+    class InterruptedProvider(FakeProvider):
+        def finalize_presentation(self, presentation_id):
+            self.finalize_calls.append(presentation_id)
+            raise RenderInterrupted()
+
+    provider = InterruptedProvider(strict_cleanup=False, fail_cleanup=False)
+    presentation, _chart = _build_presentation(provider)
+
+    with pytest.raises(RenderInterrupted):
+        presentation.render()
+
+    assert provider.abort_calls == ["presentation-1"]
 
 
 def test_render_transfers_ownership_when_configured():

--- a/uv.lock
+++ b/uv.lock
@@ -2462,6 +2462,75 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "pip"
 version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2966,6 +3035,21 @@ wheels = [
 ]
 
 [[package]]
+name = "python-pptx"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "pillow" },
+    { name = "typing-extensions" },
+    { name = "xlsxwriter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+]
+
+[[package]]
 name = "python-slugify"
 version = "8.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3412,6 +3496,9 @@ duckdb = [
     { name = "dbt-duckdb" },
     { name = "duckdb" },
 ]
+powerpoint = [
+    { name = "python-pptx" },
+]
 redshift = [
     { name = "dbt-redshift" },
     { name = "redshift-connector" },
@@ -3453,6 +3540,7 @@ requires-dist = [
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.3" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "python-pptx", marker = "extra == 'powerpoint'", specifier = ">=1.0.0,<2.0" },
     { name = "pyyaml", specifier = ">=6.0.3,<7.0" },
     { name = "redshift-connector", marker = "extra == 'redshift'", specifier = ">=2.1.8,<2.2" },
     { name = "rich", specifier = ">=13.0,<15.0" },
@@ -3460,7 +3548,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.24,<1.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
 ]
-provides-extras = ["ai", "databricks", "dbt", "bigquery", "duckdb", "redshift", "docs", "dev"]
+provides-extras = ["ai", "databricks", "dbt", "bigquery", "duckdb", "redshift", "powerpoint", "docs", "dev"]
 
 [[package]]
 name = "smmap"
@@ -3771,6 +3859,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `provider.type: powerpoint` with native local `.pptx` output via optional `python-pptx` extra.
- Support template-based deck creation, one-based/native slide ID resolution, text replacement across runs and table cells, in-memory chart image insertion, local file URL reporting, no-op sharing warnings, page-size lookup, cleanup, and provider preflight checks.
- Extend `slideflow validate --provider-contract-check` for local PowerPoint templates and update docs/CI/lockfile for the new `powerpoint` extra.

## Verification
- `uv run python -m pytest -q tests/test_powerpoint_provider.py tests/test_cli_commands.py tests/test_cli_doctor.py`
- `uv run python -m pytest -q -m "not integration and not e2e" --cov=slideflow --cov-branch --cov-report=term --cov-fail-under=82`
- `uv run python -m pytest -q -m integration`
- `uv run python -m pytest -q -m e2e`
- `uv sync --extra docs --extra dev --extra ai --extra databricks --extra dbt --extra bigquery --extra duckdb --extra redshift --extra powerpoint --locked`
- `uv lock --check && uv pip check`
- `uvx --from black==26.3.1 black --check slideflow tests scripts`
- `uv run python -m ruff check slideflow tests scripts`
- `uv run python -m mypy slideflow`
- `uv run mkdocs build --strict`
- `actionlint .github/workflows/ci.yml .github/workflows/audit.yml .github/workflows/release.yml .github/workflows/docs.yml .github/workflows/reusable-slideflow-build.yml`
- `uv run python -m pytest -q tests/test_bigquery_connector.py tests/test_duckdb_connector.py tests/test_redshift_connector.py tests/test_connectors_and_providers_unit.py tests/test_dbt_sanitization.py tests/test_powerpoint_provider.py`
- `uv run pip-audit --progress-spinner off`

Closes #103
Linear: JOE-367
