### PR TITLE
Optimize dbt compilation across vars

### DIFF
--- a/.github/dependency-audit-exceptions.json
+++ b/.github/dependency-audit-exceptions.json
@@ -1,0 +1,26 @@
+[
+  {
+    "package": "sqlparse",
+    "vulnerability": "CVE-2026-71491",
+    "expires": "2026-11-18",
+    "reason": "dbt-core 1.11 and 1.12 require sqlparse<0.6.0; dbt projects are trusted executable inputs"
+  },
+  {
+    "package": "sqlparse",
+    "vulnerability": "CVE-2026-59894",
+    "expires": "2026-11-18",
+    "reason": "dbt-core 1.11 and 1.12 require sqlparse<0.6.0; SlideFlow does not use sqlparse output-language generation"
+  },
+  {
+    "package": "sqlparse",
+    "vulnerability": "CVE-2026-59893",
+    "expires": "2026-11-18",
+    "reason": "dbt-core 1.11 and 1.12 require sqlparse<0.6.0; dbt projects are trusted executable inputs"
+  },
+  {
+    "package": "sqlparse",
+    "vulnerability": "CVE-2026-54284",
+    "expires": "2026-11-18",
+    "reason": "dbt-core 1.11 and 1.12 require sqlparse<0.6.0; dbt projects are trusted executable inputs"
+  }
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Run pip-audit
         id: pip_audit
         run: |
-          uv run pip-audit --format=json --output pip-audit.json
+          uv run python scripts/ci/run_dependency_audit.py \
+            --format=json --output pip-audit.json
 
       - name: Warn on vulnerabilities
         if: always() && steps.pip_audit.outcome == 'failure'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Run pip-audit
         run: |
-          uv run pip-audit --progress-spinner off
+          uv run python scripts/ci/run_dependency_audit.py --progress-spinner off
 
   static-security:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `target` or `vars` now reuse one clone and dependency installation while
   writing manifests, compiled SQL, and logs to isolated sibling directories
   outside the parsed dbt project. Prepared generations invalidate sibling
-  variants together, cleanup remains lease-safe, and concrete dbt output paths
-  reject symlinks and escaped locations immediately before invocation.
+  variants together, workspace-keyed filesystem locks coordinate active use and
+  cleanup across processes, failed paths remain reserved until cleanup finishes,
+  markers verify the dbt project and Git checkout, lease release re-applies cache
+  bounds, and concrete dbt output paths reject symlinks and escaped locations
+  immediately before invocation.
 - Pandas compatibility now spans `>=2.2,<4.0`, with CI coverage for the oldest
   supported 2.2 release and the latest supported 3.x release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - dbt-backed builds now parse project metadata and compile only the exact,
   deduplicated models required by an artifact. Sources that differ only by
   `target` or `vars` now reuse one clone and dependency installation while
-  writing manifests, compiled SQL, and logs to isolated variant directories.
+  writing manifests, compiled SQL, and logs to isolated sibling directories
+  outside the parsed dbt project. Managed paths reject symlinks and escaped
+  locations before dbt runs.
 - Pandas compatibility now spans `>=2.2,<4.0`, with CI coverage for the oldest
   supported 2.2 release and the latest supported 3.x release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   deduplicated models required by an artifact. Sources that differ only by
   `target` or `vars` now reuse one clone and dependency installation while
   writing manifests, compiled SQL, and logs to isolated sibling directories
-  outside the parsed dbt project. Managed paths reject symlinks and escaped
-  locations before dbt runs.
+  outside the parsed dbt project. Prepared generations invalidate sibling
+  variants together, cleanup remains lease-safe, and concrete dbt output paths
+  reject symlinks and escaped locations immediately before invocation.
 - Pandas compatibility now spans `>=2.2,<4.0`, with CI coverage for the oldest
   supported 2.2 release and the latest supported 3.x release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 - dbt-backed builds now parse project metadata and compile only the exact,
-  deduplicated models required by an artifact, while reusing one clone and
-  dependency installation per project identity.
+  deduplicated models required by an artifact. Sources that differ only by
+  `target` or `vars` now reuse one clone and dependency installation while
+  writing manifests, compiled SQL, and logs to isolated variant directories.
 - Pandas compatibility now spans `>=2.2,<4.0`, with CI coverage for the oldest
   supported 2.2 release and the latest supported 3.x release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   cleanup across processes, failed paths remain reserved until cleanup finishes,
   markers verify the dbt project and Git checkout, lease release re-applies cache
   bounds, and concrete dbt output paths reject symlinks and escaped locations
-  immediately before invocation.
+  immediately before invocation. Model lookup now prefers target-invariant
+  manifest names while preserving compiled aliases as a compatibility fallback;
+  scoped selectors intersect package, resource type, and FQN, and unsafe
+  selector metadata falls back to a full variant compile.
 - Pandas compatibility now spans `>=2.2,<4.0`, with CI coverage for the oldest
   supported 2.2 release and the latest supported 3.x release.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -496,12 +496,16 @@ sharing the same repository, branch, workspace, and profile inputs. Every unique
 and compiles its requested aliases as one exact `dbt compile --select` batch.
 Artifact directories live under `project_dir/.slideflow_dbt_targets`, outside
 the cloned project, so even broad dbt model paths cannot rediscover generated
-SQL. SlideFlow marks each successfully prepared clone as one generation; a
-missing or altered clone invalidates every sibling artifact variant before the
-workspace is prepared again. Concrete target and log paths are required to be
-contained, non-symlink directories immediately before dbt runs. dbt still
-parses the full project; scoped compilation does not build or refresh upstream
-relations and does not add ancestor `+` selectors. Set
+SQL. A workspace-keyed lock under `project_dir/.slideflow_dbt_locks` prevents
+other SlideFlow processes from preparing, using, or cleaning the same physical
+workspace concurrently. SlideFlow marks each successfully prepared clone as one
+generation; cache hits require a real dbt project, the recorded Git checkout,
+and the original in-memory generation. A missing or altered clone invalidates
+every sibling artifact variant before the workspace is prepared again.
+Concrete target and log paths are required to be contained, non-symlink
+directories immediately before dbt runs. dbt still parses the full project;
+scoped compilation does not build or refresh upstream relations and does not
+add ancestor `+` selectors. Set
 `dbt.compile: false` only when `dbt.project_dir` already points at a compiled dbt
 project with `target/manifest.json` and the compiled SQL files referenced by that
 manifest; SlideFlow will not clone or invoke dbt in that mode.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -510,7 +510,8 @@ add ancestor `+` selectors. Set
 project with `target/manifest.json` and the compiled SQL files referenced by that
 manifest; SlideFlow will not clone or invoke dbt in that mode.
 
-Optional alias disambiguation fields for `dbt`:
+`model_alias` accepts a stable manifest node name (preferred) or a legacy
+compiled alias. Optional disambiguation fields for `dbt`:
 
 - `model_unique_id` (most specific)
 - `model_package_name`

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -496,8 +496,12 @@ sharing the same repository, branch, workspace, and profile inputs. Every unique
 and compiles its requested aliases as one exact `dbt compile --select` batch.
 Artifact directories live under `project_dir/.slideflow_dbt_targets`, outside
 the cloned project, so even broad dbt model paths cannot rediscover generated
-SQL. dbt still parses the full project; scoped compilation does not build or
-refresh upstream relations and does not add ancestor `+` selectors. Set
+SQL. SlideFlow marks each successfully prepared clone as one generation; a
+missing or altered clone invalidates every sibling artifact variant before the
+workspace is prepared again. Concrete target and log paths are required to be
+contained, non-symlink directories immediately before dbt runs. dbt still
+parses the full project; scoped compilation does not build or refresh upstream
+relations and does not add ancestor `+` selectors. Set
 `dbt.compile: false` only when `dbt.project_dir` already points at a compiled dbt
 project with `target/manifest.json` and the compiled SQL files referenced by that
 manifest; SlideFlow will not clone or invoke dbt in that mode.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -494,8 +494,10 @@ warehouse:
 sharing the same repository, branch, workspace, and profile inputs. Every unique
 `target`/`vars` combination gets an isolated artifact directory, is parsed once,
 and compiles its requested aliases as one exact `dbt compile --select` batch.
-dbt still parses the full project; scoped compilation does not build or refresh
-upstream relations and does not add ancestor `+` selectors. Set
+Artifact directories live under `project_dir/.slideflow_dbt_targets`, outside
+the cloned project, so even broad dbt model paths cannot rediscover generated
+SQL. dbt still parses the full project; scoped compilation does not build or
+refresh upstream relations and does not add ancestor `+` selectors. Set
 `dbt.compile: false` only when `dbt.project_dir` already points at a compiled dbt
 project with `target/manifest.json` and the compiled SQL files referenced by that
 manifest; SlideFlow will not clone or invoke dbt in that mode.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -490,15 +490,15 @@ warehouse:
   type: "databricks"
 ```
 
-`dbt.compile: true` clones the repository, runs `dbt deps`, parses the project,
-resolves requested aliases to exact dbt nodes, and compiles the required nodes
-with one bounded `dbt compile --select` invocation per project batch. dbt still
-parses the full project; scoped compilation does not build or refresh upstream
-relations and does not add ancestor `+` selectors. Set `dbt.compile: false` only
-when `dbt.project_dir` already
-points at a compiled dbt project with `target/manifest.json` and the compiled
-SQL files referenced by that manifest; SlideFlow will not clone or invoke dbt in
-that mode.
+`dbt.compile: true` clones the repository and runs `dbt deps` once for sources
+sharing the same repository, branch, workspace, and profile inputs. Every unique
+`target`/`vars` combination gets an isolated artifact directory, is parsed once,
+and compiles its requested aliases as one exact `dbt compile --select` batch.
+dbt still parses the full project; scoped compilation does not build or refresh
+upstream relations and does not add ancestor `+` selectors. Set
+`dbt.compile: false` only when `dbt.project_dir` already points at a compiled dbt
+project with `target/manifest.json` and the compiled SQL files referenced by that
+manifest; SlideFlow will not clone or invoke dbt in that mode.
 
 Optional alias disambiguation fields for `dbt`:
 

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -255,7 +255,13 @@ Behavior highlights:
   broad model paths such as `model-paths: ['.']`.
 - Managed artifact paths must be real contained directories. SlideFlow rejects
   symlinks, non-directory collisions, and paths that resolve outside their
-  expected workspace before invoking dbt.
+  expected workspace. The concrete deps log, variant target, and variant log
+  paths are revalidated immediately before every dbt invocation.
+- A private preparation marker is written after clone and `dbt deps` complete.
+  If the clone or marker is removed or changed, every cached target/vars variant
+  for that shared workspace is invalidated and rebuilt from one new generation.
+- Evicted paths remain reserved until lease-safe cleanup finishes, preventing a
+  concurrent request from recreating a directory that cleanup could later delete.
 - `project_dir` is treated as a workspace root, not a direct clone target.
 - Default `compile: true` runs `dbt deps`, parses the full project, resolves
   exact requested nodes, and runs one scoped `dbt compile --select` for the

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -246,6 +246,11 @@ data_source:
 Behavior highlights:
 
 - Repositories are cloned under `project_dir/.slideflow_dbt_clones/<key>`.
+- The clone key covers repository, branch, and profile inputs. `target` and
+  `vars` do not trigger another clone or `dbt deps` run.
+- Each unique `target`/`vars` combination writes to an isolated
+  `.slideflow_dbt_targets/<key>` directory inside the shared clone, preventing
+  one compile from overwriting another variant's manifest or compiled SQL.
 - `project_dir` is treated as a workspace root, not a direct clone target.
 - Default `compile: true` runs `dbt deps`, parses the full project, resolves
   exact requested nodes, and runs one scoped `dbt compile --select` for the
@@ -258,9 +263,12 @@ Behavior highlights:
   workspace and runs dbt with `--profiles-dir <clone_dir>`.
 - If `profiles_dir` is omitted but the cloned repo contains `profiles.yml` at
   project root, SlideFlow auto-uses that project-root profiles file.
-- Clone/dependency/parse work for identical project identities is deduplicated.
-  Compiled selector coverage expands as a sorted union, so cached supersets
-  satisfy later subset requests without recompiling.
+- Clone/dependency work is single-flight across variants. Each variant is parsed
+  once, and all requested analyses/models for that variant are compiled as one
+  sorted, deduplicated selector batch. Cached supersets satisfy later subset
+  requests without recompiling.
+- In-process dbt invocations are serialized because dbt-core maintains process
+  globals; warehouse queries remain governed separately by `query_threads`.
 - If multiple dbt nodes share `model_alias`, set one of:
   - `model_unique_id`
   - `model_package_name`
@@ -404,7 +412,8 @@ disabled.
 Cache/compile tuning env vars:
 
 - `SLIDEFLOW_DATA_CACHE_MAX_ENTRIES` (global source cache cap)
-- `SLIDEFLOW_DBT_CACHE_MAX_ENTRIES` (default from built-in constants)
+- `SLIDEFLOW_DBT_CACHE_MAX_ENTRIES` (bounds compiled variants and inactive
+  prepared workspaces; default from built-in constants)
 - `SLIDEFLOW_DBT_COMPILE_FAILURE_BACKOFF_S`
 - `SLIDEFLOW_DBT_FAILURE_CACHE_MAX_ENTRIES`
 

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -287,7 +287,9 @@ Behavior highlights:
   requests without recompiling.
 - In-process dbt invocations are serialized because dbt-core maintains process
   globals; warehouse queries remain governed separately by `query_threads`.
-- If multiple dbt nodes share `model_alias`, set one of:
+- `model_alias` resolves a target-invariant manifest `name` first and retains
+  compiled `alias` as a compatibility fallback. If the identifier is
+  ambiguous, set one of:
   - `model_unique_id`
   - `model_package_name`
   - `model_selector_name`

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -253,15 +253,22 @@ Behavior highlights:
   This sibling tree prevents variants from overwriting each other and keeps
   generated SQL outside the parsed dbt project, including for projects with
   broad model paths such as `model-paths: ['.']`.
+- A workspace-keyed filesystem lock under `project_dir/.slideflow_dbt_locks`
+  coordinates preparation, active artifact use, and cleanup across SlideFlow
+  processes. Threads in one process still share the existing lease and
+  single-flight coordination.
 - Managed artifact paths must be real contained directories. SlideFlow rejects
   symlinks, non-directory collisions, and paths that resolve outside their
   expected workspace. The concrete deps log, variant target, and variant log
   paths are revalidated immediately before every dbt invocation.
 - A private preparation marker is written after clone and `dbt deps` complete.
-  If the clone or marker is removed or changed, every cached target/vars variant
-  for that shared workspace is invalidated and rebuilt from one new generation.
+  Cache hits require a real `dbt_project.yml`, the same checked-out Git commit,
+  and the in-memory generation originally recorded for the marker. If any of
+  those values or the clone changes, every cached target/vars variant for that
+  shared workspace is invalidated and rebuilt from one new generation.
 - Evicted paths remain reserved until lease-safe cleanup finishes, preventing a
   concurrent request from recreating a directory that cleanup could later delete.
+  Cache bounds are checked again when active leases release.
 - `project_dir` is treated as a workspace root, not a direct clone target.
 - Default `compile: true` runs `dbt deps`, parses the full project, resolves
   exact requested nodes, and runs one scoped `dbt compile --select` for the

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -249,8 +249,13 @@ Behavior highlights:
 - The clone key covers repository, branch, and profile inputs. `target` and
   `vars` do not trigger another clone or `dbt deps` run.
 - Each unique `target`/`vars` combination writes to an isolated
-  `.slideflow_dbt_targets/<key>` directory inside the shared clone, preventing
-  one compile from overwriting another variant's manifest or compiled SQL.
+  `project_dir/.slideflow_dbt_targets/<workspace-key>/<variant-key>` directory.
+  This sibling tree prevents variants from overwriting each other and keeps
+  generated SQL outside the parsed dbt project, including for projects with
+  broad model paths such as `model-paths: ['.']`.
+- Managed artifact paths must be real contained directories. SlideFlow rejects
+  symlinks, non-directory collisions, and paths that resolve outside their
+  expected workspace before invoking dbt.
 - `project_dir` is treated as a workspace root, not a direct clone target.
 - Default `compile: true` runs `dbt deps`, parses the full project, resolves
   exact requested nodes, and runs one scoped `dbt compile --select` for the
@@ -412,8 +417,9 @@ disabled.
 Cache/compile tuning env vars:
 
 - `SLIDEFLOW_DATA_CACHE_MAX_ENTRIES` (global source cache cap)
-- `SLIDEFLOW_DBT_CACHE_MAX_ENTRIES` (bounds compiled variants and inactive
-  prepared workspaces; default from built-in constants)
+- `SLIDEFLOW_DBT_CACHE_MAX_ENTRIES` (bounds compiled variants under
+  `.slideflow_dbt_targets` and inactive prepared workspaces under
+  `.slideflow_dbt_clones`; default from built-in constants)
 - `SLIDEFLOW_DBT_COMPILE_FAILURE_BACKOFF_S`
 - `SLIDEFLOW_DBT_FAILURE_CACHE_MAX_ENTRIES`
 

--- a/docs/dbt-migration.md
+++ b/docs/dbt-migration.md
@@ -75,8 +75,10 @@ data_source:
 
 ## Alias Ambiguity and Disambiguation
 
-If multiple dbt nodes share the same alias, SlideFlow now raises an explicit
-ambiguity error and asks you to disambiguate.
+SlideFlow resolves the configured identifier by stable manifest node name
+before falling back to compiled alias. If name and alias identify different
+nodes, or multiple nodes still match, SlideFlow raises an explicit ambiguity
+error and asks you to disambiguate.
 
 Available selectors:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -101,6 +101,8 @@ Common causes:
 - profile/target mismatch during dbt compile
 - a stale or externally deleted directory under `.slideflow_dbt_clones` or
   `.slideflow_dbt_targets`
+- a symlink or non-directory occupying a reserved path under
+  `.slideflow_dbt_targets`
 
 Frequent CI symptom:
 
@@ -124,6 +126,8 @@ Fixes:
 - keep sources that should share clone/dependency work on the same `project_dir`,
   `package_url`, branch, profiles path, and profile name. Different `vars` and
   targets are isolated automatically and do not require separate workspaces.
+- remove unexpected symlinks or files from `.slideflow_dbt_targets`; SlideFlow
+  intentionally fails closed rather than passing redirected paths to dbt.
 
 For private dbt deps/repo access, ensure token env vars referenced by
 `package_url` or `env_var(...)` are present at runtime.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,7 +137,8 @@ Fixes:
 For private dbt deps/repo access, ensure token env vars referenced by
 `package_url` or `env_var(...)` are present at runtime.
 
-If alias ambiguity occurs, add one of these selectors in your source config:
+`model_alias` prefers the stable manifest node name and supports compiled aliases
+for compatibility. If identifier ambiguity occurs, add one of these selectors:
 
 - `model_unique_id` (most specific)
 - `model_package_name`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -99,6 +99,8 @@ Common causes:
   region/cluster/serverless identity settings when using `warehouse.type: redshift`
 - invalid `package_url` or missing token env var used in URL
 - profile/target mismatch during dbt compile
+- a stale or externally deleted directory under `.slideflow_dbt_clones` or
+  `.slideflow_dbt_targets`
 
 Frequent CI symptom:
 
@@ -119,6 +121,9 @@ Fixes:
   `target/manifest.json` references an existing compiled SQL file.
 - use `model_unique_id`, `model_package_name`, or `model_selector_name` when an
   alias is ambiguous; SlideFlow converts the resolved node to an exact selector.
+- keep sources that should share clone/dependency work on the same `project_dir`,
+  `package_url`, branch, profiles path, and profile name. Different `vars` and
+  targets are isolated automatically and do not require separate workspaces.
 
 For private dbt deps/repo access, ensure token env vars referenced by
 `package_url` or `env_var(...)` are present at runtime.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,7 +102,7 @@ Common causes:
 - a stale or externally deleted directory under `.slideflow_dbt_clones` or
   `.slideflow_dbt_targets`
 - a symlink or non-directory occupying a reserved clone, target, or log path,
-  including `.slideflow_dbt_logs`
+  including `.slideflow_dbt_logs` or `.slideflow_dbt_locks`
 
 Frequent CI symptom:
 
@@ -127,10 +127,12 @@ Fixes:
   `package_url`, branch, profiles path, and profile name. Different `vars` and
   targets are isolated automatically and do not require separate workspaces.
 - remove unexpected symlinks or files from `.slideflow_dbt_clones`,
-  `.slideflow_dbt_targets`, or `.slideflow_dbt_logs`; SlideFlow intentionally
-  fails closed rather than passing redirected paths to dbt. Do not modify the
-  private `.slideflow-prepared.json` clone marker; a missing or mismatched marker
-  invalidates every cached variant for that shared workspace.
+  `.slideflow_dbt_targets`, `.slideflow_dbt_logs`, or `.slideflow_dbt_locks`;
+  SlideFlow intentionally fails closed rather than passing redirected paths to
+  dbt or using an unsafe coordination file. Do not modify the private
+  `.slideflow-prepared.json` clone marker or the prepared Git checkout; a
+  missing project file, checkout mismatch, or marker mismatch invalidates every
+  cached variant for that shared workspace.
 
 For private dbt deps/repo access, ensure token env vars referenced by
 `package_url` or `env_var(...)` are present at runtime.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -101,8 +101,8 @@ Common causes:
 - profile/target mismatch during dbt compile
 - a stale or externally deleted directory under `.slideflow_dbt_clones` or
   `.slideflow_dbt_targets`
-- a symlink or non-directory occupying a reserved path under
-  `.slideflow_dbt_targets`
+- a symlink or non-directory occupying a reserved clone, target, or log path,
+  including `.slideflow_dbt_logs`
 
 Frequent CI symptom:
 
@@ -126,8 +126,11 @@ Fixes:
 - keep sources that should share clone/dependency work on the same `project_dir`,
   `package_url`, branch, profiles path, and profile name. Different `vars` and
   targets are isolated automatically and do not require separate workspaces.
-- remove unexpected symlinks or files from `.slideflow_dbt_targets`; SlideFlow
-  intentionally fails closed rather than passing redirected paths to dbt.
+- remove unexpected symlinks or files from `.slideflow_dbt_clones`,
+  `.slideflow_dbt_targets`, or `.slideflow_dbt_logs`; SlideFlow intentionally
+  fails closed rather than passing redirected paths to dbt. Do not modify the
+  private `.slideflow-prepared.json` clone marker; a missing or mismatched marker
+  invalidates every cached variant for that shared workspace.
 
 For private dbt deps/repo access, ensure token env vars referenced by
 `package_url` or `env_var(...)` are present at runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,12 @@ Changelog = "https://github.com/joe-broadhead/slideflow/blob/master/CHANGELOG.md
 [project.optional-dependencies]
 ai = ["openai>=2.50.0,<3.0", "google-genai>=1.0,<3.0"]
 databricks = ["databricks-sql-connector>=4.0,<5.0"]
-dbt = ["dbt-core>=1.10,<1.12", "dbt-databricks>=1.10,<1.13", "gitpython>=3.1.58,<4.0"]
+dbt = [
+    "dbt-core>=1.10,<1.12",
+    "dbt-databricks>=1.10,<1.13",
+    "filelock>=3.20,<4.0",
+    "gitpython>=3.1.58,<4.0",
+]
 bigquery = ["google-cloud-bigquery>=3.42.2,<4.0", "dbt-bigquery>=1.11.1,<1.12"]
 duckdb = ["duckdb>=1.5.3,<2.0", "dbt-duckdb>=1.9,<1.12"]
 redshift = ["redshift-connector>=2.1.15,<2.2", "dbt-redshift>=1.10,<1.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ databricks = ["databricks-sql-connector>=4.0,<5.0"]
 dbt = [
     "dbt-core>=1.10,<1.12",
     "dbt-databricks>=1.10,<1.13",
-    "filelock>=3.20,<4.0",
+    "filelock>=3.20.1,<4.0",
     "gitpython>=3.1.58,<4.0",
 ]
 bigquery = ["google-cloud-bigquery>=3.42.2,<4.0", "dbt-bigquery>=1.11.1,<1.12"]
@@ -66,7 +66,7 @@ docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.6",
     "mkdocs-minify-plugin>=0.8",
-    "pymdown-extensions>=11.0",
+    "pymdown-extensions>=11.0.1",
 ]
 dev = [
     "pytest",

--- a/scripts/ci/run_dependency_audit.py
+++ b/scripts/ci/run_dependency_audit.py
@@ -1,23 +1,53 @@
-"""Run pip-audit with bounded, expiring dependency exceptions."""
+"""Run pip-audit with bounded, auditable dependency exceptions."""
 
 from __future__ import annotations
 
 import datetime as dt
 import json
+import re
 import subprocess
 import sys
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Sequence
 
 
-def main() -> int:
-    root = Path(__file__).resolve().parents[2]
-    policy_path = root / ".github" / "dependency-audit-exceptions.json"
-    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+@dataclass(frozen=True)
+class AuditException:
+    package: str
+    vulnerability: str
+    reason: str
+    expires: dt.date
+
+    def metadata(self) -> dict[str, str]:
+        return {
+            "package": self.package,
+            "vulnerability": self.vulnerability,
+            "reason": self.reason,
+            "expires": self.expires.isoformat(),
+        }
+
+
+def _canonicalize_package_name(package: str) -> str:
+    """Normalize a Python distribution name using the package-index rules."""
+    return re.sub(r"[-_.]+", "-", package).lower()
+
+
+def _load_policy(
+    policy_path: Path, *, today: dt.date | None = None
+) -> dict[tuple[str, str], AuditException]:
+    try:
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(
+            f"dependency audit exception policy is invalid: {error}"
+        ) from error
     if not isinstance(policy, list):
         raise SystemExit("dependency audit exception policy must be a JSON list")
 
-    today = dt.date.today()
-    ignored: list[str] = []
+    current_date = today or dt.date.today()
+    exceptions: dict[tuple[str, str], AuditException] = {}
     for entry in policy:
         if not isinstance(entry, dict):
             raise SystemExit("dependency audit exception entries must be objects")
@@ -34,16 +64,207 @@ def main() -> int:
             raise SystemExit("dependency audit exception is missing package")
         if not isinstance(reason, str) or not reason:
             raise SystemExit("dependency audit exception is missing required metadata")
-        if today > expires:
+        if current_date > expires:
             raise SystemExit(
                 f"dependency audit exception expired for {package} {vulnerability}"
             )
-        ignored.append(vulnerability)
 
-    command = [sys.executable, "-m", "pip_audit", *sys.argv[1:]]
-    for vulnerability in ignored:
-        command.extend(["--ignore-vuln", vulnerability])
-    return subprocess.run(command, check=False).returncode
+        exception = AuditException(
+            package=package,
+            vulnerability=vulnerability,
+            reason=reason,
+            expires=expires,
+        )
+        key = (_canonicalize_package_name(package), vulnerability.casefold())
+        if key in exceptions:
+            raise SystemExit(
+                f"duplicate dependency audit exception for {package} {vulnerability}"
+            )
+        exceptions[key] = exception
+    return exceptions
+
+
+def _extract_wrapper_args(args: Sequence[str]) -> tuple[list[str], Path | None]:
+    forwarded: list[str] = []
+    output_path: Path | None = None
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in {"--output", "-o"}:
+            if index + 1 >= len(args):
+                raise SystemExit(f"{arg} requires a path")
+            if output_path is not None:
+                raise SystemExit("dependency audit output may only be specified once")
+            output_path = Path(args[index + 1])
+            index += 2
+            continue
+        if arg.startswith("--output="):
+            if output_path is not None:
+                raise SystemExit("dependency audit output may only be specified once")
+            output_path = Path(arg.split("=", 1)[1])
+            index += 1
+            continue
+        if arg in {"--format", "-f"}:
+            if index + 1 >= len(args):
+                raise SystemExit(f"{arg} requires a format")
+            if args[index + 1] != "json":
+                raise SystemExit("dependency audit wrapper only supports JSON output")
+            index += 2
+            continue
+        if arg.startswith("--format="):
+            if arg.split("=", 1)[1] != "json":
+                raise SystemExit("dependency audit wrapper only supports JSON output")
+            index += 1
+            continue
+        if arg == "--ignore-vuln" or arg.startswith("--ignore-vuln="):
+            raise SystemExit(
+                "dependency audit exceptions must be declared in the policy"
+            )
+        forwarded.append(arg)
+        index += 1
+    return forwarded, output_path
+
+
+def _validate_vulnerability_ids(vulnerability: dict[str, Any]) -> list[str]:
+    vulnerability_id = vulnerability.get("id")
+    aliases = vulnerability.get("aliases", [])
+    if not isinstance(vulnerability_id, str) or not vulnerability_id:
+        raise SystemExit("pip-audit JSON contains a vulnerability without an id")
+    if not isinstance(aliases, list) or not all(
+        isinstance(alias, str) and alias for alias in aliases
+    ):
+        raise SystemExit("pip-audit JSON contains invalid vulnerability aliases")
+    return [vulnerability_id, *aliases]
+
+
+def _postprocess_audit(
+    audit: Any,
+    exceptions: dict[tuple[str, str], AuditException],
+) -> tuple[dict[str, Any], int, int]:
+    if not isinstance(audit, dict):
+        raise SystemExit("pip-audit JSON output must be an object")
+    dependencies = audit.get("dependencies")
+    if not isinstance(dependencies, list):
+        raise SystemExit("pip-audit JSON output must contain dependencies")
+
+    active_count = 0
+    suppressed_count = 0
+    enriched_dependencies: list[dict[str, Any]] = []
+    for dependency in dependencies:
+        if not isinstance(dependency, dict):
+            raise SystemExit("pip-audit JSON contains an invalid dependency")
+        enriched_dependency = dict(dependency)
+        vulnerabilities = dependency.get("vulns", [])
+        if not isinstance(vulnerabilities, list):
+            raise SystemExit("pip-audit JSON contains invalid vulnerabilities")
+
+        package = dependency.get("name")
+        if vulnerabilities and (not isinstance(package, str) or not package):
+            raise SystemExit(
+                "pip-audit JSON contains a vulnerable package without a name"
+            )
+        canonical_package = (
+            _canonicalize_package_name(package) if isinstance(package, str) else ""
+        )
+
+        enriched_vulnerabilities: list[dict[str, Any]] = []
+        for vulnerability in vulnerabilities:
+            if not isinstance(vulnerability, dict):
+                raise SystemExit("pip-audit JSON contains an invalid vulnerability")
+            vulnerability_ids = _validate_vulnerability_ids(vulnerability)
+            matches = {
+                exceptions[(canonical_package, identifier.casefold())]
+                for identifier in vulnerability_ids
+                if (canonical_package, identifier.casefold()) in exceptions
+            }
+            if len(matches) > 1:
+                raise SystemExit(
+                    f"multiple dependency audit exceptions match {package} "
+                    f"{vulnerability_ids[0]}"
+                )
+
+            enriched_vulnerability = dict(vulnerability)
+            if matches:
+                exception = next(iter(matches))
+                enriched_vulnerability["status"] = "suppressed"
+                enriched_vulnerability["suppression"] = exception.metadata()
+                suppressed_count += 1
+            else:
+                enriched_vulnerability["status"] = "active"
+                active_count += 1
+            enriched_vulnerabilities.append(enriched_vulnerability)
+        enriched_dependency["vulns"] = enriched_vulnerabilities
+        enriched_dependencies.append(enriched_dependency)
+
+    enriched_audit = dict(audit)
+    enriched_audit["dependencies"] = enriched_dependencies
+    enriched_audit["summary"] = {
+        "active_vulnerabilities": active_count,
+        "suppressed_vulnerabilities": suppressed_count,
+    }
+    return enriched_audit, active_count, suppressed_count
+
+
+def _write_audit(audit: dict[str, Any], output_path: Path | None) -> None:
+    rendered = json.dumps(audit, indent=2, sort_keys=True) + "\n"
+    if output_path is None:
+        sys.stdout.write(rendered)
+    else:
+        output_path.write_text(rendered, encoding="utf-8")
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    policy_path: Path | None = None,
+    today: dt.date | None = None,
+) -> int:
+    root = Path(__file__).resolve().parents[2]
+    resolved_policy_path = policy_path or (
+        root / ".github" / "dependency-audit-exceptions.json"
+    )
+    exceptions = _load_policy(resolved_policy_path, today=today)
+    forwarded_args, output_path = _extract_wrapper_args(
+        list(sys.argv[1:] if argv is None else argv)
+    )
+
+    with tempfile.TemporaryDirectory(prefix="slideflow-pip-audit-") as temp_dir:
+        raw_output = Path(temp_dir) / "pip-audit.json"
+        command = [
+            sys.executable,
+            "-m",
+            "pip_audit",
+            "--format=json",
+            "--output",
+            str(raw_output),
+            *forwarded_args,
+        ]
+        result = subprocess.run(command, check=False)
+        if not raw_output.is_file():
+            return result.returncode or 1
+        try:
+            raw_audit = json.loads(raw_output.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise SystemExit(
+                f"pip-audit produced invalid JSON output: {error}"
+            ) from error
+
+    enriched_audit, active_count, suppressed_count = _postprocess_audit(
+        raw_audit, exceptions
+    )
+    _write_audit(enriched_audit, output_path)
+    print(
+        f"Dependency audit policy: {active_count} active, "
+        f"{suppressed_count} suppressed",
+        file=sys.stderr,
+    )
+
+    total_findings = active_count + suppressed_count
+    if result.returncode not in {0, 1}:
+        return result.returncode
+    if result.returncode != 0 and total_findings == 0:
+        return result.returncode
+    return 1 if active_count else 0
 
 
 if __name__ == "__main__":

--- a/scripts/ci/run_dependency_audit.py
+++ b/scripts/ci/run_dependency_audit.py
@@ -1,0 +1,50 @@
+"""Run pip-audit with bounded, expiring dependency exceptions."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    policy_path = root / ".github" / "dependency-audit-exceptions.json"
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    if not isinstance(policy, list):
+        raise SystemExit("dependency audit exception policy must be a JSON list")
+
+    today = dt.date.today()
+    ignored: list[str] = []
+    for entry in policy:
+        if not isinstance(entry, dict):
+            raise SystemExit("dependency audit exception entries must be objects")
+        vulnerability = entry.get("vulnerability")
+        package = entry.get("package")
+        reason = entry.get("reason")
+        try:
+            expires = dt.date.fromisoformat(entry["expires"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise SystemExit("dependency audit exception has invalid expiry") from error
+        if not isinstance(vulnerability, str) or not vulnerability:
+            raise SystemExit("dependency audit exception is missing vulnerability")
+        if not isinstance(package, str) or not package:
+            raise SystemExit("dependency audit exception is missing package")
+        if not isinstance(reason, str) or not reason:
+            raise SystemExit("dependency audit exception is missing required metadata")
+        if today > expires:
+            raise SystemExit(
+                f"dependency audit exception expired for {package} {vulnerability}"
+            )
+        ignored.append(vulnerability)
+
+    command = [sys.executable, "-m", "pip_audit", *sys.argv[1:]]
+    for vulnerability in ignored:
+        command.extend(["--ignore-vuln", vulnerability])
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -55,6 +55,7 @@ import re
 import shutil
 import threading
 import time
+import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -102,21 +103,29 @@ Repo = _git_repo_cls
 # Global cache for compiled DBT projects
 _prepared_workspaces_cache: dict[tuple, Path] = {}
 _prepared_workspaces_last_access: dict[tuple, float] = {}
+_prepared_workspace_generations: dict[tuple, str] = {}
 _workspace_preparation_inflight: dict[tuple, threading.Event] = {}
 _prepared_workspaces_in_use: dict[Path, int] = {}
 _pending_workspace_cleanup_dirs: set[Path] = set()
 _dbt_invocation_lock = threading.Lock()
 _compiled_projects_cache: dict[tuple, Path] = {}
 _compiled_projects_last_access: dict[tuple, float] = {}
+_compiled_project_generations: dict[tuple, str] = {}
 _compilation_inflight: dict[tuple, threading.Event] = {}
 _compilation_failures: dict[tuple, tuple[float, str]] = {}
 _compiled_projects_in_use: dict[Path, int] = {}
 _pending_cleanup_dirs: set[Path] = set()
+_cleanup_in_progress_dirs: set[Path] = set()
+_cleanup_failures: dict[Path, str] = {}
 _manifest_index_cache: dict[Path, "_ManifestIndex"] = {}
 _manifest_index_inflight: dict[Path, threading.Event] = {}
 _compiled_project_coverage: dict[tuple, frozenset[str]] = {}
 _selection_locks: dict[tuple, threading.Lock] = {}
-_cache_lock = threading.Lock()
+_cache_lock = threading.RLock()
+_cache_condition = threading.Condition(_cache_lock)
+
+_PREPARED_MARKER_NAME = ".slideflow-prepared.json"
+_PREPARED_MARKER_SCHEMA = 1
 
 
 @dataclass(frozen=True)
@@ -284,6 +293,7 @@ def _get_manifest_index(clone_dir: Path) -> _ManifestIndex:
                 is_owner = False
 
         if not is_owner:
+            assert pending is not None
             pending.wait()
             continue
 
@@ -502,8 +512,8 @@ def _resolve_dbt_failure_cache_max_entries() -> int:
     return max(parsed, 1)
 
 
-def _cleanup_managed_clone_dir(clone_dir: Path) -> None:
-    """Best-effort removal of managed clone directories during cache eviction."""
+def _cleanup_managed_clone_dir(clone_dir: Path) -> bool:
+    """Remove a managed clone and sibling artifacts without following links."""
     workspace_root = clone_dir.parent.parent
     workspace_artifact_dir = workspace_root / ".slideflow_dbt_targets" / clone_dir.name
     with _cache_lock:
@@ -516,7 +526,7 @@ def _cleanup_managed_clone_dir(clone_dir: Path) -> None:
         logger.warning(
             "Refusing to delete unmanaged DBT clone directory: %s", clone_dir
         )
-        return
+        return False
 
     try:
         if clone_dir.exists():
@@ -537,17 +547,19 @@ def _cleanup_managed_clone_dir(clone_dir: Path) -> None:
                     "Refusing to delete unsafe managed DBT directory: %s",
                     sibling_dir,
                 )
-                continue
+                return False
             if sibling_dir.exists():
                 shutil.rmtree(sibling_dir)
+        return True
     except Exception as error:
         logger.warning(
             "Failed to remove evicted DBT clone directory '%s': %s", clone_dir, error
         )
+        return False
 
 
-def _cleanup_managed_compile_dir(compiled_dir: Path) -> None:
-    """Best-effort removal of one managed dbt compile variant."""
+def _cleanup_managed_compile_dir(compiled_dir: Path) -> bool:
+    """Remove one managed dbt compile variant without following links."""
     managed_root = compiled_dir.parent
     if (
         managed_root.parent.name != ".slideflow_dbt_targets"
@@ -559,18 +571,20 @@ def _cleanup_managed_compile_dir(compiled_dir: Path) -> None:
         logger.warning(
             "Refusing to delete unmanaged DBT compile directory: %s", compiled_dir
         )
-        return
+        return False
     _drop_manifest_index(compiled_dir)
     if not compiled_dir.exists():
-        return
+        return True
     try:
         shutil.rmtree(compiled_dir)
+        return True
     except Exception as error:
         logger.warning(
             "Failed to remove evicted DBT compile directory '%s': %s",
             compiled_dir,
             error,
         )
+        return False
 
 
 def _source_clone_dir(compiled_dir: Path) -> Path:
@@ -605,6 +619,7 @@ def _release_prepared_workspace_lease_locked(clone_dir: Path) -> None:
         _prepared_workspaces_in_use.pop(clone_dir, None)
     else:
         _prepared_workspaces_in_use[clone_dir] = current - 1
+    _cache_condition.notify_all()
 
 
 def _workspace_has_compiled_references_locked(clone_dir: Path) -> bool:
@@ -626,38 +641,108 @@ def _collect_ready_cleanup_dirs_locked() -> tuple[list[Path], list[Path]]:
     cached_dirs = set(_compiled_projects_cache.values())
     ready_compiles: list[Path] = []
     for compiled_dir in list(_pending_cleanup_dirs):
+        if _source_clone_dir(compiled_dir) in _pending_workspace_cleanup_dirs:
+            continue
+        if compiled_dir in _cleanup_in_progress_dirs:
+            continue
         if _compiled_projects_in_use.get(compiled_dir, 0) > 0:
             continue
         if compiled_dir in cached_dirs:
             continue
-        _pending_cleanup_dirs.discard(compiled_dir)
+        _cleanup_in_progress_dirs.add(compiled_dir)
         ready_compiles.append(compiled_dir)
 
     cached_workspaces = set(_prepared_workspaces_cache.values())
     ready_workspaces: list[Path] = []
     for clone_dir in list(_pending_workspace_cleanup_dirs):
+        if clone_dir in _cleanup_in_progress_dirs:
+            continue
         if clone_dir in cached_workspaces:
             continue
         if _prepared_workspaces_in_use.get(clone_dir, 0) > 0:
             continue
         if _workspace_has_compiled_references_locked(clone_dir):
             continue
-        _pending_workspace_cleanup_dirs.discard(clone_dir)
-        for compiled_dir in list(_pending_cleanup_dirs):
-            if _source_clone_dir(compiled_dir) == clone_dir:
-                _pending_cleanup_dirs.discard(compiled_dir)
+        if any(
+            _source_clone_dir(compiled_dir) == clone_dir
+            for compiled_dir in _cleanup_in_progress_dirs
+        ):
+            continue
+        _cleanup_in_progress_dirs.add(clone_dir)
         ready_workspaces.append(clone_dir)
     return ready_compiles, ready_workspaces
 
 
+def _finish_cleanup(directory: Path, *, workspace: bool, succeeded: bool) -> None:
+    """Finish one reserved cleanup and wake requests waiting to reuse its path."""
+    with _cache_condition:
+        _cleanup_in_progress_dirs.discard(directory)
+        pending = (
+            _pending_workspace_cleanup_dirs if workspace else _pending_cleanup_dirs
+        )
+        if succeeded:
+            pending.discard(directory)
+            _cleanup_failures.pop(directory, None)
+            if workspace:
+                for compiled_dir in list(_pending_cleanup_dirs):
+                    if _source_clone_dir(compiled_dir) == directory:
+                        _pending_cleanup_dirs.discard(compiled_dir)
+                        _cleanup_failures.pop(compiled_dir, None)
+        else:
+            _cleanup_failures[directory] = (
+                f"Failed to safely clean reserved DBT path: {directory}"
+            )
+        _cache_condition.notify_all()
+
+
 def _cleanup_ready_managed_dirs() -> None:
-    """Best-effort cleanup for pending compile and workspace directories."""
+    """Clean ready paths while keeping reservations until deletion completes."""
     with _cache_lock:
         ready_compiles, ready_workspaces = _collect_ready_cleanup_dirs_locked()
     for directory in ready_compiles:
-        _cleanup_managed_compile_dir(directory)
+        succeeded = _cleanup_managed_compile_dir(directory)
+        _finish_cleanup(directory, workspace=False, succeeded=succeeded)
     for directory in ready_workspaces:
-        _cleanup_managed_clone_dir(directory)
+        succeeded = _cleanup_managed_clone_dir(directory)
+        _finish_cleanup(directory, workspace=True, succeeded=succeeded)
+
+
+def _wait_for_managed_cleanup(directory: Path, *, workspace: bool) -> None:
+    """Wait until a reserved deterministic path is safely reusable."""
+    pending = _pending_workspace_cleanup_dirs if workspace else _pending_cleanup_dirs
+    retried_failure = False
+    while True:
+        with _cache_condition:
+            if directory not in pending:
+                return
+            failure = _cleanup_failures.pop(directory, None)
+            if failure is not None:
+                if retried_failure:
+                    raise DataSourceError(failure)
+                retried_failure = True
+
+        _cleanup_ready_managed_dirs()
+
+        with _cache_condition:
+            if directory not in pending:
+                return
+            if directory in _cleanup_failures:
+                continue
+            if directory not in _cleanup_in_progress_dirs:
+                if workspace:
+                    ready = (
+                        directory not in _prepared_workspaces_cache.values()
+                        and _prepared_workspaces_in_use.get(directory, 0) == 0
+                        and not _workspace_has_compiled_references_locked(directory)
+                    )
+                else:
+                    ready = (
+                        directory not in _compiled_projects_cache.values()
+                        and _compiled_projects_in_use.get(directory, 0) == 0
+                    )
+                if ready:
+                    continue
+            _cache_condition.wait()
 
 
 def _cleanup_ready_managed_clone_dirs() -> None:
@@ -673,13 +758,9 @@ def _release_compiled_project_lease(compiled_dir: Path) -> None:
             _compiled_projects_in_use.pop(compiled_dir, None)
         else:
             _compiled_projects_in_use[compiled_dir] = current - 1
+        _cache_condition.notify_all()
 
-        ready_compiles, ready_workspaces = _collect_ready_cleanup_dirs_locked()
-
-    for directory in ready_compiles:
-        _cleanup_managed_compile_dir(directory)
-    for directory in ready_workspaces:
-        _cleanup_managed_clone_dir(directory)
+    _cleanup_ready_managed_dirs()
 
 
 def _prune_compiled_projects_cache_locked(max_entries: int) -> None:
@@ -699,6 +780,7 @@ def _prune_compiled_projects_cache_locked(max_entries: int) -> None:
 
             _compiled_projects_cache.pop(oldest_key, None)
             _compiled_projects_last_access.pop(oldest_key, None)
+            _compiled_project_generations.pop(oldest_key, None)
             _compiled_project_coverage.pop(oldest_key, None)
             _selection_locks.pop(oldest_key, None)
             _pending_cleanup_dirs.add(compiled_dir)
@@ -728,6 +810,7 @@ def _prune_prepared_workspaces_cache_locked(max_entries: int) -> None:
                 continue
             _prepared_workspaces_cache.pop(oldest_key, None)
             _prepared_workspaces_last_access.pop(oldest_key, None)
+            _prepared_workspace_generations.pop(oldest_key, None)
             _pending_workspace_cleanup_dirs.add(clone_dir)
             evicted = True
             break
@@ -923,6 +1006,164 @@ def _resolve_managed_compile_dir(
     return managed_root / key
 
 
+def _workspace_identity_digest(cache_key: tuple) -> str:
+    """Return a stable digest for a normalized workspace cache identity."""
+    return hashlib.sha256(
+        json.dumps(cache_key, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def _prepared_marker_path(clone_dir: Path) -> Path:
+    """Return the preparation marker written only after successful dbt deps."""
+    return clone_dir / _PREPARED_MARKER_NAME
+
+
+def _write_prepared_marker(clone_dir: Path, cache_key: tuple) -> str:
+    """Atomically record one successfully prepared workspace generation."""
+    generation = uuid.uuid4().hex
+    marker = {
+        "schema": _PREPARED_MARKER_SCHEMA,
+        "identity": _workspace_identity_digest(cache_key),
+        "generation": generation,
+        "repository_revision": _resolve_repo_ref(clone_dir, None),
+    }
+    marker_path = _prepared_marker_path(clone_dir)
+    temporary_path = marker_path.with_name(f"{marker_path.name}.{generation}.tmp")
+    temporary_path.write_text(json.dumps(marker, sort_keys=True), encoding="utf-8")
+    os.replace(temporary_path, marker_path)
+    return generation
+
+
+def _validate_real_directory_chain(
+    directory: Path,
+    managed_root: Path,
+    *,
+    require_exists: bool,
+) -> None:
+    """Reject links, collisions, and escapes along a managed directory chain."""
+    try:
+        relative = directory.relative_to(managed_root)
+    except ValueError as error:
+        raise DataSourceError(
+            f"Reserved DBT path escapes its managed root: {directory}"
+        ) from error
+
+    candidates = [managed_root]
+    current = managed_root
+    for part in relative.parts:
+        current = current / part
+        candidates.append(current)
+
+    for candidate in candidates:
+        if candidate.is_symlink():
+            raise DataSourceError(
+                f"Reserved DBT path must not be a symlink: {candidate}"
+            )
+        if candidate.exists() and not candidate.is_dir():
+            raise DataSourceError(
+                f"Reserved DBT path must be a real directory: {candidate}"
+            )
+
+    if not _is_path_within(directory, managed_root):
+        raise DataSourceError(
+            f"Reserved DBT path escapes its managed root: {directory}"
+        )
+    if require_exists and not directory.is_dir():
+        raise DataSourceError(f"Reserved DBT directory does not exist: {directory}")
+
+
+def _validate_prepared_workspace(clone_dir: Path, cache_key: tuple) -> str:
+    """Validate a real prepared clone and return its generation token."""
+    clone_root = clone_dir.parent
+    if clone_root.name != ".slideflow_dbt_clones":
+        raise DataSourceError(f"Invalid managed DBT clone path: {clone_dir}")
+    _validate_real_directory_chain(clone_dir, clone_root, require_exists=True)
+
+    project_file = clone_dir / "dbt_project.yml"
+    if project_file.is_symlink() or (
+        project_file.exists() and not project_file.is_file()
+    ):
+        raise DataSourceError(
+            f"Managed DBT project file must be a real file: {project_file}"
+        )
+
+    marker_path = _prepared_marker_path(clone_dir)
+    if marker_path.is_symlink() or not marker_path.is_file():
+        raise DataSourceError(
+            f"Managed DBT workspace is missing a valid preparation marker: {marker_path}"
+        )
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError) as error:
+        raise DataSourceError(
+            f"Managed DBT preparation marker is invalid: {marker_path}"
+        ) from error
+    generation = marker.get("generation")
+    if (
+        marker.get("schema") != _PREPARED_MARKER_SCHEMA
+        or marker.get("identity") != _workspace_identity_digest(cache_key)
+        or not isinstance(generation, str)
+        or not generation
+    ):
+        raise DataSourceError(
+            f"Managed DBT preparation marker does not match its workspace: {marker_path}"
+        )
+    return generation
+
+
+def _resolve_deps_log_dir(clone_dir: Path) -> Path:
+    """Return the reserved deps log directory for one shared workspace."""
+    return clone_dir.parent.parent / ".slideflow_dbt_logs" / clone_dir.name / "deps"
+
+
+def _prepare_managed_command_dir(directory: Path, managed_root: Path) -> None:
+    """Create a command output directory and prove it remains safe."""
+    _validate_real_directory_chain(directory, managed_root, require_exists=False)
+    directory.mkdir(parents=True, exist_ok=True)
+    _validate_real_directory_chain(directory, managed_root, require_exists=True)
+
+
+def _validate_variant_command_paths(clone_dir: Path, compiled_dir: Path) -> None:
+    """Validate the exact target and log paths passed to dbt."""
+    _validate_managed_compile_dir(clone_dir, compiled_dir, require_exists=True)
+    for child in (compiled_dir / "target", compiled_dir / "logs"):
+        _prepare_managed_command_dir(child, compiled_dir)
+
+
+def _invalidate_workspace_locked(cache_key: tuple, clone_dir: Path) -> None:
+    """Invalidate a workspace generation and every compiled sibling variant."""
+    for prepared_key, prepared_dir in list(_prepared_workspaces_cache.items()):
+        if prepared_dir == clone_dir:
+            _prepared_workspaces_cache.pop(prepared_key, None)
+            _prepared_workspaces_last_access.pop(prepared_key, None)
+            _prepared_workspace_generations.pop(prepared_key, None)
+
+    for project_key, compiled_dir in list(_compiled_projects_cache.items()):
+        if _source_clone_dir(compiled_dir) != clone_dir:
+            continue
+        _compiled_projects_cache.pop(project_key, None)
+        _compiled_projects_last_access.pop(project_key, None)
+        _compiled_project_generations.pop(project_key, None)
+        _compiled_project_coverage.pop(project_key, None)
+        _selection_locks.pop(project_key, None)
+        _pending_cleanup_dirs.add(compiled_dir)
+
+    workspace_length = len(cache_key)
+    for failure_key in list(_compilation_failures):
+        if (
+            len(failure_key) > workspace_length
+            and failure_key[0] in {"workspace", "compile", "selected"}
+            and tuple(failure_key[1 : workspace_length + 1]) == cache_key
+        ):
+            _compilation_failures.pop(failure_key, None)
+
+    artifact_root = clone_dir.parent.parent / ".slideflow_dbt_targets" / clone_dir.name
+    _drop_manifest_indexes_under_locked(clone_dir)
+    _drop_manifest_indexes_under_locked(artifact_root)
+    _pending_workspace_cleanup_dirs.add(clone_dir)
+    _cache_condition.notify_all()
+
+
 def _validate_managed_compile_dir(
     clone_dir: Path,
     compiled_dir: Path,
@@ -936,24 +1177,12 @@ def _validate_managed_compile_dir(
     if compiled_dir.parent != managed_root:
         raise DataSourceError(f"Invalid managed DBT compile path: {compiled_dir}")
 
-    for directory in (target_root, managed_root, compiled_dir):
-        if directory.is_symlink():
-            raise DataSourceError(
-                f"Reserved DBT compile path must not be a symlink: {directory}"
-            )
-        if directory.exists() and not directory.is_dir():
-            raise DataSourceError(
-                f"Reserved DBT compile path must be a real directory: {directory}"
-            )
-
-    if not _is_path_within(compiled_dir, managed_root):
-        raise DataSourceError(
-            f"Reserved DBT compile path escapes its managed root: {compiled_dir}"
-        )
-    if require_exists and not compiled_dir.is_dir():
-        raise DataSourceError(
-            f"Reserved DBT compile path was not created safely: {compiled_dir}"
-        )
+    _validate_real_directory_chain(target_root, target_root, require_exists=False)
+    _validate_real_directory_chain(
+        compiled_dir,
+        target_root,
+        require_exists=require_exists,
+    )
 
 
 def _resolve_existing_compiled_project_dir(
@@ -1026,6 +1255,7 @@ def _get_prepared_workspace(
     failure_cache_max_entries = _resolve_dbt_failure_cache_max_entries()
 
     while True:
+        stale_dir: Optional[Path] = None
         with _cache_lock:
             _prune_compilation_failures_locked(
                 max_entries=failure_cache_max_entries,
@@ -1033,28 +1263,38 @@ def _get_prepared_workspace(
             )
             cached_dir = _prepared_workspaces_cache.get(cache_key)
             if cached_dir is not None:
-                if cached_dir.is_dir():
+                try:
+                    generation = _validate_prepared_workspace(cached_dir, cache_key)
+                except DataSourceError:
+                    _invalidate_workspace_locked(cache_key, cached_dir)
+                    stale_dir = cached_dir
+                else:
+                    _prepared_workspace_generations[cache_key] = generation
                     _prepared_workspaces_last_access[cache_key] = time.time()
                     if acquire_lease:
                         _acquire_prepared_workspace_lease_locked(cached_dir)
                     return cached_dir
-                _drop_manifest_indexes_under_locked(cached_dir)
-                _prepared_workspaces_cache.pop(cache_key, None)
-                _prepared_workspaces_last_access.pop(cache_key, None)
 
-            failure_entry = _compilation_failures.get(failure_key)
-            if failure_entry is not None:
-                raise DataSourceError(failure_entry[1])
+            if stale_dir is None:
+                failure_entry = _compilation_failures.get(failure_key)
+                if failure_entry is not None:
+                    raise DataSourceError(failure_entry[1])
 
-            pending = _workspace_preparation_inflight.get(cache_key)
-            if pending is None:
-                pending = threading.Event()
-                _workspace_preparation_inflight[cache_key] = pending
-                is_owner = True
-            else:
-                is_owner = False
+                pending = _workspace_preparation_inflight.get(cache_key)
+                if pending is None:
+                    pending = threading.Event()
+                    _workspace_preparation_inflight[cache_key] = pending
+                    is_owner = True
+                else:
+                    is_owner = False
+
+        if stale_dir is not None:
+            _cleanup_ready_managed_dirs()
+            _wait_for_managed_cleanup(stale_dir, workspace=True)
+            continue
 
         if not is_owner:
+            assert pending is not None
             pending.wait()
             continue
 
@@ -1067,10 +1307,15 @@ def _get_prepared_workspace(
                 profiles_dir=profiles_dir,
                 profile_name=profile_name,
             )
-            with _cache_lock:
-                _pending_workspace_cleanup_dirs.discard(clone_dir)
+            _wait_for_managed_cleanup(clone_dir, workspace=True)
             _clone_repo(package_url, clone_dir, branch)
             _prepare_profiles(clone_dir, profiles_dir)
+
+            clone_root = clone_dir.parent
+            _validate_real_directory_chain(clone_dir, clone_root, require_exists=True)
+            deps_log_dir = _resolve_deps_log_dir(clone_dir)
+            deps_log_root = deps_log_dir.parent.parent
+            _prepare_managed_command_dir(deps_log_dir, deps_log_root)
 
             runner = _require_dbt_runner_class()()
             deps_args = [
@@ -1078,12 +1323,7 @@ def _get_prepared_workspace(
                 "--project-dir",
                 str(clone_dir),
                 "--log-path",
-                str(
-                    clone_dir.parent.parent
-                    / ".slideflow_dbt_logs"
-                    / clone_dir.name
-                    / "deps"
-                ),
+                str(deps_log_dir),
             ]
             if profile_name:
                 deps_args.extend(["--profile", profile_name])
@@ -1092,8 +1332,15 @@ def _get_prepared_workspace(
 
             deps_started = time.time()
             with _dbt_invocation_lock:
+                _validate_real_directory_chain(
+                    clone_dir, clone_root, require_exists=True
+                )
+                _validate_real_directory_chain(
+                    deps_log_dir, deps_log_root, require_exists=True
+                )
                 deps_result = runner.invoke(deps_args)
             _ensure_dbt_invoke_success("deps", deps_result)
+            generation = _write_prepared_marker(clone_dir, cache_key)
             log_performance("dbt_deps", time.time() - deps_started, project=package_url)
         except BaseException as error:
             failure_message = str(error) or type(error).__name__
@@ -1114,6 +1361,7 @@ def _get_prepared_workspace(
         with _cache_lock:
             _prepared_workspaces_cache[cache_key] = clone_dir
             _prepared_workspaces_last_access[cache_key] = time.time()
+            _prepared_workspace_generations[cache_key] = generation
             _compilation_failures.pop(failure_key, None)
             if acquire_lease:
                 _acquire_prepared_workspace_lease_locked(clone_dir)
@@ -1146,6 +1394,13 @@ def _get_compiled_project(
         )
 
     canonical_profiles_dir = _canonical_profiles_dir(profiles_dir)
+    workspace_key = _workspace_cache_key(
+        package_url,
+        canonical_project_dir,
+        branch,
+        canonical_profiles_dir,
+        profile_name,
+    )
     cache_key = _project_cache_key(
         package_url,
         canonical_project_dir,
@@ -1162,6 +1417,7 @@ def _get_compiled_project(
     failure_cache_max_entries = _resolve_dbt_failure_cache_max_entries()
 
     while True:
+        stale_workspace: Optional[Path] = None
         with _cache_lock:
             _prune_compilation_failures_locked(
                 max_entries=failure_cache_max_entries,
@@ -1170,40 +1426,72 @@ def _get_compiled_project(
             cached_dir = _compiled_projects_cache.get(cache_key)
             if cached_dir is not None:
                 source_dir = _source_clone_dir(cached_dir)
-                if cached_dir.is_dir() and source_dir.is_dir():
-                    _validate_managed_compile_dir(
-                        source_dir,
-                        cached_dir,
-                        require_exists=True,
-                    )
-                    _compiled_projects_last_access[cache_key] = time.time()
-                    if acquire_lease:
-                        _acquire_compiled_project_lease_locked(cached_dir)
-                    return cached_dir
-                _drop_manifest_index_locked(cached_dir)
-                _compiled_projects_cache.pop(cache_key, None)
-                _compiled_projects_last_access.pop(cache_key, None)
-                _compiled_project_coverage.pop(cache_key, None)
+                try:
+                    generation = _validate_prepared_workspace(source_dir, workspace_key)
+                except DataSourceError:
+                    _invalidate_workspace_locked(workspace_key, source_dir)
+                    stale_workspace = source_dir
+                else:
+                    try:
+                        _validate_managed_compile_dir(
+                            source_dir,
+                            cached_dir,
+                            require_exists=True,
+                        )
+                        for child in (cached_dir / "target", cached_dir / "logs"):
+                            _validate_real_directory_chain(
+                                child, cached_dir, require_exists=True
+                            )
+                    except DataSourceError:
+                        if cached_dir.is_symlink() or any(
+                            child.is_symlink()
+                            for child in (cached_dir / "target", cached_dir / "logs")
+                        ):
+                            raise
+                        _drop_manifest_index_locked(cached_dir)
+                        _compiled_projects_cache.pop(cache_key, None)
+                        _compiled_projects_last_access.pop(cache_key, None)
+                        _compiled_project_generations.pop(cache_key, None)
+                        _compiled_project_coverage.pop(cache_key, None)
+                        _selection_locks.pop(cache_key, None)
+                        _pending_cleanup_dirs.add(cached_dir)
+                    else:
+                        if _compiled_project_generations.get(cache_key) != generation:
+                            _invalidate_workspace_locked(workspace_key, source_dir)
+                            stale_workspace = source_dir
+                        else:
+                            _compiled_projects_last_access[cache_key] = time.time()
+                            if acquire_lease:
+                                _acquire_compiled_project_lease_locked(cached_dir)
+                            return cached_dir
 
-            failure_entry = _compilation_failures.get(failure_key)
-            if failure_entry is not None:
-                _failed_at, failure_message = failure_entry
-                raise DataSourceError(failure_message)
+            if stale_workspace is None:
+                failure_entry = _compilation_failures.get(failure_key)
+                if failure_entry is not None:
+                    _failed_at, failure_message = failure_entry
+                    raise DataSourceError(failure_message)
 
-            pending = _compilation_inflight.get(cache_key)
-            if pending is None:
-                pending = threading.Event()
-                _compilation_inflight[cache_key] = pending
-                is_owner = True
-            else:
-                is_owner = False
+                pending = _compilation_inflight.get(cache_key)
+                if pending is None:
+                    pending = threading.Event()
+                    _compilation_inflight[cache_key] = pending
+                    is_owner = True
+                else:
+                    is_owner = False
+
+        if stale_workspace is not None:
+            _cleanup_ready_managed_dirs()
+            _wait_for_managed_cleanup(stale_workspace, workspace=True)
+            continue
 
         if not is_owner:
+            assert pending is not None
             pending.wait()
             continue
 
         compiled_dir: Optional[Path] = None
         clone_dir: Optional[Path] = None
+        workspace_generation: Optional[str] = None
         workspace_leased = False
         try:
             clone_dir = _get_prepared_workspace(
@@ -1215,10 +1503,12 @@ def _get_compiled_project(
                 acquire_lease=True,
             )
             workspace_leased = True
+            workspace_generation = _validate_prepared_workspace(
+                clone_dir, workspace_key
+            )
             compiled_dir = _resolve_managed_compile_dir(clone_dir, target, vars)
+            _wait_for_managed_cleanup(compiled_dir, workspace=False)
             _validate_managed_compile_dir(clone_dir, compiled_dir, require_exists=False)
-            with _cache_lock:
-                _pending_cleanup_dirs.discard(compiled_dir)
             if compiled_dir.exists():
                 _cleanup_managed_compile_dir(compiled_dir)
                 if compiled_dir.exists():
@@ -1230,6 +1520,7 @@ def _get_compiled_project(
             _validate_managed_compile_dir(clone_dir, compiled_dir, require_exists=False)
             compiled_dir.mkdir()
             _validate_managed_compile_dir(clone_dir, compiled_dir, require_exists=True)
+            _validate_variant_command_paths(clone_dir, compiled_dir)
 
             runner = _require_dbt_runner_class()()
             compile_start = time.time()
@@ -1252,9 +1543,14 @@ def _get_compiled_project(
             if vars:
                 args += ["--vars", json.dumps(vars)]
             with _dbt_invocation_lock:
-                _validate_managed_compile_dir(
-                    clone_dir, compiled_dir, require_exists=True
-                )
+                if (
+                    _validate_prepared_workspace(clone_dir, workspace_key)
+                    != workspace_generation
+                ):
+                    raise DataSourceError(
+                        "Prepared DBT workspace changed before compilation"
+                    )
+                _validate_variant_command_paths(clone_dir, compiled_dir)
                 compile_result = runner.invoke(args)
             _ensure_dbt_invoke_success(command, compile_result)
             _drop_manifest_index(compiled_dir)
@@ -1286,16 +1582,33 @@ def _get_compiled_project(
             raise
 
         assert compiled_dir is not None
+        assert clone_dir is not None
+        assert workspace_generation is not None
+        stale_generation = False
+        try:
+            disk_generation = _validate_prepared_workspace(clone_dir, workspace_key)
+        except DataSourceError:
+            disk_generation = None
         with _cache_lock:
-            _compiled_projects_cache[cache_key] = compiled_dir
-            _compiled_project_coverage[cache_key] = (
-                frozenset() if parse_only else frozenset({"*"})
-            )
-            _compiled_projects_last_access[cache_key] = time.time()
-            _compilation_failures.pop(failure_key, None)
-            _prune_compiled_projects_cache_locked(max_cache_entries)
-            if acquire_lease:
-                _acquire_compiled_project_lease_locked(compiled_dir)
+            current_generation = _prepared_workspace_generations.get(workspace_key)
+            if (
+                current_generation != workspace_generation
+                or disk_generation != workspace_generation
+            ):
+                stale_generation = True
+                _invalidate_workspace_locked(workspace_key, clone_dir)
+                _pending_cleanup_dirs.add(compiled_dir)
+            else:
+                _compiled_projects_cache[cache_key] = compiled_dir
+                _compiled_project_generations[cache_key] = workspace_generation
+                _compiled_project_coverage[cache_key] = (
+                    frozenset() if parse_only else frozenset({"*"})
+                )
+                _compiled_projects_last_access[cache_key] = time.time()
+                _compilation_failures.pop(failure_key, None)
+                if acquire_lease:
+                    _acquire_compiled_project_lease_locked(compiled_dir)
+                _prune_compiled_projects_cache_locked(max_cache_entries)
             if workspace_leased and clone_dir is not None:
                 _release_prepared_workspace_lease_locked(clone_dir)
             _prune_prepared_workspaces_cache_locked(max_cache_entries)
@@ -1303,6 +1616,9 @@ def _get_compiled_project(
             if event is not None:
                 event.set()
         _cleanup_ready_managed_dirs()
+
+        if stale_generation:
+            continue
 
         return compiled_dir
 
@@ -1332,6 +1648,13 @@ def _ensure_selected_compilation(
         profiles_dir,
         profile_name,
     )
+    workspace_key = _workspace_cache_key(
+        package_url,
+        project_dir,
+        branch,
+        profiles_dir,
+        profile_name,
+    )
     with _cache_lock:
         selection_lock = _selection_locks.setdefault(cache_key, threading.Lock())
 
@@ -1356,6 +1679,9 @@ def _ensure_selected_compilation(
 
         compiled_dir = clone_dir
         source_dir = _source_clone_dir(compiled_dir)
+        expected_generation = _compiled_project_generations.get(cache_key)
+        if expected_generation is None:
+            raise DataSourceError("Compiled DBT workspace generation is unavailable")
         runner = _require_dbt_runner_class()()
         args = [
             "compile",
@@ -1381,9 +1707,14 @@ def _ensure_selected_compilation(
         started = time.time()
         try:
             with _dbt_invocation_lock:
-                _validate_managed_compile_dir(
-                    source_dir, compiled_dir, require_exists=True
-                )
+                if (
+                    _validate_prepared_workspace(source_dir, workspace_key)
+                    != expected_generation
+                ):
+                    raise DataSourceError(
+                        "Prepared DBT workspace changed before selected compilation"
+                    )
+                _validate_variant_command_paths(source_dir, compiled_dir)
                 result = runner.invoke(args)
             _ensure_dbt_invoke_success("compile", result)
             _drop_manifest_index(compiled_dir)
@@ -1405,7 +1736,20 @@ def _ensure_selected_compilation(
             vars_count=len(vars) if vars else 0,
             selection_count=len(union),
         )
+        try:
+            disk_generation = _validate_prepared_workspace(source_dir, workspace_key)
+        except DataSourceError:
+            disk_generation = None
         with _cache_lock:
+            if (
+                _prepared_workspace_generations.get(workspace_key)
+                != expected_generation
+                or disk_generation != expected_generation
+            ):
+                _invalidate_workspace_locked(workspace_key, source_dir)
+                raise DataSourceError(
+                    "Prepared DBT workspace changed during selected compilation"
+                )
             _compiled_project_coverage[cache_key] = frozenset(union)
             _compilation_failures.pop(failure_key, None)
 

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -504,8 +504,11 @@ def _resolve_dbt_failure_cache_max_entries() -> int:
 
 def _cleanup_managed_clone_dir(clone_dir: Path) -> None:
     """Best-effort removal of managed clone directories during cache eviction."""
+    workspace_root = clone_dir.parent.parent
+    workspace_artifact_dir = workspace_root / ".slideflow_dbt_targets" / clone_dir.name
     with _cache_lock:
         _drop_manifest_indexes_under_locked(clone_dir)
+        _drop_manifest_indexes_under_locked(workspace_artifact_dir)
     managed_root = clone_dir.parent
     if managed_root.name != ".slideflow_dbt_clones" or not _is_path_within(
         clone_dir, managed_root
@@ -515,18 +518,28 @@ def _cleanup_managed_clone_dir(clone_dir: Path) -> None:
         )
         return
 
-    if not clone_dir.exists():
-        return
-
     try:
-        shutil.rmtree(clone_dir)
-        workspace_log_dir = (
-            clone_dir.parent.parent / ".slideflow_dbt_logs" / clone_dir.name
+        if clone_dir.exists():
+            shutil.rmtree(clone_dir)
+        sibling_dirs = (
+            workspace_artifact_dir,
+            workspace_root / ".slideflow_dbt_logs" / clone_dir.name,
         )
-        if workspace_log_dir.exists() and _is_path_within(
-            workspace_log_dir, clone_dir.parent.parent / ".slideflow_dbt_logs"
-        ):
-            shutil.rmtree(workspace_log_dir)
+        for sibling_dir in sibling_dirs:
+            managed_root = sibling_dir.parent
+            if (
+                managed_root.is_symlink()
+                or (managed_root.exists() and not managed_root.is_dir())
+                or sibling_dir.is_symlink()
+                or not _is_path_within(sibling_dir, managed_root)
+            ):
+                logger.warning(
+                    "Refusing to delete unsafe managed DBT directory: %s",
+                    sibling_dir,
+                )
+                continue
+            if sibling_dir.exists():
+                shutil.rmtree(sibling_dir)
     except Exception as error:
         logger.warning(
             "Failed to remove evicted DBT clone directory '%s': %s", clone_dir, error
@@ -535,18 +548,19 @@ def _cleanup_managed_clone_dir(clone_dir: Path) -> None:
 
 def _cleanup_managed_compile_dir(compiled_dir: Path) -> None:
     """Best-effort removal of one managed dbt compile variant."""
-    _drop_manifest_index(compiled_dir)
     managed_root = compiled_dir.parent
-    clone_dir = managed_root.parent
     if (
-        managed_root.name != ".slideflow_dbt_targets"
-        or clone_dir.parent.name != ".slideflow_dbt_clones"
+        managed_root.parent.name != ".slideflow_dbt_targets"
+        or compiled_dir.is_symlink()
+        or managed_root.is_symlink()
+        or managed_root.parent.is_symlink()
         or not _is_path_within(compiled_dir, managed_root)
     ):
         logger.warning(
             "Refusing to delete unmanaged DBT compile directory: %s", compiled_dir
         )
         return
+    _drop_manifest_index(compiled_dir)
     if not compiled_dir.exists():
         return
     try:
@@ -561,11 +575,9 @@ def _cleanup_managed_compile_dir(compiled_dir: Path) -> None:
 
 def _source_clone_dir(compiled_dir: Path) -> Path:
     """Resolve the source clone for a managed compile variant."""
-    if (
-        compiled_dir.parent.name == ".slideflow_dbt_targets"
-        and compiled_dir.parent.parent.parent.name == ".slideflow_dbt_clones"
-    ):
-        return compiled_dir.parent.parent
+    if compiled_dir.parent.parent.name == ".slideflow_dbt_targets":
+        workspace_root = compiled_dir.parent.parent.parent
+        return workspace_root / ".slideflow_dbt_clones" / compiled_dir.parent.name
     return compiled_dir
 
 
@@ -632,7 +644,7 @@ def _collect_ready_cleanup_dirs_locked() -> tuple[list[Path], list[Path]]:
             continue
         _pending_workspace_cleanup_dirs.discard(clone_dir)
         for compiled_dir in list(_pending_cleanup_dirs):
-            if _is_path_within(compiled_dir, clone_dir):
+            if _source_clone_dir(compiled_dir) == clone_dir:
                 _pending_cleanup_dirs.discard(compiled_dir)
         ready_workspaces.append(clone_dir)
     return ready_compiles, ready_workspaces
@@ -776,6 +788,28 @@ def _ensure_dbt_invoke_success(command: str, invocation_result: Any) -> None:
         raise DataSourceError(f"dbt {command} failed.")
 
 
+def _optional_workspace_identity(value: Optional[str]) -> tuple[str, Optional[str]]:
+    """Encode optional identity values without colliding with literal sentinels."""
+    if value is None:
+        return ("absent", None)
+    return ("value", value)
+
+
+def _workspace_identity(
+    package_url: str,
+    branch: Optional[str],
+    profiles_dir: Optional[str] = None,
+    profile_name: Optional[str] = None,
+) -> tuple:
+    """Return the normalized identity shared by caches and physical paths."""
+    return (
+        package_url,
+        _optional_workspace_identity(branch or None),
+        _optional_workspace_identity(_canonical_profiles_dir(profiles_dir)),
+        _optional_workspace_identity(profile_name or None),
+    )
+
+
 def _build_clone_identity_key(
     package_url: str,
     branch: Optional[str],
@@ -784,20 +818,15 @@ def _build_clone_identity_key(
     profiles_dir: Optional[str] = None,
     profile_name: Optional[str] = None,
 ) -> str:
-    """Build a deterministic identity key for shared DBT workspaces.
+    """Build a deterministic directory key for a shared DBT workspace.
 
     ``target`` and ``vars`` remain accepted for internal compatibility but are
     deliberately excluded: they affect compilation artifacts, not repository
     checkout or dependency installation.
     """
-    payload = {
-        "package_url": package_url,
-        "branch": branch or "default",
-        "profiles_dir": profiles_dir or "",
-        "profile_name": profile_name or "",
-    }
+    identity = _workspace_identity(package_url, branch, profiles_dir, profile_name)
     return hashlib.sha1(
-        json.dumps(payload, sort_keys=True).encode("utf-8"),
+        json.dumps(identity, sort_keys=True).encode("utf-8"),
         usedforsecurity=False,
     ).hexdigest()[:16]
 
@@ -810,12 +839,8 @@ def _workspace_cache_key(
     profile_name: Optional[str],
 ) -> tuple:
     """Return the identity for clone and dependency preparation."""
-    return (
-        package_url,
-        _canonical_project_dir(project_dir),
-        branch,
-        _canonical_profiles_dir(profiles_dir),
-        profile_name,
+    return (_canonical_project_dir(project_dir),) + _workspace_identity(
+        package_url, branch, profiles_dir, profile_name
     )
 
 
@@ -890,15 +915,45 @@ def _resolve_managed_compile_dir(
     vars: Optional[dict[str, Any]],
 ) -> Path:
     """Resolve the isolated artifact root for one target/vars combination."""
-    managed_root = clone_dir / ".slideflow_dbt_targets"
-    if managed_root.is_symlink() or (
-        managed_root.exists() and not managed_root.is_dir()
-    ):
-        raise DataSourceError(
-            "Reserved DBT compile path must be a real directory: " f"{managed_root}"
-        )
+    clone_root = clone_dir.parent
+    if clone_root.name != ".slideflow_dbt_clones":
+        raise DataSourceError(f"Invalid managed DBT clone path: {clone_dir}")
+    managed_root = clone_root.parent / ".slideflow_dbt_targets" / clone_dir.name
     key = _build_compile_identity_key(target, vars)
     return managed_root / key
+
+
+def _validate_managed_compile_dir(
+    clone_dir: Path,
+    compiled_dir: Path,
+    *,
+    require_exists: bool,
+) -> None:
+    """Fail closed unless a compile path is a real contained managed directory."""
+    expected_dir = _resolve_managed_compile_dir(clone_dir, "identity-check", None)
+    managed_root = expected_dir.parent
+    target_root = managed_root.parent
+    if compiled_dir.parent != managed_root:
+        raise DataSourceError(f"Invalid managed DBT compile path: {compiled_dir}")
+
+    for directory in (target_root, managed_root, compiled_dir):
+        if directory.is_symlink():
+            raise DataSourceError(
+                f"Reserved DBT compile path must not be a symlink: {directory}"
+            )
+        if directory.exists() and not directory.is_dir():
+            raise DataSourceError(
+                f"Reserved DBT compile path must be a real directory: {directory}"
+            )
+
+    if not _is_path_within(compiled_dir, managed_root):
+        raise DataSourceError(
+            f"Reserved DBT compile path escapes its managed root: {compiled_dir}"
+        )
+    if require_exists and not compiled_dir.is_dir():
+        raise DataSourceError(
+            f"Reserved DBT compile path was not created safely: {compiled_dir}"
+        )
 
 
 def _resolve_existing_compiled_project_dir(
@@ -1015,12 +1070,6 @@ def _get_prepared_workspace(
             with _cache_lock:
                 _pending_workspace_cleanup_dirs.discard(clone_dir)
             _clone_repo(package_url, clone_dir, branch)
-            reserved_targets = clone_dir / ".slideflow_dbt_targets"
-            if reserved_targets.exists() or reserved_targets.is_symlink():
-                raise DataSourceError(
-                    "DBT repository contains reserved Slideflow path "
-                    f"{reserved_targets}. Remove it from the repository."
-                )
             _prepare_profiles(clone_dir, profiles_dir)
 
             runner = _require_dbt_runner_class()()
@@ -1121,6 +1170,11 @@ def _get_compiled_project(
             cached_dir = _compiled_projects_cache.get(cache_key)
             if cached_dir is not None:
                 if cached_dir.exists():
+                    _validate_managed_compile_dir(
+                        _source_clone_dir(cached_dir),
+                        cached_dir,
+                        require_exists=True,
+                    )
                     _compiled_projects_last_access[cache_key] = time.time()
                     if acquire_lease:
                         _acquire_compiled_project_lease_locked(cached_dir)
@@ -1161,11 +1215,20 @@ def _get_compiled_project(
             )
             workspace_leased = True
             compiled_dir = _resolve_managed_compile_dir(clone_dir, target, vars)
+            _validate_managed_compile_dir(clone_dir, compiled_dir, require_exists=False)
             with _cache_lock:
                 _pending_cleanup_dirs.discard(compiled_dir)
             if compiled_dir.exists():
                 _cleanup_managed_compile_dir(compiled_dir)
-            compiled_dir.mkdir(parents=True, exist_ok=True)
+                if compiled_dir.exists():
+                    raise DataSourceError(
+                        "Failed to safely reset managed DBT compile path: "
+                        f"{compiled_dir}"
+                    )
+            compiled_dir.parent.mkdir(parents=True, exist_ok=True)
+            _validate_managed_compile_dir(clone_dir, compiled_dir, require_exists=False)
+            compiled_dir.mkdir()
+            _validate_managed_compile_dir(clone_dir, compiled_dir, require_exists=True)
 
             runner = _require_dbt_runner_class()()
             compile_start = time.time()
@@ -1188,6 +1251,9 @@ def _get_compiled_project(
             if vars:
                 args += ["--vars", json.dumps(vars)]
             with _dbt_invocation_lock:
+                _validate_managed_compile_dir(
+                    clone_dir, compiled_dir, require_exists=True
+                )
                 compile_result = runner.invoke(args)
             _ensure_dbt_invoke_success(command, compile_result)
             _drop_manifest_index(compiled_dir)
@@ -1314,6 +1380,9 @@ def _ensure_selected_compilation(
         started = time.time()
         try:
             with _dbt_invocation_lock:
+                _validate_managed_compile_dir(
+                    source_dir, compiled_dir, require_exists=True
+                )
                 result = runner.invoke(args)
             _ensure_dbt_invoke_success("compile", result)
             _drop_manifest_index(compiled_dir)

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -100,6 +100,12 @@ dbtRunner = _dbt_runner_cls
 Repo = _git_repo_cls
 
 # Global cache for compiled DBT projects
+_prepared_workspaces_cache: dict[tuple, Path] = {}
+_prepared_workspaces_last_access: dict[tuple, float] = {}
+_workspace_preparation_inflight: dict[tuple, threading.Event] = {}
+_prepared_workspaces_in_use: dict[Path, int] = {}
+_pending_workspace_cleanup_dirs: set[Path] = set()
+_dbt_invocation_lock = threading.Lock()
 _compiled_projects_cache: dict[tuple, Path] = {}
 _compiled_projects_last_access: dict[tuple, float] = {}
 _compilation_inflight: dict[tuple, threading.Event] = {}
@@ -194,6 +200,23 @@ def _drop_manifest_index_locked(clone_dir: Path) -> None:
     pending = _manifest_index_inflight.pop(key, None)
     if pending is not None:
         pending.set()
+
+
+def _drop_manifest_indexes_under_locked(project_dir: Path) -> None:
+    """Remove manifest indexes rooted in a managed project directory."""
+    project_dir = project_dir.resolve()
+    cached_keys = [
+        key for key in _manifest_index_cache if _is_path_within(key, project_dir)
+    ]
+    inflight_keys = [
+        key for key in _manifest_index_inflight if _is_path_within(key, project_dir)
+    ]
+    for key in cached_keys:
+        _manifest_index_cache.pop(key, None)
+    for key in inflight_keys:
+        pending = _manifest_index_inflight.pop(key, None)
+        if pending is not None:
+            pending.set()
 
 
 def _drop_manifest_index(clone_dir: Path) -> None:
@@ -481,7 +504,8 @@ def _resolve_dbt_failure_cache_max_entries() -> int:
 
 def _cleanup_managed_clone_dir(clone_dir: Path) -> None:
     """Best-effort removal of managed clone directories during cache eviction."""
-    _drop_manifest_index(clone_dir)
+    with _cache_lock:
+        _drop_manifest_indexes_under_locked(clone_dir)
     managed_root = clone_dir.parent
     if managed_root.name != ".slideflow_dbt_clones" or not _is_path_within(
         clone_dir, managed_root
@@ -496,59 +520,153 @@ def _cleanup_managed_clone_dir(clone_dir: Path) -> None:
 
     try:
         shutil.rmtree(clone_dir)
+        workspace_log_dir = (
+            clone_dir.parent.parent / ".slideflow_dbt_logs" / clone_dir.name
+        )
+        if workspace_log_dir.exists() and _is_path_within(
+            workspace_log_dir, clone_dir.parent.parent / ".slideflow_dbt_logs"
+        ):
+            shutil.rmtree(workspace_log_dir)
     except Exception as error:
         logger.warning(
             "Failed to remove evicted DBT clone directory '%s': %s", clone_dir, error
         )
 
 
-def _acquire_compiled_project_lease_locked(clone_dir: Path) -> None:
-    """Mark a compiled clone directory as actively in use.
+def _cleanup_managed_compile_dir(compiled_dir: Path) -> None:
+    """Best-effort removal of one managed dbt compile variant."""
+    _drop_manifest_index(compiled_dir)
+    managed_root = compiled_dir.parent
+    clone_dir = managed_root.parent
+    if (
+        managed_root.name != ".slideflow_dbt_targets"
+        or clone_dir.parent.name != ".slideflow_dbt_clones"
+        or not _is_path_within(compiled_dir, managed_root)
+    ):
+        logger.warning(
+            "Refusing to delete unmanaged DBT compile directory: %s", compiled_dir
+        )
+        return
+    if not compiled_dir.exists():
+        return
+    try:
+        shutil.rmtree(compiled_dir)
+    except Exception as error:
+        logger.warning(
+            "Failed to remove evicted DBT compile directory '%s': %s",
+            compiled_dir,
+            error,
+        )
+
+
+def _source_clone_dir(compiled_dir: Path) -> Path:
+    """Resolve the source clone for a managed compile variant."""
+    if (
+        compiled_dir.parent.name == ".slideflow_dbt_targets"
+        and compiled_dir.parent.parent.parent.name == ".slideflow_dbt_clones"
+    ):
+        return compiled_dir.parent.parent
+    return compiled_dir
+
+
+def _acquire_compiled_project_lease_locked(compiled_dir: Path) -> None:
+    """Mark a compiled output directory as actively in use.
 
     Requires caller to hold _cache_lock.
     """
-    _compiled_projects_in_use[clone_dir] = (
-        _compiled_projects_in_use.get(clone_dir, 0) + 1
+    _compiled_projects_in_use[compiled_dir] = (
+        _compiled_projects_in_use.get(compiled_dir, 0) + 1
     )
 
 
-def _collect_ready_cleanup_dirs_locked() -> list[Path]:
-    """Collect pending cleanup directories that are safe to remove.
+def _acquire_prepared_workspace_lease_locked(clone_dir: Path) -> None:
+    """Mark a prepared clone as actively used by compilation."""
+    _prepared_workspaces_in_use[clone_dir] = (
+        _prepared_workspaces_in_use.get(clone_dir, 0) + 1
+    )
+
+
+def _release_prepared_workspace_lease_locked(clone_dir: Path) -> None:
+    """Release one prepared-workspace usage lease."""
+    current = _prepared_workspaces_in_use.get(clone_dir, 0)
+    if current <= 1:
+        _prepared_workspaces_in_use.pop(clone_dir, None)
+    else:
+        _prepared_workspaces_in_use[clone_dir] = current - 1
+
+
+def _workspace_has_compiled_references_locked(clone_dir: Path) -> bool:
+    """Return whether cached or leased compile variants use a workspace."""
+    for compiled_dir in _compiled_projects_cache.values():
+        if _source_clone_dir(compiled_dir) == clone_dir:
+            return True
+    for compiled_dir, count in _compiled_projects_in_use.items():
+        if count > 0 and _source_clone_dir(compiled_dir) == clone_dir:
+            return True
+    return False
+
+
+def _collect_ready_cleanup_dirs_locked() -> tuple[list[Path], list[Path]]:
+    """Collect safe compile and workspace cleanup directories.
 
     Requires caller to hold _cache_lock.
     """
     cached_dirs = set(_compiled_projects_cache.values())
-    ready: list[Path] = []
-    for clone_dir in list(_pending_cleanup_dirs):
-        if _compiled_projects_in_use.get(clone_dir, 0) > 0:
+    ready_compiles: list[Path] = []
+    for compiled_dir in list(_pending_cleanup_dirs):
+        if _compiled_projects_in_use.get(compiled_dir, 0) > 0:
             continue
-        if clone_dir in cached_dirs:
+        if compiled_dir in cached_dirs:
             continue
-        _pending_cleanup_dirs.discard(clone_dir)
-        ready.append(clone_dir)
-    return ready
+        _pending_cleanup_dirs.discard(compiled_dir)
+        ready_compiles.append(compiled_dir)
+
+    cached_workspaces = set(_prepared_workspaces_cache.values())
+    ready_workspaces: list[Path] = []
+    for clone_dir in list(_pending_workspace_cleanup_dirs):
+        if clone_dir in cached_workspaces:
+            continue
+        if _prepared_workspaces_in_use.get(clone_dir, 0) > 0:
+            continue
+        if _workspace_has_compiled_references_locked(clone_dir):
+            continue
+        _pending_workspace_cleanup_dirs.discard(clone_dir)
+        for compiled_dir in list(_pending_cleanup_dirs):
+            if _is_path_within(compiled_dir, clone_dir):
+                _pending_cleanup_dirs.discard(compiled_dir)
+        ready_workspaces.append(clone_dir)
+    return ready_compiles, ready_workspaces
 
 
-def _cleanup_ready_managed_clone_dirs() -> None:
-    """Best-effort cleanup for pending evicted clone directories."""
+def _cleanup_ready_managed_dirs() -> None:
+    """Best-effort cleanup for pending compile and workspace directories."""
     with _cache_lock:
-        ready_dirs = _collect_ready_cleanup_dirs_locked()
-    for directory in ready_dirs:
+        ready_compiles, ready_workspaces = _collect_ready_cleanup_dirs_locked()
+    for directory in ready_compiles:
+        _cleanup_managed_compile_dir(directory)
+    for directory in ready_workspaces:
         _cleanup_managed_clone_dir(directory)
 
 
-def _release_compiled_project_lease(clone_dir: Path) -> None:
+def _cleanup_ready_managed_clone_dirs() -> None:
+    """Backward-compatible wrapper for all managed dbt cleanup."""
+    _cleanup_ready_managed_dirs()
+
+
+def _release_compiled_project_lease(compiled_dir: Path) -> None:
     """Release a compiled project lease and cleanup any newly-safe evictions."""
     with _cache_lock:
-        current = _compiled_projects_in_use.get(clone_dir, 0)
+        current = _compiled_projects_in_use.get(compiled_dir, 0)
         if current <= 1:
-            _compiled_projects_in_use.pop(clone_dir, None)
+            _compiled_projects_in_use.pop(compiled_dir, None)
         else:
-            _compiled_projects_in_use[clone_dir] = current - 1
+            _compiled_projects_in_use[compiled_dir] = current - 1
 
-        ready_dirs = _collect_ready_cleanup_dirs_locked()
+        ready_compiles, ready_workspaces = _collect_ready_cleanup_dirs_locked()
 
-    for directory in ready_dirs:
+    for directory in ready_compiles:
+        _cleanup_managed_compile_dir(directory)
+    for directory in ready_workspaces:
         _cleanup_managed_clone_dir(directory)
 
 
@@ -561,22 +679,47 @@ def _prune_compiled_projects_cache_locked(max_entries: int) -> None:
         )
         evicted = False
         for oldest_key in ordered_keys:
-            clone_dir = _compiled_projects_cache.get(oldest_key)
-            if clone_dir is None:
+            compiled_dir = _compiled_projects_cache.get(oldest_key)
+            if compiled_dir is None:
                 continue
-            if _compiled_projects_in_use.get(clone_dir, 0) > 0:
+            if _compiled_projects_in_use.get(compiled_dir, 0) > 0:
                 continue
 
             _compiled_projects_cache.pop(oldest_key, None)
             _compiled_projects_last_access.pop(oldest_key, None)
             _compiled_project_coverage.pop(oldest_key, None)
             _selection_locks.pop(oldest_key, None)
-            _pending_cleanup_dirs.add(clone_dir)
+            _pending_cleanup_dirs.add(compiled_dir)
             evicted = True
             break
 
         if not evicted:
             # All cache entries are actively in use. Temporarily exceed max_entries.
+            break
+
+
+def _prune_prepared_workspaces_cache_locked(max_entries: int) -> None:
+    """Prune unused prepared workspaces to the shared cache bound."""
+    while len(_prepared_workspaces_cache) > max_entries:
+        ordered_keys = sorted(
+            _prepared_workspaces_cache,
+            key=lambda key: _prepared_workspaces_last_access.get(key, 0.0),
+        )
+        evicted = False
+        for oldest_key in ordered_keys:
+            clone_dir = _prepared_workspaces_cache.get(oldest_key)
+            if clone_dir is None:
+                continue
+            if _prepared_workspaces_in_use.get(clone_dir, 0) > 0:
+                continue
+            if _workspace_has_compiled_references_locked(clone_dir):
+                continue
+            _prepared_workspaces_cache.pop(oldest_key, None)
+            _prepared_workspaces_last_access.pop(oldest_key, None)
+            _pending_workspace_cleanup_dirs.add(clone_dir)
+            evicted = True
+            break
+        if not evicted:
             break
 
 
@@ -641,12 +784,15 @@ def _build_clone_identity_key(
     profiles_dir: Optional[str] = None,
     profile_name: Optional[str] = None,
 ) -> str:
-    """Build a deterministic identity key for managed DBT clone directories."""
+    """Build a deterministic identity key for shared DBT workspaces.
+
+    ``target`` and ``vars`` remain accepted for internal compatibility but are
+    deliberately excluded: they affect compilation artifacts, not repository
+    checkout or dependency installation.
+    """
     payload = {
         "package_url": package_url,
         "branch": branch or "default",
-        "target": target or "",
-        "vars": vars or {},
         "profiles_dir": profiles_dir or "",
         "profile_name": profile_name or "",
     }
@@ -654,6 +800,23 @@ def _build_clone_identity_key(
         json.dumps(payload, sort_keys=True).encode("utf-8"),
         usedforsecurity=False,
     ).hexdigest()[:16]
+
+
+def _workspace_cache_key(
+    package_url: str,
+    project_dir: str,
+    branch: Optional[str],
+    profiles_dir: Optional[str],
+    profile_name: Optional[str],
+) -> tuple:
+    """Return the identity for clone and dependency preparation."""
+    return (
+        package_url,
+        _canonical_project_dir(project_dir),
+        branch,
+        _canonical_profiles_dir(profiles_dir),
+        profile_name,
+    )
 
 
 def _project_cache_key(
@@ -665,15 +828,26 @@ def _project_cache_key(
     profiles_dir: Optional[str],
     profile_name: Optional[str],
 ) -> tuple:
-    return (
+    """Return the identity for one isolated compiled artifact variant."""
+    return _workspace_cache_key(
         package_url,
-        _canonical_project_dir(project_dir),
+        project_dir,
         branch,
+        profiles_dir,
+        profile_name,
+    ) + (
         target,
         json.dumps(vars or {}, sort_keys=True),
-        _canonical_profiles_dir(profiles_dir),
-        profile_name,
     )
+
+
+def _build_compile_identity_key(target: str, vars: Optional[dict[str, Any]]) -> str:
+    """Build a deterministic directory key for one compile variant."""
+    payload = {"target": target, "vars": vars or {}}
+    return hashlib.sha1(
+        json.dumps(payload, sort_keys=True).encode("utf-8"),
+        usedforsecurity=False,
+    ).hexdigest()[:16]
 
 
 def _resolve_managed_clone_dir(
@@ -704,11 +878,26 @@ def _resolve_managed_clone_dir(
     key = _build_clone_identity_key(
         package_url=package_url,
         branch=branch,
-        target=target,
-        vars=vars,
         profiles_dir=profiles_dir,
         profile_name=profile_name,
     )
+    return managed_root / key
+
+
+def _resolve_managed_compile_dir(
+    clone_dir: Path,
+    target: str,
+    vars: Optional[dict[str, Any]],
+) -> Path:
+    """Resolve the isolated artifact root for one target/vars combination."""
+    managed_root = clone_dir / ".slideflow_dbt_targets"
+    if managed_root.is_symlink() or (
+        managed_root.exists() and not managed_root.is_dir()
+    ):
+        raise DataSourceError(
+            "Reserved DBT compile path must be a real directory: " f"{managed_root}"
+        )
+    key = _build_compile_identity_key(target, vars)
     return managed_root / key
 
 
@@ -734,6 +923,159 @@ def _resolve_existing_compiled_project_dir(
     return compiled_project_dir
 
 
+def _prepare_profiles(clone_dir: Path, profiles_dir: Optional[str]) -> None:
+    """Copy configured profiles into a prepared clone once."""
+    if not profiles_dir:
+        return
+    try:
+        src = Path(profiles_dir)
+        if src.is_dir():
+            candidate = src / "profiles.yml"
+            if candidate.exists():
+                shutil.copy2(candidate, clone_dir / "profiles.yml")
+            else:
+                for profile_file in src.glob("*.y*ml"):
+                    shutil.copy2(profile_file, clone_dir / profile_file.name)
+        elif src.is_file():
+            destination = clone_dir / (
+                "profiles.yml" if src.name != "profiles.yml" else src.name
+            )
+            shutil.copy2(src, destination)
+        else:
+            logger.warning("profiles_dir path not found: %s", profiles_dir)
+    except Exception as error:
+        logger.warning(
+            "Failed to prepare dbt profiles from %s: %s",
+            profiles_dir,
+            error,
+            exc_info=True,
+        )
+
+
+def _get_prepared_workspace(
+    *,
+    package_url: str,
+    project_dir: str,
+    branch: Optional[str],
+    profiles_dir: Optional[str],
+    profile_name: Optional[str],
+    acquire_lease: bool = False,
+) -> Path:
+    """Clone a dbt repository and install dependencies once per workspace."""
+    cache_key = _workspace_cache_key(
+        package_url, project_dir, branch, profiles_dir, profile_name
+    )
+    failure_key = ("workspace",) + cache_key
+    max_cache_entries = _resolve_dbt_cache_max_entries()
+    failure_backoff_s = _resolve_dbt_compile_failure_backoff_seconds()
+    failure_cache_max_entries = _resolve_dbt_failure_cache_max_entries()
+
+    while True:
+        with _cache_lock:
+            _prune_compilation_failures_locked(
+                max_entries=failure_cache_max_entries,
+                failure_backoff_s=failure_backoff_s,
+            )
+            cached_dir = _prepared_workspaces_cache.get(cache_key)
+            if cached_dir is not None:
+                if cached_dir.exists():
+                    _prepared_workspaces_last_access[cache_key] = time.time()
+                    if acquire_lease:
+                        _acquire_prepared_workspace_lease_locked(cached_dir)
+                    return cached_dir
+                _drop_manifest_indexes_under_locked(cached_dir)
+                _prepared_workspaces_cache.pop(cache_key, None)
+                _prepared_workspaces_last_access.pop(cache_key, None)
+
+            failure_entry = _compilation_failures.get(failure_key)
+            if failure_entry is not None:
+                raise DataSourceError(failure_entry[1])
+
+            pending = _workspace_preparation_inflight.get(cache_key)
+            if pending is None:
+                pending = threading.Event()
+                _workspace_preparation_inflight[cache_key] = pending
+                is_owner = True
+            else:
+                is_owner = False
+
+        if not is_owner:
+            pending.wait()
+            continue
+
+        clone_dir: Optional[Path] = None
+        try:
+            clone_dir = _resolve_managed_clone_dir(
+                project_dir=project_dir,
+                package_url=package_url,
+                branch=branch,
+                profiles_dir=profiles_dir,
+                profile_name=profile_name,
+            )
+            with _cache_lock:
+                _pending_workspace_cleanup_dirs.discard(clone_dir)
+            _clone_repo(package_url, clone_dir, branch)
+            reserved_targets = clone_dir / ".slideflow_dbt_targets"
+            if reserved_targets.exists() or reserved_targets.is_symlink():
+                raise DataSourceError(
+                    "DBT repository contains reserved Slideflow path "
+                    f"{reserved_targets}. Remove it from the repository."
+                )
+            _prepare_profiles(clone_dir, profiles_dir)
+
+            runner = _require_dbt_runner_class()()
+            deps_args = [
+                "deps",
+                "--project-dir",
+                str(clone_dir),
+                "--log-path",
+                str(
+                    clone_dir.parent.parent
+                    / ".slideflow_dbt_logs"
+                    / clone_dir.name
+                    / "deps"
+                ),
+            ]
+            if profile_name:
+                deps_args.extend(["--profile", profile_name])
+            if profiles_dir or (clone_dir / "profiles.yml").exists():
+                deps_args.extend(["--profiles-dir", str(clone_dir)])
+
+            deps_started = time.time()
+            with _dbt_invocation_lock:
+                deps_result = runner.invoke(deps_args)
+            _ensure_dbt_invoke_success("deps", deps_result)
+            log_performance("dbt_deps", time.time() - deps_started, project=package_url)
+        except BaseException as error:
+            failure_message = str(error) or type(error).__name__
+            with _cache_lock:
+                _compilation_failures[failure_key] = (time.time(), failure_message)
+                _prune_compilation_failures_locked(
+                    max_entries=failure_cache_max_entries,
+                    failure_backoff_s=failure_backoff_s,
+                )
+                event = _workspace_preparation_inflight.pop(cache_key, None)
+                if event is not None:
+                    event.set()
+            if clone_dir is not None:
+                _cleanup_managed_clone_dir(clone_dir)
+            raise
+
+        assert clone_dir is not None
+        with _cache_lock:
+            _prepared_workspaces_cache[cache_key] = clone_dir
+            _prepared_workspaces_last_access[cache_key] = time.time()
+            _compilation_failures.pop(failure_key, None)
+            if acquire_lease:
+                _acquire_prepared_workspace_lease_locked(clone_dir)
+            event = _workspace_preparation_inflight.pop(cache_key, None)
+            if event is not None:
+                event.set()
+            _prune_prepared_workspaces_cache_locked(max_cache_entries)
+        _cleanup_ready_managed_dirs()
+        return clone_dir
+
+
 def _get_compiled_project(
     package_url: str,
     project_dir: str,
@@ -746,41 +1088,7 @@ def _get_compiled_project(
     acquire_lease: bool = False,
     parse_only: bool = False,
 ) -> Path:
-    """Get or create a compiled DBT project with caching.
-
-    Retrieves a compiled DBT project from cache if available, or compiles
-    a new project by cloning the repository and running DBT compilation.
-    Projects are cached by their unique parameter combination to avoid
-    redundant compilation operations.
-
-    The function is thread-safe and handles concurrent access to the
-    compilation cache. It logs performance metrics for both dependency
-    installation and compilation phases.
-
-    Args:
-        package_url: Git URL of the DBT project repository.
-        project_dir: Local directory path for the cloned project.
-        branch: Optional Git branch to checkout.
-        target: DBT target environment (e.g., 'dev', 'prod').
-        vars: Optional DBT variables dictionary.
-        profiles_dir: Optional path to a dbt profiles directory or profiles.yml.
-        profile_name: Optional dbt profile name to override the one in dbt_project.yml.
-
-    Returns:
-        Path to the compiled DBT project directory.
-
-    Raises:
-        DataSourceError: If Git cloning or DBT compilation fails.
-
-    Example:
-        >>> project_path = _get_compiled_project(
-        ...     "https://github.com/company/dbt-project.git",
-        ...     "/tmp/dbt_project",
-        ...     "main",
-        ...     "prod",
-        ...     {"start_date": "2024-01-01"}
-        ... )
-    """
+    """Return isolated artifacts backed by a shared prepared DBT workspace."""
     canonical_project_dir = _canonical_project_dir(project_dir)
     if not compile:
         return _resolve_existing_compiled_project_dir(
@@ -798,6 +1106,7 @@ def _get_compiled_project(
         canonical_profiles_dir,
         profile_name,
     )
+    failure_key = ("compile",) + cache_key
 
     max_cache_entries = _resolve_dbt_cache_max_entries()
     failure_backoff_s = _resolve_dbt_compile_failure_backoff_seconds()
@@ -821,7 +1130,7 @@ def _get_compiled_project(
                 _compiled_projects_last_access.pop(cache_key, None)
                 _compiled_project_coverage.pop(cache_key, None)
 
-            failure_entry = _compilation_failures.get(cache_key)
+            failure_entry = _compilation_failures.get(failure_key)
             if failure_entry is not None:
                 _failed_at, failure_message = failure_entry
                 raise DataSourceError(failure_message)
@@ -838,84 +1147,50 @@ def _get_compiled_project(
             pending.wait()
             continue
 
+        compiled_dir: Optional[Path] = None
+        clone_dir: Optional[Path] = None
+        workspace_leased = False
         try:
-            clone_dir = _resolve_managed_clone_dir(
-                project_dir=canonical_project_dir,
+            clone_dir = _get_prepared_workspace(
                 package_url=package_url,
+                project_dir=canonical_project_dir,
                 branch=branch,
-                target=target,
-                vars=vars,
                 profiles_dir=canonical_profiles_dir,
                 profile_name=profile_name,
+                acquire_lease=True,
             )
+            workspace_leased = True
+            compiled_dir = _resolve_managed_compile_dir(clone_dir, target, vars)
             with _cache_lock:
-                _pending_cleanup_dirs.discard(clone_dir)
-            _clone_repo(package_url, clone_dir, branch)
+                _pending_cleanup_dirs.discard(compiled_dir)
+            if compiled_dir.exists():
+                _cleanup_managed_compile_dir(compiled_dir)
+            compiled_dir.mkdir(parents=True, exist_ok=True)
 
-            # If provided, copy profiles directory or file into cloned project root
-            if profiles_dir:
-                try:
-                    src = Path(profiles_dir)
-                    if src.is_dir():
-                        # Prefer a direct profiles.yml in the given directory
-                        candidate = src / "profiles.yml"
-                        if candidate.exists():
-                            shutil.copy2(candidate, clone_dir / "profiles.yml")
-                        else:
-                            # Fallback: copy all yml/yaml files from directory
-                            for p in src.glob("*.y*ml"):
-                                shutil.copy2(p, clone_dir / p.name)
-                    elif src.is_file():
-                        # If a file is passed, copy to profiles.yml in clone_dir
-                        dest = clone_dir / (
-                            "profiles.yml" if src.name != "profiles.yml" else src.name
-                        )
-                        shutil.copy2(src, dest)
-                    else:
-                        logger.warning("profiles_dir path not found: %s", profiles_dir)
-                except Exception as error:
-                    logger.warning(
-                        "Failed to prepare dbt profiles from %s: %s",
-                        profiles_dir,
-                        error,
-                        exc_info=True,
-                    )
-
-            runner_class = _require_dbt_runner_class()
-            runner = runner_class()
-            project_profiles_path = clone_dir / "profiles.yml"
-            use_project_profiles_dir = (
-                bool(profiles_dir) or project_profiles_path.exists()
-            )
-
-            # Log dependencies install
-            deps_start = time.time()
-            deps_args = ["deps", "--project-dir", str(clone_dir)]
-            if profile_name:
-                deps_args.extend(["--profile", profile_name])
-            if use_project_profiles_dir:
-                deps_args.extend(["--profiles-dir", str(clone_dir)])
-            deps_result = runner.invoke(deps_args)
-            _ensure_dbt_invoke_success("deps", deps_result)
-            deps_duration = time.time() - deps_start
-            log_performance(
-                "dbt_deps", deps_duration, project=package_url, target=target
-            )
-
-            # Parse for scoped compilation discovery, or retain the legacy
-            # full-project compile path for internal/backward compatibility.
+            runner = _require_dbt_runner_class()()
             compile_start = time.time()
             command = "parse" if parse_only else "compile"
-            args = [command, "--project-dir", str(clone_dir), "--target", target]
-            if use_project_profiles_dir:
+            args = [
+                command,
+                "--project-dir",
+                str(clone_dir),
+                "--target",
+                target,
+                "--target-path",
+                str(compiled_dir / "target"),
+                "--log-path",
+                str(compiled_dir / "logs"),
+            ]
+            if profiles_dir or (clone_dir / "profiles.yml").exists():
                 args.extend(["--profiles-dir", str(clone_dir)])
             if profile_name:
                 args.extend(["--profile", profile_name])
             if vars:
                 args += ["--vars", json.dumps(vars)]
-            compile_result = runner.invoke(args)
+            with _dbt_invocation_lock:
+                compile_result = runner.invoke(args)
             _ensure_dbt_invoke_success(command, compile_result)
-            _drop_manifest_index(clone_dir)
+            _drop_manifest_index(compiled_dir)
             compile_duration = time.time() - compile_start
             log_performance(
                 f"dbt_{command}",
@@ -927,7 +1202,7 @@ def _get_compiled_project(
         except BaseException as error:
             failure_message = str(error) or type(error).__name__
             with _cache_lock:
-                _compilation_failures[cache_key] = (time.time(), failure_message)
+                _compilation_failures[failure_key] = (time.time(), failure_message)
                 _prune_compilation_failures_locked(
                     max_entries=failure_cache_max_entries,
                     failure_backoff_s=failure_backoff_s,
@@ -935,24 +1210,34 @@ def _get_compiled_project(
                 event = _compilation_inflight.pop(cache_key, None)
                 if event is not None:
                     event.set()
+                if workspace_leased and clone_dir is not None:
+                    _release_prepared_workspace_lease_locked(clone_dir)
+                _prune_prepared_workspaces_cache_locked(max_cache_entries)
+            if compiled_dir is not None:
+                _cleanup_managed_compile_dir(compiled_dir)
+            _cleanup_ready_managed_dirs()
             raise
 
+        assert compiled_dir is not None
         with _cache_lock:
-            _compiled_projects_cache[cache_key] = clone_dir
+            _compiled_projects_cache[cache_key] = compiled_dir
             _compiled_project_coverage[cache_key] = (
                 frozenset() if parse_only else frozenset({"*"})
             )
             _compiled_projects_last_access[cache_key] = time.time()
-            _compilation_failures.pop(cache_key, None)
+            _compilation_failures.pop(failure_key, None)
             _prune_compiled_projects_cache_locked(max_cache_entries)
             if acquire_lease:
-                _acquire_compiled_project_lease_locked(clone_dir)
+                _acquire_compiled_project_lease_locked(compiled_dir)
+            if workspace_leased and clone_dir is not None:
+                _release_prepared_workspace_lease_locked(clone_dir)
+            _prune_prepared_workspaces_cache_locked(max_cache_entries)
             event = _compilation_inflight.pop(cache_key, None)
             if event is not None:
                 event.set()
-        _cleanup_ready_managed_clone_dirs()
+        _cleanup_ready_managed_dirs()
 
-        return clone_dir
+        return compiled_dir
 
 
 def _ensure_selected_compilation(
@@ -990,7 +1275,7 @@ def _ensure_selected_compilation(
             return
 
         union = tuple(sorted(set(coverage).union(normalized)))
-        failure_key = cache_key + ("selected", union)
+        failure_key = ("selected",) + cache_key + (union,)
         failure_backoff_s = _resolve_dbt_compile_failure_backoff_seconds()
         failure_cache_max_entries = _resolve_dbt_failure_cache_max_entries()
         with _cache_lock:
@@ -1002,19 +1287,25 @@ def _ensure_selected_compilation(
         if failure_entry is not None:
             raise DataSourceError(failure_entry[1])
 
+        compiled_dir = clone_dir
+        source_dir = _source_clone_dir(compiled_dir)
         runner = _require_dbt_runner_class()()
         args = [
             "compile",
             "--project-dir",
-            str(clone_dir),
+            str(source_dir),
             "--target",
             target,
+            "--target-path",
+            str(compiled_dir / "target"),
+            "--log-path",
+            str(compiled_dir / "logs"),
             "--select",
             " ".join(union),
         ]
-        project_profiles_path = clone_dir / "profiles.yml"
+        project_profiles_path = source_dir / "profiles.yml"
         if profiles_dir or project_profiles_path.exists():
-            args.extend(["--profiles-dir", str(clone_dir)])
+            args.extend(["--profiles-dir", str(source_dir)])
         if profile_name:
             args.extend(["--profile", profile_name])
         if vars:
@@ -1022,9 +1313,10 @@ def _ensure_selected_compilation(
 
         started = time.time()
         try:
-            result = runner.invoke(args)
+            with _dbt_invocation_lock:
+                result = runner.invoke(args)
             _ensure_dbt_invoke_success("compile", result)
-            _drop_manifest_index(clone_dir)
+            _drop_manifest_index(compiled_dir)
         except BaseException as error:
             failure_message = str(error) or type(error).__name__
             with _cache_lock:
@@ -1333,7 +1625,7 @@ class DBTManifestConnector(BaseModel, DataConnector):
             if full and full.exists():
                 sql_text = full.read_text()
                 repo_url = canonical_repo_web_url(self.package_url)
-                ref = _resolve_repo_ref(clone_dir, self.branch)
+                ref = _resolve_repo_ref(_source_clone_dir(clone_dir), self.branch)
                 file_url = build_repo_file_url(
                     repo_web_url=repo_url,
                     ref=ref,

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -16,7 +16,7 @@ The DBT connector system includes:
 Key Features:
     - Automatic DBT project cloning from Git repositories
     - Model compilation with custom variables and targets
-    - Thread-safe caching of compiled projects
+    - Thread- and process-safe caching of compiled projects
     - Integration with Databricks SQL warehouses
     - Performance tracking for compilation and execution
     - Error handling and comprehensive logging
@@ -96,9 +96,18 @@ try:
 except ImportError:  # pragma: no cover - exercised in optional-dependency tests
     pass
 
+_file_lock_cls: Any = None
+try:
+    from filelock import FileLock as _imported_file_lock_cls
+
+    _file_lock_cls = _imported_file_lock_cls
+except ImportError:  # pragma: no cover - exercised in optional-dependency tests
+    pass
+
 # Keep module-level symbols for test monkeypatch compatibility.
 dbtRunner = _dbt_runner_cls
 Repo = _git_repo_cls
+FileLock = _file_lock_cls
 
 # Global cache for compiled DBT projects
 _prepared_workspaces_cache: dict[tuple, Path] = {}
@@ -117,6 +126,8 @@ _compiled_projects_in_use: dict[Path, int] = {}
 _pending_cleanup_dirs: set[Path] = set()
 _cleanup_in_progress_dirs: set[Path] = set()
 _cleanup_failures: dict[Path, str] = {}
+_workspace_file_locks: dict[Path, Any] = {}
+_workspace_lock_state = threading.local()
 _manifest_index_cache: dict[Path, "_ManifestIndex"] = {}
 _manifest_index_inflight: dict[Path, threading.Event] = {}
 _compiled_project_coverage: dict[tuple, frozenset[str]] = {}
@@ -187,6 +198,16 @@ def _require_repo_class() -> Any:
             "Install with: pip install slideflow-presentations[dbt]"
         )
     return Repo
+
+
+def _require_file_lock_class() -> Any:
+    """Return FileLock or raise actionable install guidance."""
+    if FileLock is None:
+        raise DataSourceError(
+            "filelock is required for dbt shared-workspace coordination. "
+            "Install with: pip install slideflow-presentations[dbt]"
+        )
+    return FileLock
 
 
 def _create_databricks_sql_executor() -> SQLExecutor:
@@ -356,6 +377,25 @@ def _resolve_repo_ref(clone_dir: Path, branch: Optional[str]) -> Optional[str]:
         return repo.head.commit.hexsha
     except Exception:
         return branch or "default"
+
+
+def _resolve_checkout_revision(clone_dir: Path) -> str:
+    """Return the immutable commit for a real prepared Git checkout."""
+    try:
+        repo_cls = _require_repo_class()
+        repo = repo_cls(clone_dir)
+        if repo.bare:
+            raise ValueError("repository is bare")
+        revision = repo.head.commit.hexsha
+    except Exception as error:
+        raise DataSourceError(
+            f"Managed DBT workspace is not a valid Git checkout: {clone_dir}"
+        ) from error
+    if not revision:
+        raise DataSourceError(
+            f"Managed DBT workspace has no checkout revision: {clone_dir}"
+        )
+    return str(revision)
 
 
 def _clone_repo(git_url: str, clone_dir: Path, branch: Optional[str]) -> None:
@@ -633,7 +673,9 @@ def _workspace_has_compiled_references_locked(clone_dir: Path) -> bool:
     return False
 
 
-def _collect_ready_cleanup_dirs_locked() -> tuple[list[Path], list[Path]]:
+def _collect_ready_cleanup_dirs_locked(
+    allowed_workspaces: Optional[set[Path]] = None,
+) -> tuple[list[Path], list[Path]]:
     """Collect safe compile and workspace cleanup directories.
 
     Requires caller to hold _cache_lock.
@@ -641,6 +683,11 @@ def _collect_ready_cleanup_dirs_locked() -> tuple[list[Path], list[Path]]:
     cached_dirs = set(_compiled_projects_cache.values())
     ready_compiles: list[Path] = []
     for compiled_dir in list(_pending_cleanup_dirs):
+        if (
+            allowed_workspaces is not None
+            and _source_clone_dir(compiled_dir) not in allowed_workspaces
+        ):
+            continue
         if _source_clone_dir(compiled_dir) in _pending_workspace_cleanup_dirs:
             continue
         if compiled_dir in _cleanup_in_progress_dirs:
@@ -655,6 +702,8 @@ def _collect_ready_cleanup_dirs_locked() -> tuple[list[Path], list[Path]]:
     cached_workspaces = set(_prepared_workspaces_cache.values())
     ready_workspaces: list[Path] = []
     for clone_dir in list(_pending_workspace_cleanup_dirs):
+        if allowed_workspaces is not None and clone_dir not in allowed_workspaces:
+            continue
         if clone_dir in _cleanup_in_progress_dirs:
             continue
         if clone_dir in cached_workspaces:
@@ -697,14 +746,19 @@ def _finish_cleanup(directory: Path, *, workspace: bool, succeeded: bool) -> Non
 
 def _cleanup_ready_managed_dirs() -> None:
     """Clean ready paths while keeping reservations until deletion completes."""
+    held_workspaces = set(getattr(_workspace_lock_state, "held", {}))
     with _cache_lock:
-        ready_compiles, ready_workspaces = _collect_ready_cleanup_dirs_locked()
-    for directory in ready_compiles:
-        succeeded = _cleanup_managed_compile_dir(directory)
-        _finish_cleanup(directory, workspace=False, succeeded=succeeded)
-    for directory in ready_workspaces:
-        succeeded = _cleanup_managed_clone_dir(directory)
-        _finish_cleanup(directory, workspace=True, succeeded=succeeded)
+        ready_compiles, ready_workspaces = _collect_ready_cleanup_dirs_locked(
+            held_workspaces or None
+        )
+    for directory in sorted(ready_compiles):
+        with _workspace_process_lock(_source_clone_dir(directory)):
+            succeeded = _cleanup_managed_compile_dir(directory)
+            _finish_cleanup(directory, workspace=False, succeeded=succeeded)
+    for directory in sorted(ready_workspaces):
+        with _workspace_process_lock(directory):
+            succeeded = _cleanup_managed_clone_dir(directory)
+            _finish_cleanup(directory, workspace=True, succeeded=succeeded)
 
 
 def _wait_for_managed_cleanup(directory: Path, *, workspace: bool) -> None:
@@ -752,12 +806,15 @@ def _cleanup_ready_managed_clone_dirs() -> None:
 
 def _release_compiled_project_lease(compiled_dir: Path) -> None:
     """Release a compiled project lease and cleanup any newly-safe evictions."""
+    max_cache_entries = _resolve_dbt_cache_max_entries()
     with _cache_lock:
         current = _compiled_projects_in_use.get(compiled_dir, 0)
         if current <= 1:
             _compiled_projects_in_use.pop(compiled_dir, None)
         else:
             _compiled_projects_in_use[compiled_dir] = current - 1
+        _prune_compiled_projects_cache_locked(max_cache_entries)
+        _prune_prepared_workspaces_cache_locked(max_cache_entries)
         _cache_condition.notify_all()
 
     _cleanup_ready_managed_dirs()
@@ -1025,7 +1082,7 @@ def _write_prepared_marker(clone_dir: Path, cache_key: tuple) -> str:
         "schema": _PREPARED_MARKER_SCHEMA,
         "identity": _workspace_identity_digest(cache_key),
         "generation": generation,
-        "repository_revision": _resolve_repo_ref(clone_dir, None),
+        "repository_revision": _resolve_checkout_revision(clone_dir),
     }
     marker_path = _prepared_marker_path(clone_dir)
     temporary_path = marker_path.with_name(f"{marker_path.name}.{generation}.tmp")
@@ -1072,6 +1129,55 @@ def _validate_real_directory_chain(
         raise DataSourceError(f"Reserved DBT directory does not exist: {directory}")
 
 
+def _resolve_workspace_lock_path(clone_dir: Path) -> Path:
+    """Return a safe filesystem-lock path for one physical workspace."""
+    clone_root = clone_dir.parent
+    if clone_root.name != ".slideflow_dbt_clones":
+        raise DataSourceError(f"Invalid managed DBT clone path: {clone_dir}")
+    workspace_root = clone_root.parent
+    lock_root = workspace_root / ".slideflow_dbt_locks"
+    _validate_real_directory_chain(lock_root, workspace_root, require_exists=False)
+    lock_root.mkdir(parents=True, exist_ok=True)
+    _validate_real_directory_chain(lock_root, workspace_root, require_exists=True)
+    lock_path = lock_root / f"{clone_dir.name}.lock"
+    if lock_path.is_symlink() or (lock_path.exists() and not lock_path.is_file()):
+        raise DataSourceError(
+            f"Reserved DBT lock path must be a real file: {lock_path}"
+        )
+    return lock_path
+
+
+@contextmanager
+def _workspace_process_lock(clone_dir: Path) -> Iterator[None]:
+    """Serialize preparation, use, and cleanup for a shared disk workspace."""
+    lock_path = _resolve_workspace_lock_path(clone_dir)
+    lock_cls = _require_file_lock_class()
+    with _cache_lock:
+        lock = _workspace_file_locks.get(lock_path)
+        if lock is None:
+            # Process-local leases provide thread-level safety. Sharing one
+            # re-entrant lock context across threads preserves sibling-variant
+            # concurrency while the OS lock excludes other processes.
+            lock = lock_cls(str(lock_path), thread_local=False)
+            _workspace_file_locks[lock_path] = lock
+    with lock:
+        if lock_path.is_symlink() or not lock_path.is_file():
+            raise DataSourceError(
+                f"Reserved DBT lock path must be a real file: {lock_path}"
+            )
+        held = getattr(_workspace_lock_state, "held", {})
+        _workspace_lock_state.held = held
+        held[clone_dir] = held.get(clone_dir, 0) + 1
+        try:
+            yield
+        finally:
+            remaining = held[clone_dir] - 1
+            if remaining:
+                held[clone_dir] = remaining
+            else:
+                held.pop(clone_dir, None)
+
+
 def _validate_prepared_workspace(clone_dir: Path, cache_key: tuple) -> str:
     """Validate a real prepared clone and return its generation token."""
     clone_root = clone_dir.parent
@@ -1080,9 +1186,7 @@ def _validate_prepared_workspace(clone_dir: Path, cache_key: tuple) -> str:
     _validate_real_directory_chain(clone_dir, clone_root, require_exists=True)
 
     project_file = clone_dir / "dbt_project.yml"
-    if project_file.is_symlink() or (
-        project_file.exists() and not project_file.is_file()
-    ):
+    if project_file.is_symlink() or not project_file.is_file():
         raise DataSourceError(
             f"Managed DBT project file must be a real file: {project_file}"
         )
@@ -1098,15 +1202,26 @@ def _validate_prepared_workspace(clone_dir: Path, cache_key: tuple) -> str:
         raise DataSourceError(
             f"Managed DBT preparation marker is invalid: {marker_path}"
         ) from error
+    if not isinstance(marker, dict):
+        raise DataSourceError(
+            f"Managed DBT preparation marker is invalid: {marker_path}"
+        )
     generation = marker.get("generation")
+    repository_revision = marker.get("repository_revision")
     if (
         marker.get("schema") != _PREPARED_MARKER_SCHEMA
         or marker.get("identity") != _workspace_identity_digest(cache_key)
         or not isinstance(generation, str)
         or not generation
+        or not isinstance(repository_revision, str)
+        or not repository_revision
     ):
         raise DataSourceError(
             f"Managed DBT preparation marker does not match its workspace: {marker_path}"
+        )
+    if _resolve_checkout_revision(clone_dir) != repository_revision:
+        raise DataSourceError(
+            f"Managed DBT checkout does not match its preparation marker: {marker_path}"
         )
     return generation
 
@@ -1269,11 +1384,15 @@ def _get_prepared_workspace(
                     _invalidate_workspace_locked(cache_key, cached_dir)
                     stale_dir = cached_dir
                 else:
-                    _prepared_workspace_generations[cache_key] = generation
-                    _prepared_workspaces_last_access[cache_key] = time.time()
-                    if acquire_lease:
-                        _acquire_prepared_workspace_lease_locked(cached_dir)
-                    return cached_dir
+                    expected_generation = _prepared_workspace_generations.get(cache_key)
+                    if expected_generation != generation:
+                        _invalidate_workspace_locked(cache_key, cached_dir)
+                        stale_dir = cached_dir
+                    else:
+                        _prepared_workspaces_last_access[cache_key] = time.time()
+                        if acquire_lease:
+                            _acquire_prepared_workspace_lease_locked(cached_dir)
+                        return cached_dir
 
             if stale_dir is None:
                 failure_entry = _compilation_failures.get(failure_key)
@@ -1350,11 +1469,24 @@ def _get_prepared_workspace(
                     max_entries=failure_cache_max_entries,
                     failure_backoff_s=failure_backoff_s,
                 )
-                event = _workspace_preparation_inflight.pop(cache_key, None)
-                if event is not None:
-                    event.set()
-            if clone_dir is not None:
-                _cleanup_managed_clone_dir(clone_dir)
+                if clone_dir is not None:
+                    _pending_workspace_cleanup_dirs.add(clone_dir)
+                _cache_condition.notify_all()
+            try:
+                if clone_dir is not None:
+                    _cleanup_ready_managed_dirs()
+                    _wait_for_managed_cleanup(clone_dir, workspace=True)
+            except DataSourceError:
+                # Preserve the preparation error for this caller. The failed
+                # reservation remains in place so a later retry cannot reuse
+                # the path without completing safe cleanup first.
+                pass
+            finally:
+                with _cache_lock:
+                    event = _workspace_preparation_inflight.pop(cache_key, None)
+                    if event is not None:
+                        event.set()
+                    _cache_condition.notify_all()
             raise
 
         assert clone_dir is not None
@@ -1374,6 +1506,60 @@ def _get_prepared_workspace(
 
 
 def _get_compiled_project(
+    package_url: str,
+    project_dir: str,
+    branch: Optional[str],
+    target: str,
+    vars: Optional[dict[str, Any]],
+    profiles_dir: Optional[str] = None,
+    profile_name: Optional[str] = None,
+    compile: bool = Defaults.DBT_COMPILE,
+    acquire_lease: bool = False,
+    parse_only: bool = False,
+) -> Path:
+    """Coordinate one compiled-project request across local processes."""
+    if not compile:
+        return _get_compiled_project_unlocked(
+            package_url=package_url,
+            project_dir=project_dir,
+            branch=branch,
+            target=target,
+            vars=vars,
+            profiles_dir=profiles_dir,
+            profile_name=profile_name,
+            compile=False,
+            acquire_lease=acquire_lease,
+            parse_only=parse_only,
+        )
+
+    canonical_project_dir = _canonical_project_dir(project_dir)
+    canonical_profiles_dir = _canonical_profiles_dir(profiles_dir)
+    clone_dir = _resolve_managed_clone_dir(
+        project_dir=canonical_project_dir,
+        package_url=package_url,
+        branch=branch,
+        profiles_dir=canonical_profiles_dir,
+        profile_name=profile_name,
+    )
+    try:
+        with _workspace_process_lock(clone_dir):
+            return _get_compiled_project_unlocked(
+                package_url=package_url,
+                project_dir=canonical_project_dir,
+                branch=branch,
+                target=target,
+                vars=vars,
+                profiles_dir=canonical_profiles_dir,
+                profile_name=profile_name,
+                compile=True,
+                acquire_lease=acquire_lease,
+                parse_only=parse_only,
+            )
+    finally:
+        _cleanup_ready_managed_dirs()
+
+
+def _get_compiled_project_unlocked(
     package_url: str,
     project_dir: str,
     branch: Optional[str],
@@ -1489,7 +1675,18 @@ def _get_compiled_project(
             pending.wait()
             continue
 
-        compiled_dir: Optional[Path] = None
+        expected_clone_dir = _resolve_managed_clone_dir(
+            project_dir=canonical_project_dir,
+            package_url=package_url,
+            branch=branch,
+            profiles_dir=canonical_profiles_dir,
+            profile_name=profile_name,
+        )
+        compiled_dir: Path = _resolve_managed_compile_dir(
+            expected_clone_dir, target, vars
+        )
+        _wait_for_managed_cleanup(compiled_dir, workspace=False)
+
         clone_dir: Optional[Path] = None
         workspace_generation: Optional[str] = None
         workspace_leased = False
@@ -1503,11 +1700,24 @@ def _get_compiled_project(
                 acquire_lease=True,
             )
             workspace_leased = True
+            with _cache_lock:
+                cleanup_became_pending = (
+                    clone_dir in _pending_workspace_cleanup_dirs
+                    or compiled_dir in _pending_cleanup_dirs
+                )
+                if cleanup_became_pending:
+                    _release_prepared_workspace_lease_locked(clone_dir)
+                    workspace_leased = False
+            if cleanup_became_pending:
+                _cleanup_ready_managed_dirs()
+                with _cache_lock:
+                    event = _compilation_inflight.pop(cache_key, None)
+                    if event is not None:
+                        event.set()
+                continue
             workspace_generation = _validate_prepared_workspace(
                 clone_dir, workspace_key
             )
-            compiled_dir = _resolve_managed_compile_dir(clone_dir, target, vars)
-            _wait_for_managed_cleanup(compiled_dir, workspace=False)
             _validate_managed_compile_dir(clone_dir, compiled_dir, require_exists=False)
             if compiled_dir.exists():
                 _cleanup_managed_compile_dir(compiled_dir)
@@ -1570,15 +1780,28 @@ def _get_compiled_project(
                     max_entries=failure_cache_max_entries,
                     failure_backoff_s=failure_backoff_s,
                 )
-                event = _compilation_inflight.pop(cache_key, None)
-                if event is not None:
-                    event.set()
+                if compiled_dir is not None:
+                    _pending_cleanup_dirs.add(compiled_dir)
                 if workspace_leased and clone_dir is not None:
                     _release_prepared_workspace_lease_locked(clone_dir)
+                    workspace_leased = False
+                _prune_compiled_projects_cache_locked(max_cache_entries)
                 _prune_prepared_workspaces_cache_locked(max_cache_entries)
-            if compiled_dir is not None:
-                _cleanup_managed_compile_dir(compiled_dir)
-            _cleanup_ready_managed_dirs()
+                _cache_condition.notify_all()
+            try:
+                if compiled_dir is not None:
+                    _cleanup_ready_managed_dirs()
+                    _wait_for_managed_cleanup(compiled_dir, workspace=False)
+            except DataSourceError:
+                # Preserve the compilation/path-validation error for this
+                # caller while retaining the failed cleanup reservation.
+                pass
+            finally:
+                with _cache_lock:
+                    event = _compilation_inflight.pop(cache_key, None)
+                    if event is not None:
+                        event.set()
+                    _cache_condition.notify_all()
             raise
 
         assert compiled_dir is not None
@@ -1611,6 +1834,7 @@ def _get_compiled_project(
                 _prune_compiled_projects_cache_locked(max_cache_entries)
             if workspace_leased and clone_dir is not None:
                 _release_prepared_workspace_lease_locked(clone_dir)
+            _prune_compiled_projects_cache_locked(max_cache_entries)
             _prune_prepared_workspaces_cache_locked(max_cache_entries)
             event = _compilation_inflight.pop(cache_key, None)
             if event is not None:
@@ -1624,6 +1848,34 @@ def _get_compiled_project(
 
 
 def _ensure_selected_compilation(
+    *,
+    clone_dir: Path,
+    package_url: str,
+    project_dir: str,
+    branch: Optional[str],
+    target: str,
+    vars: Optional[dict[str, Any]],
+    profiles_dir: Optional[str],
+    profile_name: Optional[str],
+    selectors: tuple[str, ...],
+) -> None:
+    """Coordinate selected compilation with other local processes."""
+    source_dir = _source_clone_dir(clone_dir)
+    with _workspace_process_lock(source_dir):
+        _ensure_selected_compilation_unlocked(
+            clone_dir=clone_dir,
+            package_url=package_url,
+            project_dir=project_dir,
+            branch=branch,
+            target=target,
+            vars=vars,
+            profiles_dir=profiles_dir,
+            profile_name=profile_name,
+            selectors=selectors,
+        )
+
+
+def _ensure_selected_compilation_unlocked(
     *,
     clone_dir: Path,
     package_url: str,
@@ -1767,22 +2019,52 @@ def _compiled_project_lease(
     parse_only: bool = False,
 ) -> Iterator[Path]:
     """Acquire a temporary usage lease for a compiled DBT clone directory."""
-    clone_dir = _get_compiled_project(
+    if not compile:
+        clone_dir = _get_compiled_project(
+            package_url=package_url,
+            project_dir=project_dir,
+            branch=branch,
+            target=target,
+            vars=vars,
+            profiles_dir=profiles_dir,
+            profile_name=profile_name,
+            compile=False,
+            acquire_lease=True,
+            parse_only=parse_only,
+        )
+        try:
+            yield clone_dir
+        finally:
+            _release_compiled_project_lease(clone_dir)
+        return
+
+    canonical_project_dir = _canonical_project_dir(project_dir)
+    canonical_profiles_dir = _canonical_profiles_dir(profiles_dir)
+    source_dir = _resolve_managed_clone_dir(
+        project_dir=canonical_project_dir,
         package_url=package_url,
-        project_dir=project_dir,
         branch=branch,
-        target=target,
-        vars=vars,
-        profiles_dir=profiles_dir,
+        profiles_dir=canonical_profiles_dir,
         profile_name=profile_name,
-        compile=compile,
-        acquire_lease=True,
-        parse_only=parse_only,
     )
-    try:
-        yield clone_dir
-    finally:
-        _release_compiled_project_lease(clone_dir)
+    with _workspace_process_lock(source_dir):
+        clone_dir = _get_compiled_project(
+            package_url=package_url,
+            project_dir=canonical_project_dir,
+            branch=branch,
+            target=target,
+            vars=vars,
+            profiles_dir=canonical_profiles_dir,
+            profile_name=profile_name,
+            compile=True,
+            acquire_lease=True,
+            parse_only=parse_only,
+        )
+        try:
+            yield clone_dir
+        finally:
+            _release_compiled_project_lease(clone_dir)
+    _cleanup_ready_managed_dirs()
 
 
 def _resolve_model_from_index(

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -1033,7 +1033,7 @@ def _get_prepared_workspace(
             )
             cached_dir = _prepared_workspaces_cache.get(cache_key)
             if cached_dir is not None:
-                if cached_dir.exists():
+                if cached_dir.is_dir():
                     _prepared_workspaces_last_access[cache_key] = time.time()
                     if acquire_lease:
                         _acquire_prepared_workspace_lease_locked(cached_dir)
@@ -1169,9 +1169,10 @@ def _get_compiled_project(
             )
             cached_dir = _compiled_projects_cache.get(cache_key)
             if cached_dir is not None:
-                if cached_dir.exists():
+                source_dir = _source_clone_dir(cached_dir)
+                if cached_dir.is_dir() and source_dir.is_dir():
                     _validate_managed_compile_dir(
-                        _source_clone_dir(cached_dir),
+                        source_dir,
                         cached_dir,
                         require_exists=True,
                     )

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -662,6 +662,35 @@ def _release_prepared_workspace_lease_locked(clone_dir: Path) -> None:
     _cache_condition.notify_all()
 
 
+def _finalize_prepared_workspace_use_locked(
+    clone_dir: Optional[Path],
+    *,
+    lease_acquired: bool,
+    max_cache_entries: int,
+) -> None:
+    """Release compilation workspace state and re-apply cache bounds.
+
+    Requires caller to hold ``_cache_lock``.
+    """
+    if lease_acquired:
+        if clone_dir is None:
+            raise RuntimeError("Prepared DBT workspace lease has no clone directory")
+        _release_prepared_workspace_lease_locked(clone_dir)
+    _prune_compiled_projects_cache_locked(max_cache_entries)
+    _prune_prepared_workspaces_cache_locked(max_cache_entries)
+
+
+def _finish_compilation_owner_locked(cache_key: tuple) -> None:
+    """Release compilation ownership and wake all local waiters.
+
+    Requires caller to hold ``_cache_lock``.
+    """
+    event = _compilation_inflight.pop(cache_key, None)
+    if event is not None:
+        event.set()
+    _cache_condition.notify_all()
+
+
 def _workspace_has_compiled_references_locked(clone_dir: Path) -> bool:
     """Return whether cached or leased compile variants use a workspace."""
     for compiled_dir in _compiled_projects_cache.values():
@@ -1706,14 +1735,14 @@ def _get_compiled_project_unlocked(
                     or compiled_dir in _pending_cleanup_dirs
                 )
                 if cleanup_became_pending:
-                    _release_prepared_workspace_lease_locked(clone_dir)
-                    workspace_leased = False
+                    _finalize_prepared_workspace_use_locked(
+                        clone_dir,
+                        lease_acquired=True,
+                        max_cache_entries=max_cache_entries,
+                    )
+                    _finish_compilation_owner_locked(cache_key)
             if cleanup_became_pending:
                 _cleanup_ready_managed_dirs()
-                with _cache_lock:
-                    event = _compilation_inflight.pop(cache_key, None)
-                    if event is not None:
-                        event.set()
                 continue
             workspace_generation = _validate_prepared_workspace(
                 clone_dir, workspace_key
@@ -1782,12 +1811,11 @@ def _get_compiled_project_unlocked(
                 )
                 if compiled_dir is not None:
                     _pending_cleanup_dirs.add(compiled_dir)
-                if workspace_leased and clone_dir is not None:
-                    _release_prepared_workspace_lease_locked(clone_dir)
-                    workspace_leased = False
-                _prune_compiled_projects_cache_locked(max_cache_entries)
-                _prune_prepared_workspaces_cache_locked(max_cache_entries)
-                _cache_condition.notify_all()
+                _finalize_prepared_workspace_use_locked(
+                    clone_dir,
+                    lease_acquired=workspace_leased,
+                    max_cache_entries=max_cache_entries,
+                )
             try:
                 if compiled_dir is not None:
                     _cleanup_ready_managed_dirs()
@@ -1798,10 +1826,7 @@ def _get_compiled_project_unlocked(
                 pass
             finally:
                 with _cache_lock:
-                    event = _compilation_inflight.pop(cache_key, None)
-                    if event is not None:
-                        event.set()
-                    _cache_condition.notify_all()
+                    _finish_compilation_owner_locked(cache_key)
             raise
 
         assert compiled_dir is not None
@@ -1831,14 +1856,12 @@ def _get_compiled_project_unlocked(
                 _compilation_failures.pop(failure_key, None)
                 if acquire_lease:
                     _acquire_compiled_project_lease_locked(compiled_dir)
-                _prune_compiled_projects_cache_locked(max_cache_entries)
-            if workspace_leased and clone_dir is not None:
-                _release_prepared_workspace_lease_locked(clone_dir)
-            _prune_compiled_projects_cache_locked(max_cache_entries)
-            _prune_prepared_workspaces_cache_locked(max_cache_entries)
-            event = _compilation_inflight.pop(cache_key, None)
-            if event is not None:
-                event.set()
+            _finalize_prepared_workspace_use_locked(
+                clone_dir,
+                lease_acquired=workspace_leased,
+                max_cache_entries=max_cache_entries,
+            )
+            _finish_compilation_owner_locked(cache_key)
         _cleanup_ready_managed_dirs()
 
         if stale_generation:

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -2189,41 +2189,54 @@ def _resolve_model_from_index(
                 f"identifier '{model_name}'."
             )
         candidates = [unique_candidate]
-    elif model_selector_name:
-        candidates = list(manifest_index.by_name.get(model_selector_name, []))
     else:
         name_candidates = list(manifest_index.by_name.get(model_name, []))
         alias_candidates = list(manifest_index.by_alias.get(model_name, []))
-        if model_package_name:
-            name_candidates = [
-                candidate
-                for candidate in name_candidates
-                if candidate.package_name == model_package_name
-            ]
-            alias_candidates = [
-                candidate
-                for candidate in alias_candidates
-                if candidate.package_name == model_package_name
-            ]
+        identifier_candidates_exist = bool(name_candidates or alias_candidates)
 
-        name_ids = {candidate.unique_id for candidate in name_candidates}
-        alias_ids = {candidate.unique_id for candidate in alias_candidates}
-        if name_ids and alias_ids and name_ids != alias_ids:
-            combined = {
-                candidate.unique_id: candidate
-                for candidate in name_candidates + alias_candidates
-            }
-            rendered_candidates = ", ".join(
-                _format_manifest_candidate(candidate) for candidate in combined.values()
-            )
-            raise DataSourceError(
-                f"dbt model identifier '{model_name}' matches different nodes by "
-                "stable name and compiled alias. Provide one of "
-                "`model_unique_id`, `model_package_name`, or "
-                "`model_selector_name` to select the intended node. "
-                f"Candidates: {rendered_candidates}"
-            )
-        candidates = name_candidates or alias_candidates
+        if identifier_candidates_exist:
+            if model_package_name:
+                name_candidates = [
+                    candidate
+                    for candidate in name_candidates
+                    if candidate.package_name == model_package_name
+                ]
+                alias_candidates = [
+                    candidate
+                    for candidate in alias_candidates
+                    if candidate.package_name == model_package_name
+                ]
+
+            name_ids = {candidate.unique_id for candidate in name_candidates}
+            alias_ids = {candidate.unique_id for candidate in alias_candidates}
+            if name_ids and alias_ids and name_ids != alias_ids:
+                combined = {
+                    candidate.unique_id: candidate
+                    for candidate in name_candidates + alias_candidates
+                }
+                if not model_selector_name:
+                    rendered_candidates = ", ".join(
+                        _format_manifest_candidate(candidate)
+                        for candidate in combined.values()
+                    )
+                    raise DataSourceError(
+                        f"dbt model identifier '{model_name}' matches different "
+                        "nodes by stable name and compiled alias. Provide one of "
+                        "`model_unique_id`, `model_package_name`, or "
+                        "`model_selector_name` to select the intended node. "
+                        f"Candidates: {rendered_candidates}"
+                    )
+                candidates = list(combined.values())
+            else:
+                candidates = name_candidates or alias_candidates
+        elif model_selector_name:
+            # Compiled aliases can vary by target. Only fall back to a global
+            # stable-name lookup when the configured identifier has no name or
+            # alias matches at all; otherwise selector fields must disambiguate
+            # that identifier-scoped candidate set.
+            candidates = list(manifest_index.by_name.get(model_selector_name, []))
+        else:
+            candidates = []
 
     if model_package_name:
         candidates = [

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -57,7 +57,7 @@ import threading
 import time
 import uuid
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Iterator, Literal, Optional, Sequence, Type
 
@@ -150,6 +150,7 @@ class _ManifestNodeIndexEntry:
     compiled_path: Optional[str]
     fqn: Optional[tuple[str, ...]] = None
     original_file_path: Optional[str] = None
+    resource_type: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -158,6 +159,7 @@ class _ManifestIndex:
 
     by_alias: dict[str, list[_ManifestNodeIndexEntry]]
     by_unique_id: dict[str, _ManifestNodeIndexEntry]
+    by_name: dict[str, list[_ManifestNodeIndexEntry]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -266,6 +268,7 @@ def _load_manifest_index(clone_dir: Path) -> _ManifestIndex:
         manifest = json.load(f)
 
     by_alias: dict[str, list[_ManifestNodeIndexEntry]] = {}
+    by_name: dict[str, list[_ManifestNodeIndexEntry]] = {}
     by_unique_id: dict[str, _ManifestNodeIndexEntry] = {}
 
     for unique_id, node in manifest.get("nodes", {}).items():
@@ -297,12 +300,19 @@ def _load_manifest_index(clone_dir: Path) -> _ManifestIndex:
                 if node.get("original_file_path")
                 else None
             ),
+            resource_type=str(node.get("resource_type")),
         )
 
         by_alias.setdefault(entry.alias, []).append(entry)
+        if entry.model_name:
+            by_name.setdefault(entry.model_name, []).append(entry)
         by_unique_id[entry.unique_id] = entry
 
-    return _ManifestIndex(by_alias=by_alias, by_unique_id=by_unique_id)
+    return _ManifestIndex(
+        by_alias=by_alias,
+        by_unique_id=by_unique_id,
+        by_name=by_name,
+    )
 
 
 def _get_manifest_index(clone_dir: Path) -> _ManifestIndex:
@@ -359,7 +369,7 @@ def _format_manifest_candidate(entry: _ManifestNodeIndexEntry) -> str:
 def _format_selector_context(
     model_unique_id: Optional[str],
     model_package_name: Optional[str],
-    model_name: Optional[str],
+    model_selector_name: Optional[str],
 ) -> str:
     """Format optional selector fields for user-facing error messages."""
     selectors = []
@@ -367,8 +377,8 @@ def _format_selector_context(
         selectors.append(f"model_unique_id='{model_unique_id}'")
     if model_package_name:
         selectors.append(f"model_package_name='{model_package_name}'")
-    if model_name:
-        selectors.append(f"model_name='{model_name}'")
+    if model_selector_name:
+        selectors.append(f"model_selector_name='{model_selector_name}'")
     if not selectors:
         return ""
     return " with selectors " + ", ".join(selectors)
@@ -608,6 +618,30 @@ def _cleanup_managed_clone_dir(clone_dir: Path) -> bool:
         return False
 
 
+def _validate_existing_workspace_artifacts(clone_dir: Path) -> bool:
+    """Validate an old on-disk generation before cold-process cleanup.
+
+    Return whether any workspace path exists.  Every concrete child is checked
+    before deletion so cleanup cannot silently erase a symlink collision that
+    normal command-path validation would reject.
+    """
+    workspace_root = clone_dir.parent.parent
+    roots = (
+        workspace_root / ".slideflow_dbt_targets" / clone_dir.name,
+        workspace_root / ".slideflow_dbt_logs" / clone_dir.name,
+    )
+    found = clone_dir.exists() or clone_dir.is_symlink()
+    for root in roots:
+        namespace = root.parent
+        _validate_real_directory_chain(namespace, workspace_root, require_exists=False)
+        _validate_real_directory_chain(root, namespace, require_exists=False)
+        if root.exists():
+            found = True
+            for child in root.iterdir():
+                _validate_real_directory_chain(child, root, require_exists=True)
+    return found
+
+
 def _cleanup_managed_compile_dir(compiled_dir: Path) -> bool:
     """Remove one managed dbt compile variant without following links."""
     managed_root = compiled_dir.parent
@@ -791,12 +825,20 @@ def _cleanup_ready_managed_dirs() -> None:
             held_workspaces or None
         )
     for directory in sorted(ready_compiles):
-        with _workspace_process_lock(_source_clone_dir(directory)):
-            succeeded = _cleanup_managed_compile_dir(directory)
+        succeeded = False
+        try:
+            with _workspace_process_lock(_source_clone_dir(directory)):
+                succeeded = _cleanup_managed_compile_dir(directory)
+        finally:
+            # Reservation finalization must also cover lock acquisition and
+            # context-entry failures; otherwise this path can be stranded.
             _finish_cleanup(directory, workspace=False, succeeded=succeeded)
     for directory in sorted(ready_workspaces):
-        with _workspace_process_lock(directory):
-            succeeded = _cleanup_managed_clone_dir(directory)
+        succeeded = False
+        try:
+            with _workspace_process_lock(directory):
+                succeeded = _cleanup_managed_clone_dir(directory)
+        finally:
             _finish_cleanup(directory, workspace=True, succeeded=succeeded)
 
 
@@ -808,6 +850,14 @@ def _wait_for_managed_cleanup(directory: Path, *, workspace: bool) -> None:
         with _cache_condition:
             if directory not in pending:
                 return
+            if not workspace:
+                parent = _source_clone_dir(directory)
+                parent_failure = _cleanup_failures.get(parent)
+                if (
+                    parent in _pending_workspace_cleanup_dirs
+                    and parent_failure is not None
+                ):
+                    raise DataSourceError(parent_failure)
             failure = _cleanup_failures.pop(directory, None)
             if failure is not None:
                 if retried_failure:
@@ -1466,6 +1516,17 @@ def _get_prepared_workspace(
                 profile_name=profile_name,
             )
             _wait_for_managed_cleanup(clone_dir, workspace=True)
+            # A process with empty in-memory indexes must treat the complete
+            # on-disk workspace (clone, variants, and logs) as one generation.
+            # Clearing only the clone or requested variant leaves untracked
+            # sibling artifacts from the previous generation.
+            if _validate_existing_workspace_artifacts(
+                clone_dir
+            ) and not _cleanup_managed_clone_dir(clone_dir):
+                raise DataSourceError(
+                    "Failed to safely reset the managed DBT workspace before "
+                    f"preparation: {clone_dir}"
+                )
             _clone_repo(package_url, clone_dir, branch)
             _prepare_profiles(clone_dir, profiles_dir)
 
@@ -1724,12 +1785,13 @@ def _get_compiled_project_unlocked(
         compiled_dir: Path = _resolve_managed_compile_dir(
             expected_clone_dir, target, vars
         )
-        _wait_for_managed_cleanup(compiled_dir, workspace=False)
-
         clone_dir: Optional[Path] = None
         workspace_generation: Optional[str] = None
         workspace_leased = False
         try:
+            # Ownership is already registered, so every operation from this
+            # point onward must be covered by the owner finalizer below.
+            _wait_for_managed_cleanup(compiled_dir, workspace=False)
             clone_dir = _get_prepared_workspace(
                 package_url=package_url,
                 project_dir=canonical_project_dir,
@@ -1890,7 +1952,7 @@ def _ensure_selected_compilation(
     vars: Optional[dict[str, Any]],
     profiles_dir: Optional[str],
     profile_name: Optional[str],
-    selectors: tuple[str, ...],
+    selectors: Optional[tuple[str, ...]],
 ) -> None:
     """Coordinate selected compilation with other local processes."""
     source_dir = _source_clone_dir(clone_dir)
@@ -1918,10 +1980,11 @@ def _ensure_selected_compilation_unlocked(
     vars: Optional[dict[str, Any]],
     profiles_dir: Optional[str],
     profile_name: Optional[str],
-    selectors: tuple[str, ...],
+    selectors: Optional[tuple[str, ...]],
 ) -> None:
     """Compile the deterministic union of requested selectors once per project."""
-    normalized = tuple(sorted(set(selectors)))
+    full_compile = selectors is None
+    normalized = ("*",) if selectors is None else tuple(sorted(set(selectors)))
     if not normalized:
         return
     cache_key = _project_cache_key(
@@ -1949,7 +2012,11 @@ def _ensure_selected_compilation_unlocked(
         if "*" in coverage or set(normalized).issubset(coverage):
             return
 
-        union = tuple(sorted(set(coverage).union(normalized)))
+        union = (
+            ("*",)
+            if full_compile or "*" in normalized
+            else tuple(sorted(set(coverage).union(normalized)))
+        )
         failure_key = ("selected",) + cache_key + (union,)
         failure_backoff_s = _resolve_dbt_compile_failure_backoff_seconds()
         failure_cache_max_entries = _resolve_dbt_failure_cache_max_entries()
@@ -1978,9 +2045,9 @@ def _ensure_selected_compilation_unlocked(
             str(compiled_dir / "target"),
             "--log-path",
             str(compiled_dir / "logs"),
-            "--select",
-            " ".join(union),
         ]
+        if "*" not in union:
+            args.extend(["--select", " ".join(union)])
         project_profiles_path = source_dir / "profiles.yml"
         if profiles_dir or project_profiles_path.exists():
             args.extend(["--profiles-dir", str(source_dir)])
@@ -2019,7 +2086,7 @@ def _ensure_selected_compilation_unlocked(
             project=package_url,
             target=target,
             vars_count=len(vars) if vars else 0,
-            selection_count=len(union),
+            selection_count=0 if "*" in union else len(union),
         )
         try:
             disk_generation = _validate_prepared_workspace(source_dir, workspace_key)
@@ -2108,27 +2175,56 @@ def _resolve_model_from_index(
     model_package_name: Optional[str] = None,
     model_selector_name: Optional[str] = None,
 ) -> Optional[_ManifestNodeIndexEntry]:
-    candidates = list(manifest_index.by_alias.get(model_name, []))
-    if not candidates:
-        return None
     selector_context = _format_selector_context(
         model_unique_id=model_unique_id,
         model_package_name=model_package_name,
-        model_name=model_selector_name,
+        model_selector_name=model_selector_name,
     )
+
     if model_unique_id:
         unique_candidate = manifest_index.by_unique_id.get(model_unique_id)
         if unique_candidate is None:
             raise DataSourceError(
-                f"No dbt node with unique_id '{model_unique_id}' for alias "
-                f"'{model_name}'."
-            )
-        if unique_candidate.alias != model_name:
-            raise DataSourceError(
-                f"unique_id '{model_unique_id}' resolved to alias "
-                f"'{unique_candidate.alias}', expected '{model_name}'."
+                f"No dbt node with unique_id '{model_unique_id}' for model "
+                f"identifier '{model_name}'."
             )
         candidates = [unique_candidate]
+    elif model_selector_name:
+        candidates = list(manifest_index.by_name.get(model_selector_name, []))
+    else:
+        name_candidates = list(manifest_index.by_name.get(model_name, []))
+        alias_candidates = list(manifest_index.by_alias.get(model_name, []))
+        if model_package_name:
+            name_candidates = [
+                candidate
+                for candidate in name_candidates
+                if candidate.package_name == model_package_name
+            ]
+            alias_candidates = [
+                candidate
+                for candidate in alias_candidates
+                if candidate.package_name == model_package_name
+            ]
+
+        name_ids = {candidate.unique_id for candidate in name_candidates}
+        alias_ids = {candidate.unique_id for candidate in alias_candidates}
+        if name_ids and alias_ids and name_ids != alias_ids:
+            combined = {
+                candidate.unique_id: candidate
+                for candidate in name_candidates + alias_candidates
+            }
+            rendered_candidates = ", ".join(
+                _format_manifest_candidate(candidate) for candidate in combined.values()
+            )
+            raise DataSourceError(
+                f"dbt model identifier '{model_name}' matches different nodes by "
+                "stable name and compiled alias. Provide one of "
+                "`model_unique_id`, `model_package_name`, or "
+                "`model_selector_name` to select the intended node. "
+                f"Candidates: {rendered_candidates}"
+            )
+        candidates = name_candidates or alias_candidates
+
     if model_package_name:
         candidates = [
             candidate
@@ -2142,24 +2238,44 @@ def _resolve_model_from_index(
             if candidate.model_name == model_selector_name
         ]
     if not candidates:
+        if not selector_context:
+            return None
         raise DataSourceError(
-            f"No dbt model found for alias '{model_name}'{selector_context}."
+            f"No dbt model found for identifier '{model_name}'{selector_context}."
         )
     if len(candidates) > 1:
         rendered_candidates = ", ".join(
             _format_manifest_candidate(candidate) for candidate in candidates
         )
         raise DataSourceError(
-            f"Ambiguous dbt model alias '{model_name}'. Provide one of "
+            f"Ambiguous dbt model identifier '{model_name}'. Provide one of "
             "`model_unique_id`, `model_package_name`, or `model_selector_name` "
             f"to disambiguate. Candidates: {rendered_candidates}"
         )
     return candidates[0]
 
 
-def _exact_selector(node: _ManifestNodeIndexEntry) -> str:
-    if node.fqn:
-        return f"fqn:{'.'.join(node.fqn)}"
+_SAFE_DBT_SELECTOR_COMPONENT = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _exact_selector(node: _ManifestNodeIndexEntry) -> Optional[str]:
+    """Render a provably bounded selector, or request a full compile.
+
+    dbt's CLI selector grammar treats whitespace, commas, globs, and graph
+    operators as syntax.  Never interpolate manifest data unless every
+    component is grammar-safe.  Package and resource-type intersections are
+    required because dbt's FQN matcher intentionally ignores package prefixes
+    for some versioned-node matches.
+    """
+    if node.fqn and node.package_name and node.resource_type:
+        components = (*node.fqn, node.package_name, node.resource_type)
+        if all(_SAFE_DBT_SELECTOR_COMPONENT.fullmatch(part) for part in components):
+            return (
+                f"package:{node.package_name},"
+                f"resource_type:{node.resource_type},"
+                f"fqn:{'.'.join(node.fqn)}"
+            )
+        return None
 
     unique_id_parts = node.unique_id.split(".")
     package_name = node.package_name
@@ -2171,7 +2287,12 @@ def _exact_selector(node: _ManifestNodeIndexEntry) -> str:
         raise DataSourceError(
             f"dbt node '{node.unique_id}' is missing a selector-compatible name."
         )
-    return f"{package_name}.{model_name}" if package_name else model_name
+    components = tuple(part for part in (package_name, model_name) if part)
+    if not components or not all(
+        _SAFE_DBT_SELECTOR_COMPONENT.fullmatch(part) for part in components
+    ):
+        return None
+    return ".".join(components)
 
 
 class DBTManifestConnector(BaseModel, DataConnector):
@@ -2253,9 +2374,20 @@ class DBTManifestConnector(BaseModel, DataConnector):
                     model_selector_name=selector_name,
                 )
                 if selection is None:
-                    raise DataSourceError(f"No dbt model found for alias '{alias}'.")
+                    raise DataSourceError(
+                        f"No dbt model found for identifier '{alias}'."
+                    )
                 selections.append(selection)
-            selectors = tuple(_exact_selector(selection) for selection in selections)
+            rendered_selectors = tuple(
+                _exact_selector(selection) for selection in selections
+            )
+            selectors = (
+                None
+                if any(selector is None for selector in rendered_selectors)
+                else tuple(
+                    selector for selector in rendered_selectors if selector is not None
+                )
+            )
             _ensure_selected_compilation(
                 clone_dir=clone_dir,
                 package_url=self.package_url,
@@ -2290,7 +2422,7 @@ class DBTManifestConnector(BaseModel, DataConnector):
         model_package_name: Optional[str] = None,
         model_selector_name: Optional[str] = None,
     ) -> Optional[str]:
-        """Extract compiled SQL query for a specific DBT model alias."""
+        """Extract compiled SQL for a dbt node name or legacy compiled alias."""
         model_info = self.get_compiled_model_info(
             model_name,
             model_unique_id=model_unique_id,
@@ -2330,6 +2462,7 @@ class DBTManifestConnector(BaseModel, DataConnector):
             if selected is None:
                 return None
             if self.compile:
+                selector = _exact_selector(selected)
                 _ensure_selected_compilation(
                     clone_dir=clone_dir,
                     package_url=self.package_url,
@@ -2339,7 +2472,7 @@ class DBTManifestConnector(BaseModel, DataConnector):
                     vars=self.vars,
                     profiles_dir=self.profiles_dir,
                     profile_name=self.profile_name,
-                    selectors=(_exact_selector(selected),),
+                    selectors=None if selector is None else (selector,),
                 )
                 refreshed_index = _get_manifest_index(clone_dir)
                 refreshed = refreshed_index.by_unique_id.get(selected.unique_id)
@@ -2486,7 +2619,7 @@ class DBTDatabricksConnector(_DBTWarehouseConnectorBase):
     3. Return results as a pandas DataFrame
 
     Attributes:
-        model_alias: The alias of the DBT model to execute.
+        model_alias: Stable dbt node name or legacy compiled alias to execute.
         package_url: Git URL of the DBT project repository.
         project_dir: Local directory path for cloning the project.
         profile_name: Optional dbt profile name to override project default.
@@ -2686,7 +2819,7 @@ class DBTDatabricksSourceConfig(BaseSourceConfig):
 
     Attributes:
         type: Always "databricks_dbt" for DBT-Databricks data sources.
-        model_alias: The alias of the DBT model to execute.
+        model_alias: Stable dbt node name or legacy compiled alias to execute.
         package_url: Git URL of the DBT project repository.
         project_dir: Local directory path for cloning the project.
         profile_name: Optional dbt profile name to override project default.
@@ -2739,7 +2872,10 @@ class DBTDatabricksSourceConfig(BaseSourceConfig):
     type: Literal["databricks_dbt"] = Field(
         "databricks_dbt", description="dbt + Databricks data source"
     )
-    model_alias: str = Field(..., description="dbt model alias")
+    model_alias: str = Field(
+        ...,
+        description="dbt node name (preferred) or legacy compiled alias",
+    )
     model_unique_id: Optional[str] = Field(
         None, description="Optional dbt unique_id selector for alias disambiguation"
     )
@@ -2957,7 +3093,10 @@ class DBTSourceConfig(BaseSourceConfig):
     """
 
     type: Literal["dbt"] = Field("dbt", description="Composable dbt data source")
-    model_alias: str = Field(..., description="dbt model alias")
+    model_alias: str = Field(
+        ...,
+        description="dbt node name (preferred) or legacy compiled alias",
+    )
     model_unique_id: Optional[str] = Field(
         None, description="Optional dbt unique_id selector for alias disambiguation"
     )

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -148,6 +148,7 @@ class _ManifestNodeIndexEntry:
     package_name: Optional[str]
     model_name: Optional[str]
     compiled_path: Optional[str]
+    fqn: Optional[tuple[str, ...]] = None
     original_file_path: Optional[str] = None
 
 
@@ -276,12 +277,21 @@ def _load_manifest_index(clone_dir: Path) -> _ManifestIndex:
             continue
 
         compiled_path = node.get("compiled_path")
+        raw_fqn = node.get("fqn")
+        fqn = (
+            tuple(raw_fqn)
+            if isinstance(raw_fqn, list)
+            and raw_fqn
+            and all(isinstance(part, str) and part for part in raw_fqn)
+            else None
+        )
         entry = _ManifestNodeIndexEntry(
             unique_id=str(unique_id),
             alias=str(alias),
             package_name=node.get("package_name"),
             model_name=node.get("name"),
             compiled_path=str(compiled_path) if compiled_path else None,
+            fqn=fqn,
             original_file_path=(
                 str(node.get("original_file_path"))
                 if node.get("original_file_path")
@@ -2148,6 +2158,9 @@ def _resolve_model_from_index(
 
 
 def _exact_selector(node: _ManifestNodeIndexEntry) -> str:
+    if node.fqn:
+        return f"fqn:{'.'.join(node.fqn)}"
+
     unique_id_parts = node.unique_id.split(".")
     package_name = node.package_name
     model_name = node.model_name

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -133,14 +133,22 @@ def test_prepare_models_batches_exact_sorted_selectors(monkeypatch, tmp_path):
             )
         manifest = {
             "nodes": {
-                f"model.analytics.{name}": {
+                "model.analytics.model_a": {
                     "resource_type": "model",
-                    "alias": f"alias_{name}",
+                    "alias": "alias_model_a",
                     "package_name": "analytics",
-                    "name": name,
-                    "compiled_path": f"target/compiled/{name}.sql",
-                }
-                for name in ("model_a", "model_b")
+                    "name": "model_a",
+                    "fqn": ["analytics", "staging", "model_a"],
+                    "compiled_path": "target/compiled/model_a.sql",
+                },
+                "analysis.analytics.model_b": {
+                    "resource_type": "analysis",
+                    "alias": "alias_model_b",
+                    "package_name": "analytics",
+                    "name": "model_b",
+                    "fqn": ["analytics", "analysis", "reporting", "model_b"],
+                    "compiled_path": "target/compiled/model_b.sql",
+                },
             }
         }
         (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
@@ -170,12 +178,24 @@ def test_prepare_models_batches_exact_sorted_selectors(monkeypatch, tmp_path):
     assert [args[0] for args in invocations] == ["deps", "parse", "compile"]
     compile_args = invocations[-1]
     assert compile_args[compile_args.index("--select") + 1] == (
-        "analytics.model_a analytics.model_b"
+        "fqn:analytics.analysis.reporting.model_b fqn:analytics.staging.model_a"
     )
 
     assert connector.get_compiled_query("alias_model_a") == "select 'model_a'"
     assert connector.get_compiled_query("alias_model_b") == "select 'model_b'"
     assert [args[0] for args in invocations].count("compile") == 1
+
+
+def test_exact_selector_falls_back_when_manifest_fqn_is_missing():
+    node = dbt_module._ManifestNodeIndexEntry(
+        unique_id="model.analytics.metrics",
+        alias="metrics",
+        package_name="analytics",
+        model_name="metrics",
+        compiled_path=None,
+    )
+
+    assert dbt_module._exact_selector(node) == "analytics.metrics"
 
 
 @pytest.mark.integration
@@ -354,6 +374,80 @@ print(json.dumps(payload))
     assert all("'CA' as region" in sql for sql in payload["CA"])
     assert "'a' as analysis" in payload["US"][0]
     assert "'b' as analysis" in payload["US"][1]
+
+
+@pytest.mark.integration
+def test_scoped_compile_supports_nested_models_and_analyses(tmp_path):
+    try:
+        version("dbt-core")
+        version("dbt-duckdb")
+        version("gitpython")
+    except PackageNotFoundError:
+        pytest.skip("dbt and GitPython integration extras are not installed")
+
+    repo_dir = tmp_path / "source_repo"
+    models_dir = repo_dir / "models" / "staging"
+    analyses_dir = repo_dir / "analyses" / "webtraffic"
+    models_dir.mkdir(parents=True)
+    analyses_dir.mkdir(parents=True)
+    (repo_dir / "dbt_project.yml").write_text(
+        "name: analytics\nversion: '1.0'\nconfig-version: 2\n"
+        "profile: analytics\nmodel-paths: ['models']\n"
+        "analysis-paths: ['analyses']\n",
+        encoding="utf-8",
+    )
+    (repo_dir / "profiles.yml").write_text(
+        "analytics:\n  target: dev\n  outputs:\n    dev:\n"
+        f"      type: duckdb\n      path: {tmp_path / 'warehouse.duckdb'}\n"
+        "      threads: 1\n",
+        encoding="utf-8",
+    )
+    (models_dir / "nested_model.sql").write_text(
+        "{{ config(alias='nested_alias') }} select 1 as model_value\n",
+        encoding="utf-8",
+    )
+    (analyses_dir / "traffic_report.sql").write_text(
+        "select 2 as analysis_value\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", str(repo_dir)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "config", "user.name", "Slideflow Tests"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo_dir), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "commit", "-m", "fixture"],
+        check=True,
+        capture_output=True,
+    )
+
+    script = f"""
+from slideflow.data.connectors.dbt import DBTManifestConnector
+connector = DBTManifestConnector(
+    package_url={str(repo_dir)!r},
+    project_dir={str(tmp_path / "workspace")!r},
+    target='dev',
+)
+connector.prepare_models([
+    ('nested_alias', None, None, None),
+    ('traffic_report', None, None, None),
+])
+print(connector.get_compiled_query('nested_alias'))
+print(connector.get_compiled_query('traffic_report'))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "select 1 as model_value" in result.stdout.lower()
+    assert "select 2 as analysis_value" in result.stdout.lower()
 
 
 def test_sanitize_git_url_redacts_embedded_credentials():

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -1,5 +1,6 @@
 import builtins
 import json
+import multiprocessing
 import shutil
 import subprocess
 import sys
@@ -37,10 +38,49 @@ def _reset_dbt_caches() -> None:
     dbt_module._pending_cleanup_dirs.clear()
     dbt_module._cleanup_in_progress_dirs.clear()
     dbt_module._cleanup_failures.clear()
+    dbt_module._workspace_file_locks.clear()
     dbt_module._manifest_index_cache.clear()
     dbt_module._manifest_index_inflight.clear()
     dbt_module._compiled_project_coverage.clear()
     dbt_module._selection_locks.clear()
+
+
+@pytest.fixture(autouse=True)
+def _stable_fake_checkout_revision(monkeypatch):
+    """Keep unit-test clones lightweight while production requires real Git."""
+    monkeypatch.setattr(
+        dbt_module, "_resolve_checkout_revision", lambda _clone_dir: "test-revision"
+    )
+
+
+def _write_fake_dbt_project(clone_dir: Path) -> None:
+    clone_dir.mkdir(parents=True, exist_ok=True)
+    (clone_dir / "dbt_project.yml").write_text("name: test_project\nversion: 1.0\n")
+
+
+def _hold_workspace_process_lock(
+    workspace: str,
+    acquired: Any,
+    release: Any,
+) -> None:
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        workspace,
+        "https://github.com/org/repo.git",
+        "main",
+    )
+    with dbt_module._workspace_process_lock(clone_dir):
+        acquired.set()
+        release.wait(10)
+
+
+def _enter_workspace_process_lock(workspace: str, entered: Any) -> None:
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        workspace,
+        "https://github.com/org/repo.git",
+        "main",
+    )
+    with dbt_module._workspace_process_lock(clone_dir):
+        entered.set()
 
 
 def _copy_seeded_target_to_invocation(args: list[str]) -> None:
@@ -60,6 +100,7 @@ def _write_compiled_dbt_project(
     compiled_path: str = "target/compiled.sql",
     sql: str = "select 1 as answer",
 ) -> None:
+    _write_fake_dbt_project(project_dir)
     compiled_file = project_dir / compiled_path
     compiled_file.parent.mkdir(parents=True, exist_ok=True)
     compiled_file.write_text(sql)
@@ -84,6 +125,7 @@ def test_prepare_models_batches_exact_sorted_selectors(monkeypatch, tmp_path):
     invocations = []
 
     def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target" / "compiled").mkdir(parents=True, exist_ok=True)
         for name in ("model_a", "model_b"):
             (clone_dir / "target" / "compiled" / f"{name}.sql").write_text(
@@ -451,6 +493,7 @@ def test_get_compiled_project_allows_target_named_path_inside_repo(
     invocations = []
 
     def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / ".slideflow_dbt_targets").mkdir(parents=True)
 
     class _Runner:
@@ -564,7 +607,7 @@ def test_concurrent_literal_default_and_absent_branch_use_distinct_workspaces(
     def _fake_clone(_url, clone_dir, _branch):
         with clone_lock:
             clone_paths.append(clone_dir)
-        clone_dir.mkdir(parents=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, _args):
@@ -678,7 +721,7 @@ def test_get_compiled_project_rejects_symlinked_artifact_paths(
         compiled_dir.symlink_to(external, target_is_directory=True)
 
     def _fake_clone(_url, path, _branch):
-        path.mkdir(parents=True)
+        _write_fake_dbt_project(path)
 
     invocations = []
 
@@ -707,7 +750,7 @@ def test_cached_compile_path_rejects_symlink_replacement(monkeypatch, tmp_path):
     _reset_dbt_caches()
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, _args):
@@ -747,7 +790,7 @@ def test_cached_compile_reprepares_externally_deleted_source_clone(
     def _fake_clone(_url, clone_dir, _branch):
         nonlocal clone_calls
         clone_calls += 1
-        clone_dir.mkdir(parents=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -831,7 +874,7 @@ def test_workspace_refresh_invalidates_every_compiled_variant(monkeypatch, tmp_p
     def _fake_clone(_url, clone_dir, _branch):
         nonlocal clone_generation
         clone_generation += 1
-        clone_dir.mkdir(parents=True)
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "generation.txt").write_text(str(clone_generation))
 
     class _Runner:
@@ -891,7 +934,7 @@ def test_workspace_refresh_waits_for_active_sibling_variant_lease(
     def _fake_clone(_url, clone_dir, _branch):
         nonlocal clone_calls
         clone_calls += 1
-        clone_dir.mkdir(parents=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, _args):
@@ -943,7 +986,7 @@ def test_selected_compile_rejects_concrete_output_symlink(
     invocations: list[list[str]] = []
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -998,7 +1041,7 @@ def test_dbt_deps_rejects_concrete_log_symlink(monkeypatch, tmp_path):
     invocations = []
 
     def _fake_clone(_url, path, _branch):
-        path.mkdir(parents=True)
+        _write_fake_dbt_project(path)
 
     class _Runner:
         def invoke(self, args):
@@ -1030,7 +1073,7 @@ def test_prepared_workspace_marker_mismatch_reprepares_all_variants(
     def _fake_clone(_url, clone_dir, _branch):
         nonlocal clone_calls
         clone_calls += 1
-        clone_dir.mkdir(parents=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, _args):
@@ -1056,6 +1099,231 @@ def test_prepared_workspace_marker_mismatch_reprepares_all_variants(
     dbt_module._get_compiled_project(**kwargs)
 
     assert clone_calls == 2
+
+
+def test_workspace_process_lock_excludes_other_processes(tmp_path):
+    _reset_dbt_caches()
+    context = multiprocessing.get_context("spawn")
+    acquired = context.Event()
+    release = context.Event()
+    entered = context.Event()
+    workspace = str(tmp_path / "workspace")
+    holder = context.Process(
+        target=_hold_workspace_process_lock,
+        args=(workspace, acquired, release),
+    )
+    waiter = context.Process(
+        target=_enter_workspace_process_lock,
+        args=(workspace, entered),
+    )
+
+    holder.start()
+    assert acquired.wait(10), "first process did not acquire the workspace lock"
+    waiter.start()
+    assert not entered.wait(0.2)
+    release.set()
+    holder.join(timeout=10)
+    waiter.join(timeout=10)
+
+    assert holder.exitcode == 0
+    assert waiter.exitcode == 0
+    assert entered.is_set()
+
+
+def test_workspace_process_lock_rejects_symlinked_namespace(tmp_path):
+    _reset_dbt_caches()
+    workspace = tmp_path / "workspace"
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(workspace),
+        "https://github.com/org/repo.git",
+        "main",
+    )
+    external = tmp_path / "external-locks"
+    external.mkdir()
+    lock_root = workspace / ".slideflow_dbt_locks"
+    lock_root.symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(DataSourceError, match="must not be a symlink"):
+        with dbt_module._workspace_process_lock(clone_dir):
+            pass
+
+
+def test_pending_workspace_cleanup_restarts_after_releasing_prepared_lease(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    workspace = str(tmp_path / "workspace")
+    package_url = "https://github.com/org/repo.git"
+    workspace_key = dbt_module._workspace_cache_key(
+        package_url, workspace, "main", None, None
+    )
+    clone_dir = dbt_module._resolve_managed_clone_dir(workspace, package_url, "main")
+    compiled_dir = dbt_module._resolve_managed_compile_dir(clone_dir, "prod", None)
+    injected = False
+
+    def _fake_clone(_url, path, _branch):
+        _write_fake_dbt_project(path)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    real_get_prepared = dbt_module._get_prepared_workspace
+
+    def _inject_pending_cleanup(**kwargs):
+        nonlocal injected
+        prepared = real_get_prepared(**kwargs)
+        if not injected:
+            injected = True
+            with dbt_module._cache_lock:
+                dbt_module._invalidate_workspace_locked(workspace_key, prepared)
+                dbt_module._pending_cleanup_dirs.add(compiled_dir)
+        return prepared
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    monkeypatch.setattr(dbt_module, "_get_prepared_workspace", _inject_pending_cleanup)
+    result: list[Path] = []
+    errors: list[BaseException] = []
+
+    def _worker():
+        try:
+            result.append(
+                dbt_module._get_compiled_project(
+                    package_url=package_url,
+                    project_dir=workspace,
+                    branch="main",
+                    target="prod",
+                    vars=None,
+                )
+            )
+        except BaseException as error:  # pragma: no cover - assertion helper
+            errors.append(error)
+
+    worker = threading.Thread(target=_worker)
+    worker.start()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert errors == []
+    assert len(result) == 1
+    assert result[0].is_dir()
+    assert dbt_module._prepared_workspaces_in_use == {}
+
+
+@pytest.mark.parametrize("marker_payload", [[], "invalid", 7, None])
+def test_non_object_preparation_marker_rebuilds_without_attribute_error(
+    monkeypatch, tmp_path, marker_payload
+):
+    _reset_dbt_caches()
+    clone_calls = 0
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        _write_fake_dbt_project(clone_dir)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "vars": None,
+    }
+    compiled_dir = dbt_module._get_compiled_project(**kwargs)
+    marker_path = dbt_module._prepared_marker_path(
+        dbt_module._source_clone_dir(compiled_dir)
+    )
+    marker_path.write_text(json.dumps(marker_payload))
+
+    rebuilt = dbt_module._get_compiled_project(**kwargs)
+
+    assert rebuilt.is_dir()
+    assert clone_calls == 2
+
+
+def test_prepared_workspace_requires_project_file_and_matching_checkout(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_calls = 0
+    revision = "revision-1"
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        _write_fake_dbt_project(clone_dir)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    monkeypatch.setattr(
+        dbt_module, "_resolve_checkout_revision", lambda _path: revision
+    )
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "vars": None,
+    }
+    compiled_dir = dbt_module._get_compiled_project(**kwargs)
+    source_dir = dbt_module._source_clone_dir(compiled_dir)
+    (source_dir / "dbt_project.yml").unlink()
+
+    dbt_module._get_compiled_project(**kwargs)
+    assert clone_calls == 2
+
+    revision = "revision-2"
+    dbt_module._get_compiled_project(**kwargs)
+    assert clone_calls == 3
+
+
+def test_external_generation_change_invalidates_siblings_before_new_variant(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_calls = 0
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        _write_fake_dbt_project(clone_dir)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+    }
+    us_path = dbt_module._get_compiled_project(vars={"country": "US"}, **kwargs)
+    marker_path = dbt_module._prepared_marker_path(
+        dbt_module._source_clone_dir(us_path)
+    )
+    marker = json.loads(marker_path.read_text())
+    marker["generation"] = "externally-replaced"
+    marker_path.write_text(json.dumps(marker))
+
+    ca_path = dbt_module._get_compiled_project(vars={"country": "CA"}, **kwargs)
+
+    assert clone_calls == 2
+    assert not us_path.exists()
+    assert ca_path.exists()
 
 
 def test_cleanup_reservation_blocks_reuse_until_deletion_finishes(
@@ -1136,6 +1404,150 @@ def test_cleanup_failure_keeps_reservation_until_retry_succeeds(monkeypatch, tmp
     assert not compiled_dir.exists()
 
 
+def test_workspace_failure_cleanup_finishes_before_retry_waiter_recreates_path(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    monkeypatch.setenv("SLIDEFLOW_DBT_COMPILE_FAILURE_BACKOFF_S", "0")
+    cleanup_started = threading.Event()
+    allow_cleanup = threading.Event()
+    clone_calls = 0
+    real_cleanup = dbt_module._cleanup_managed_clone_dir
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        _write_fake_dbt_project(clone_dir)
+        if clone_calls == 1:
+            raise DataSourceError("clone failed after creating workspace")
+
+    def _blocking_cleanup(clone_dir):
+        if not cleanup_started.is_set():
+            cleanup_started.set()
+            assert allow_cleanup.wait(5)
+        return real_cleanup(clone_dir)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "_cleanup_managed_clone_dir", _blocking_cleanup)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "vars": None,
+    }
+    first_errors: list[BaseException] = []
+    retry_results: list[Path] = []
+
+    def _first():
+        try:
+            dbt_module._get_compiled_project(**kwargs)
+        except BaseException as error:  # pragma: no cover - assertion helper
+            first_errors.append(error)
+
+    def _retry():
+        retry_results.append(dbt_module._get_compiled_project(**kwargs))
+
+    first = threading.Thread(target=_first)
+    first.start()
+    assert cleanup_started.wait(5)
+    retry = threading.Thread(target=_retry)
+    retry.start()
+    time.sleep(0.1)
+
+    assert clone_calls == 1
+    assert retry.is_alive()
+    allow_cleanup.set()
+    first.join(timeout=5)
+    retry.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not retry.is_alive()
+    assert len(first_errors) == 1
+    assert clone_calls == 2
+    assert len(retry_results) == 1
+    assert retry_results[0].is_dir()
+
+
+def test_compile_failure_cleanup_finishes_before_retry_waiter_reuses_variant(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    monkeypatch.setenv("SLIDEFLOW_DBT_COMPILE_FAILURE_BACKOFF_S", "0")
+    cleanup_started = threading.Event()
+    allow_cleanup = threading.Event()
+    compile_calls = 0
+    real_cleanup = dbt_module._cleanup_managed_compile_dir
+
+    def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
+
+    def _blocking_cleanup(compiled_dir):
+        if not cleanup_started.is_set():
+            cleanup_started.set()
+            assert allow_cleanup.wait(5)
+        return real_cleanup(compiled_dir)
+
+    class _Runner:
+        def invoke(self, args):
+            nonlocal compile_calls
+            if args[0] == "deps":
+                return SimpleNamespace(success=True)
+            compile_calls += 1
+            if compile_calls == 1:
+                return SimpleNamespace(
+                    success=False, exception=RuntimeError("transient compile failure")
+                )
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "_cleanup_managed_compile_dir", _blocking_cleanup)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "vars": None,
+    }
+    first_errors: list[BaseException] = []
+    retry_results: list[Path] = []
+
+    def _first():
+        try:
+            dbt_module._get_compiled_project(**kwargs)
+        except BaseException as error:  # pragma: no cover - assertion helper
+            first_errors.append(error)
+
+    def _retry():
+        retry_results.append(dbt_module._get_compiled_project(**kwargs))
+
+    first = threading.Thread(target=_first)
+    first.start()
+    assert cleanup_started.wait(5)
+    retry = threading.Thread(target=_retry)
+    retry.start()
+    time.sleep(0.1)
+
+    assert compile_calls == 1
+    assert retry.is_alive()
+    allow_cleanup.set()
+    first.join(timeout=5)
+    retry.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not retry.is_alive()
+    assert len(first_errors) == 1
+    assert compile_calls == 2
+    assert len(retry_results) == 1
+    assert retry_results[0].is_dir()
+
+
 def test_compile_stops_when_existing_variant_cannot_be_removed(monkeypatch, tmp_path):
     _reset_dbt_caches()
     workspace = str(tmp_path / "workspace")
@@ -1145,7 +1557,7 @@ def test_compile_stops_when_existing_variant_cannot_be_removed(monkeypatch, tmp_
     compiled_dir.mkdir(parents=True)
 
     def _fake_clone(_url, path, _branch):
-        path.mkdir(parents=True)
+        _write_fake_dbt_project(path)
 
     invocations = []
 
@@ -1180,7 +1592,7 @@ def test_get_compiled_project_reuses_clone_and_deps_across_isolated_vars(
     def _fake_clone(_url, clone_dir, _branch):
         nonlocal clone_calls
         clone_calls += 1
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1236,7 +1648,7 @@ def test_get_compiled_project_does_not_change_process_cwd(monkeypatch, tmp_path)
     _reset_dbt_caches()
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     invoke_args = []
 
@@ -1274,7 +1686,7 @@ def test_get_compiled_project_uses_project_root_profiles_when_present(
     _reset_dbt_caches()
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "profiles.yml").write_text("default: {}")
 
     invoke_args = []
@@ -1314,7 +1726,7 @@ def test_get_compiled_project_raises_when_dbt_compile_reports_failure(
     _reset_dbt_caches()
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1349,7 +1761,7 @@ def test_get_compiled_project_caches_failure_and_fails_fast_for_same_key(
     compile_calls = 0
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1390,7 +1802,7 @@ def test_compile_failure_isolated_from_other_vars(monkeypatch, tmp_path):
     def _fake_clone(_url, clone_dir, _branch):
         nonlocal clone_calls
         clone_calls += 1
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1433,7 +1845,7 @@ def test_get_compiled_project_retries_after_failure_backoff_expiry(
     compile_calls = 0
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1475,7 +1887,7 @@ def test_get_compiled_project_caches_failure_for_waiting_threads(monkeypatch, tm
     start_barrier = threading.Barrier(4)
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1519,7 +1931,7 @@ def test_get_compiled_project_bounds_failure_cache_entries(monkeypatch, tmp_path
     monkeypatch.setenv("SLIDEFLOW_DBT_FAILURE_CACHE_MAX_ENTRIES", "2")
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1561,7 +1973,7 @@ def test_get_compiled_project_single_flight_deduplicates_concurrent_compiles(
         nonlocal clone_calls
         with counter_lock:
             clone_calls += 1
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1611,7 +2023,7 @@ def test_concurrent_vars_single_flight_shared_workspace_preparation(
         with counter_lock:
             clone_calls += 1
         time.sleep(0.05)
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, args):
@@ -1663,7 +2075,7 @@ def test_manifest_connector_single_flight_deduplicates_concurrent_manifest_reads
         nonlocal clone_calls
         with counter_lock:
             clone_calls += 1
-
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
         (clone_dir / "target" / "compiled.sql").write_text("select 1 as answer")
         manifest = {
@@ -1714,6 +2126,7 @@ def test_manifest_lookup_ambiguous_alias_requires_disambiguation(monkeypatch, tm
     _reset_dbt_caches()
 
     def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
         (clone_dir / "target" / "us.sql").write_text("select 'US' as country")
         (clone_dir / "target" / "eu.sql").write_text("select 'EU' as country")
@@ -1761,6 +2174,7 @@ def test_manifest_lookup_supports_alias_disambiguation_selectors(monkeypatch, tm
     _reset_dbt_caches()
 
     def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
         (clone_dir / "target" / "us.sql").write_text("select 'US' as country")
         (clone_dir / "target" / "eu.sql").write_text("select 'EU' as country")
@@ -1823,6 +2237,7 @@ def test_manifest_lookup_reuses_manifest_index_for_repeated_queries(
     load_calls = 0
 
     def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
         (clone_dir / "target" / "compiled.sql").write_text("select 1 as answer")
         manifest = {
@@ -1877,6 +2292,7 @@ def test_manifest_index_is_rebuilt_without_recloning_when_variant_is_missing(
     def _fake_clone(_url, clone_dir, _branch):
         nonlocal clone_calls
         clone_calls += 1
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
         if clone_calls == 1:
             compiled_name = "compiled_first.sql"
@@ -1932,6 +2348,7 @@ def test_manifest_index_single_flight_deduplicates_parallel_reads_on_warm_cache(
     load_calls = 0
 
     def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
         (clone_dir / "target" / "compiled.sql").write_text("select 1 as answer")
         manifest = {
@@ -2045,6 +2462,7 @@ def test_manifest_lookup_returns_none_when_compiled_file_is_missing(
     _reset_dbt_caches()
 
     def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
         manifest = {
             "nodes": {
@@ -2452,6 +2870,7 @@ def test_parallel_model_fetches_with_low_cache_do_not_delete_active_manifest(
     )
 
     def _write_compiled_artifacts(clone_dir):
+        _write_fake_dbt_project(clone_dir)
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
         (clone_dir / "target" / "compiled.sql").write_text("select 1 as answer")
         manifest = {
@@ -2551,7 +2970,7 @@ def test_in_use_cache_entry_is_not_evicted_or_recompiled_for_same_key(
     def _fake_clone(_url, clone_dir, _branch):
         with count_lock:
             clone_counts[str(clone_dir)] += 1
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, _args):
@@ -2588,12 +3007,57 @@ def test_in_use_cache_entry_is_not_evicted_or_recompiled_for_same_key(
     assert clone_counts[str(dbt_module._source_clone_dir(us_path))] == 1
 
 
+def test_lease_release_reprunes_compiled_then_prepared_caches(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    monkeypatch.setenv("SLIDEFLOW_DBT_CACHE_MAX_ENTRIES", "1")
+
+    def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    workspace = str(tmp_path / "workspace")
+    first = dbt_module._get_compiled_project(
+        package_url="https://github.com/org/repo-a.git",
+        project_dir=workspace,
+        branch="main",
+        target="prod",
+        vars=None,
+        acquire_lease=True,
+    )
+    second = dbt_module._get_compiled_project(
+        package_url="https://github.com/org/repo-b.git",
+        project_dir=workspace,
+        branch="main",
+        target="prod",
+        vars=None,
+        acquire_lease=True,
+    )
+
+    assert len(dbt_module._compiled_projects_cache) == 2
+    assert len(dbt_module._prepared_workspaces_cache) == 2
+
+    dbt_module._release_compiled_project_lease(first)
+
+    assert len(dbt_module._compiled_projects_cache) == 1
+    assert len(dbt_module._prepared_workspaces_cache) == 1
+    assert not first.exists()
+    assert not dbt_module._source_clone_dir(first).exists()
+    assert second.exists()
+
+    dbt_module._release_compiled_project_lease(second)
+
+
 def test_get_compiled_project_prunes_old_entries(monkeypatch, tmp_path):
     _reset_dbt_caches()
     monkeypatch.setenv("SLIDEFLOW_DBT_CACHE_MAX_ENTRIES", "2")
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, _args):
@@ -2629,7 +3093,7 @@ def test_cache_prunes_unreferenced_shared_workspaces(monkeypatch, tmp_path):
     monkeypatch.setenv("SLIDEFLOW_DBT_CACHE_MAX_ENTRIES", "1")
 
     def _fake_clone(_url, clone_dir, _branch):
-        clone_dir.mkdir(parents=True, exist_ok=True)
+        _write_fake_dbt_project(clone_dir)
 
     class _Runner:
         def invoke(self, _args):

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -24,15 +24,19 @@ from slideflow.utilities.exceptions import DataSourceError
 def _reset_dbt_caches() -> None:
     dbt_module._prepared_workspaces_cache.clear()
     dbt_module._prepared_workspaces_last_access.clear()
+    dbt_module._prepared_workspace_generations.clear()
     dbt_module._workspace_preparation_inflight.clear()
     dbt_module._prepared_workspaces_in_use.clear()
     dbt_module._pending_workspace_cleanup_dirs.clear()
     dbt_module._compiled_projects_cache.clear()
     dbt_module._compiled_projects_last_access.clear()
+    dbt_module._compiled_project_generations.clear()
     dbt_module._compilation_inflight.clear()
     dbt_module._compilation_failures.clear()
     dbt_module._compiled_projects_in_use.clear()
     dbt_module._pending_cleanup_dirs.clear()
+    dbt_module._cleanup_in_progress_dirs.clear()
+    dbt_module._cleanup_failures.clear()
     dbt_module._manifest_index_cache.clear()
     dbt_module._manifest_index_inflight.clear()
     dbt_module._compiled_project_coverage.clear()
@@ -818,6 +822,318 @@ def test_cached_compile_reprepares_externally_deleted_source_clone(
     assert invocations[-1][invocations[-1].index("--select") + 1] == (
         "model.project.new_selector"
     )
+
+
+def test_workspace_refresh_invalidates_every_compiled_variant(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    clone_generation = 0
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_generation
+        clone_generation += 1
+        clone_dir.mkdir(parents=True)
+        (clone_dir / "generation.txt").write_text(str(clone_generation))
+
+    class _Runner:
+        def invoke(self, args):
+            if "--target-path" in args:
+                source = Path(args[args.index("--project-dir") + 1])
+                target_path = Path(args[args.index("--target-path") + 1])
+                target_path.mkdir(parents=True, exist_ok=True)
+                (target_path / "generation.txt").write_text(
+                    (source / "generation.txt").read_text()
+                )
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "parse_only": True,
+    }
+
+    us_path = dbt_module._get_compiled_project(vars={"country": "US"}, **kwargs)
+    ca_path = dbt_module._get_compiled_project(vars={"country": "CA"}, **kwargs)
+    ca_key = dbt_module._project_cache_key(
+        kwargs["package_url"],
+        kwargs["project_dir"],
+        kwargs["branch"],
+        kwargs["target"],
+        {"country": "CA"},
+        None,
+        None,
+    )
+    dbt_module._compiled_project_coverage[ca_key] = frozenset({"old.selector"})
+    source_dir = dbt_module._source_clone_dir(us_path)
+    shutil.rmtree(source_dir)
+
+    refreshed_us = dbt_module._get_compiled_project(vars={"country": "US"}, **kwargs)
+
+    assert ca_key not in dbt_module._compiled_projects_cache
+    assert ca_key not in dbt_module._compiled_project_coverage
+    assert not ca_path.exists()
+
+    refreshed_ca = dbt_module._get_compiled_project(vars={"country": "CA"}, **kwargs)
+    assert clone_generation == 2
+    assert (refreshed_us / "target" / "generation.txt").read_text() == "2"
+    assert (refreshed_ca / "target" / "generation.txt").read_text() == "2"
+
+
+def test_workspace_refresh_waits_for_active_sibling_variant_lease(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_calls = 0
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        clone_dir.mkdir(parents=True)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+    }
+    us_path = dbt_module._get_compiled_project(vars={"country": "US"}, **kwargs)
+    dbt_module._get_compiled_project(vars={"country": "CA"}, **kwargs)
+    refresh_finished = threading.Event()
+    refresh_errors = []
+
+    with dbt_module._compiled_project_lease(
+        vars={"country": "CA"}, **kwargs
+    ) as leased_ca:
+        shutil.rmtree(dbt_module._source_clone_dir(us_path))
+
+        def _refresh():
+            try:
+                dbt_module._get_compiled_project(vars={"country": "US"}, **kwargs)
+            except Exception as error:  # pragma: no cover - assertion helper path
+                refresh_errors.append(error)
+            finally:
+                refresh_finished.set()
+
+        refresh_thread = threading.Thread(target=_refresh)
+        refresh_thread.start()
+        assert not refresh_finished.wait(0.1)
+        assert leased_ca.exists()
+
+    refresh_thread.join(timeout=5)
+
+    assert refresh_finished.is_set()
+    assert refresh_errors == []
+    assert clone_calls == 2
+
+
+@pytest.mark.parametrize("child_name", ["target", "logs"])
+def test_selected_compile_rejects_concrete_output_symlink(
+    monkeypatch, tmp_path, child_name
+):
+    _reset_dbt_caches()
+    invocations: list[list[str]] = []
+
+    def _fake_clone(_url, clone_dir, _branch):
+        clone_dir.mkdir(parents=True)
+
+    class _Runner:
+        def invoke(self, args):
+            invocations.append(list(args))
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "vars": {"country": "US"},
+        "parse_only": True,
+    }
+    compiled_dir = dbt_module._get_compiled_project(**kwargs)
+    child = compiled_dir / child_name
+    shutil.rmtree(child)
+    external = tmp_path / f"external-{child_name}"
+    external.mkdir()
+    child.symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(DataSourceError, match="must not be a symlink"):
+        dbt_module._ensure_selected_compilation(
+            clone_dir=compiled_dir,
+            package_url=kwargs["package_url"],
+            project_dir=kwargs["project_dir"],
+            branch=kwargs["branch"],
+            target=kwargs["target"],
+            vars=kwargs["vars"],
+            profiles_dir=None,
+            profile_name=None,
+            selectors=("model.project.metrics",),
+        )
+
+    assert [args[0] for args in invocations] == ["deps", "parse"]
+
+
+def test_dbt_deps_rejects_concrete_log_symlink(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    workspace = str(tmp_path / "workspace")
+    package_url = "https://github.com/org/repo.git"
+    clone_dir = dbt_module._resolve_managed_clone_dir(workspace, package_url, "main")
+    deps_log = dbt_module._resolve_deps_log_dir(clone_dir)
+    deps_log.parent.mkdir(parents=True)
+    external = tmp_path / "external-deps"
+    external.mkdir()
+    sentinel = external / "sentinel.txt"
+    sentinel.write_text("preserve")
+    deps_log.symlink_to(external, target_is_directory=True)
+    invocations = []
+
+    def _fake_clone(_url, path, _branch):
+        path.mkdir(parents=True)
+
+    class _Runner:
+        def invoke(self, args):
+            invocations.append(args)
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+
+    with pytest.raises(DataSourceError, match="must not be a symlink"):
+        dbt_module._get_compiled_project(
+            package_url=package_url,
+            project_dir=workspace,
+            branch="main",
+            target="prod",
+            vars=None,
+        )
+
+    assert invocations == []
+    assert sentinel.read_text() == "preserve"
+
+
+def test_prepared_workspace_marker_mismatch_reprepares_all_variants(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_calls = 0
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        clone_dir.mkdir(parents=True)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "vars": {"country": "US"},
+    }
+    compiled_dir = dbt_module._get_compiled_project(**kwargs)
+    marker_path = dbt_module._prepared_marker_path(
+        dbt_module._source_clone_dir(compiled_dir)
+    )
+    marker = json.loads(marker_path.read_text())
+    marker["identity"] = "wrong-workspace"
+    marker_path.write_text(json.dumps(marker))
+
+    dbt_module._get_compiled_project(**kwargs)
+
+    assert clone_calls == 2
+
+
+def test_cleanup_reservation_blocks_reuse_until_deletion_finishes(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(tmp_path / "workspace"),
+        "https://github.com/org/repo.git",
+        "main",
+    )
+    compiled_dir = dbt_module._resolve_managed_compile_dir(clone_dir, "prod", None)
+    compiled_dir.mkdir(parents=True)
+    started = threading.Event()
+    allow_delete = threading.Event()
+    real_rmtree = shutil.rmtree
+
+    def _blocking_rmtree(path):
+        if Path(path) == compiled_dir:
+            started.set()
+            assert allow_delete.wait(5)
+        real_rmtree(path)
+
+    monkeypatch.setattr(dbt_module.shutil, "rmtree", _blocking_rmtree)
+    with dbt_module._cache_lock:
+        dbt_module._pending_cleanup_dirs.add(compiled_dir)
+
+    cleanup_thread = threading.Thread(target=dbt_module._cleanup_ready_managed_dirs)
+    cleanup_thread.start()
+    assert started.wait(5)
+
+    waiter_finished = threading.Event()
+
+    def _waiter():
+        dbt_module._wait_for_managed_cleanup(compiled_dir, workspace=False)
+        waiter_finished.set()
+
+    waiter = threading.Thread(target=_waiter)
+    waiter.start()
+    assert not waiter_finished.wait(0.1)
+    allow_delete.set()
+    cleanup_thread.join(timeout=5)
+    waiter.join(timeout=5)
+
+    assert waiter_finished.is_set()
+    assert compiled_dir not in dbt_module._pending_cleanup_dirs
+    assert not compiled_dir.exists()
+
+
+def test_cleanup_failure_keeps_reservation_until_retry_succeeds(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(tmp_path / "workspace"),
+        "https://github.com/org/repo.git",
+        "main",
+    )
+    compiled_dir = dbt_module._resolve_managed_compile_dir(clone_dir, "prod", None)
+    compiled_dir.mkdir(parents=True)
+    cleanup_attempts = 0
+    real_cleanup = dbt_module._cleanup_managed_compile_dir
+
+    def _flaky_cleanup(path):
+        nonlocal cleanup_attempts
+        cleanup_attempts += 1
+        if cleanup_attempts == 1:
+            return False
+        return real_cleanup(path)
+
+    monkeypatch.setattr(dbt_module, "_cleanup_managed_compile_dir", _flaky_cleanup)
+    with dbt_module._cache_lock:
+        dbt_module._pending_cleanup_dirs.add(compiled_dir)
+
+    dbt_module._wait_for_managed_cleanup(compiled_dir, workspace=False)
+
+    assert cleanup_attempts == 2
+    assert compiled_dir not in dbt_module._pending_cleanup_dirs
+    assert compiled_dir not in dbt_module._cleanup_failures
+    assert not compiled_dir.exists()
 
 
 def test_compile_stops_when_existing_variant_cannot_be_removed(monkeypatch, tmp_path):

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -160,8 +160,7 @@ def test_scoped_compile_ignores_unrelated_execute_time_failure(tmp_path):
         encoding="utf-8",
     )
     (models_dir / "model_a.sql").write_text(
-        "{{ config(alias='alias_a') }} "
-        "select * from {{ ref('ephemeral_parent') }}\n",
+        "{{ config(alias='alias_a') }} select * from {{ ref('ephemeral_parent') }}\n",
         encoding="utf-8",
     )
     (models_dir / "model_b.sql").write_text(
@@ -193,7 +192,7 @@ def test_scoped_compile_ignores_unrelated_execute_time_failure(tmp_path):
 from slideflow.data.connectors.dbt import DBTManifestConnector
 connector = DBTManifestConnector(
     package_url={str(repo_dir)!r},
-    project_dir={str(tmp_path / 'workspace')!r},
+    project_dir={str(tmp_path / "workspace")!r},
     target='dev',
 )
 connector.prepare_models([
@@ -223,11 +222,11 @@ def test_multi_source_vars_share_workspace_and_isolate_artifacts(tmp_path):
         pytest.skip("dbt and GitPython integration extras are not installed")
 
     repo_dir = tmp_path / "source_repo"
-    models_dir = repo_dir / "models"
+    models_dir = repo_dir
     models_dir.mkdir(parents=True)
     (repo_dir / "dbt_project.yml").write_text(
         "name: analytics\nversion: '1.0'\nconfig-version: 2\n"
-        "profile: analytics\nmodel-paths: ['models']\n",
+        "profile: analytics\nmodel-paths: ['.']\n",
         encoding="utf-8",
     )
     (repo_dir / "profiles.yml").write_text(
@@ -290,7 +289,9 @@ payload = {{
 }}
 clones = list((workspace / '.slideflow_dbt_clones').iterdir())
 payload['clone_count'] = len(clones)
-payload['variant_count'] = len(list((clones[0] / '.slideflow_dbt_targets').iterdir()))
+variant_roots = list((workspace / '.slideflow_dbt_targets').iterdir())
+payload['variant_count'] = len(list(variant_roots[0].iterdir()))
+payload['artifacts_outside_clone'] = not variant_roots[0].is_relative_to(clones[0])
 print(json.dumps(payload))
 """
     result = subprocess.run(
@@ -302,6 +303,7 @@ print(json.dumps(payload))
     payload = json.loads(result.stdout.strip().splitlines()[-1])
     assert payload["clone_count"] == 1
     assert payload["variant_count"] == 2
+    assert payload["artifacts_outside_clone"] is True
     assert all("'US' as region" in sql for sql in payload["US"])
     assert all("'CA' as region" in sql for sql in payload["CA"])
     assert "'a' as analysis" in payload["US"][0]
@@ -438,29 +440,34 @@ def test_resolve_managed_clone_dir_uses_managed_workspace(tmp_path):
     assert clone_dir.parent.exists()
 
 
-def test_get_compiled_project_rejects_reserved_target_path_from_repo(
+def test_get_compiled_project_allows_target_named_path_inside_repo(
     monkeypatch, tmp_path
 ):
     _reset_dbt_caches()
+    invocations = []
 
     def _fake_clone(_url, clone_dir, _branch):
         (clone_dir / ".slideflow_dbt_targets").mkdir(parents=True)
 
     class _Runner:
-        def invoke(self, _args):
-            raise AssertionError("dbt must not run for a reserved-path collision")
+        def invoke(self, args):
+            invocations.append(args)
+            return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
     monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
 
-    with pytest.raises(DataSourceError, match="reserved Slideflow path"):
-        dbt_module._get_compiled_project(
-            package_url="https://github.com/org/repo.git",
-            project_dir=str(tmp_path / "workspace"),
-            branch="main",
-            target="prod",
-            vars={"country": "US"},
-        )
+    compiled_dir = dbt_module._get_compiled_project(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(tmp_path / "workspace"),
+        branch="main",
+        target="prod",
+        vars={"country": "US"},
+    )
+
+    assert [args[0] for args in invocations] == ["deps", "compile"]
+    assert compiled_dir.parent.parent.name == ".slideflow_dbt_targets"
+    assert ".slideflow_dbt_clones" not in compiled_dir.parts
 
 
 def test_resolve_managed_clone_dir_excludes_compile_variant_inputs(tmp_path):
@@ -518,6 +525,245 @@ def test_resolve_managed_clone_dir_excludes_compile_variant_inputs(tmp_path):
     ) != dbt_module._resolve_managed_compile_dir(
         baseline, "prod", {"as_of_date": "2026-02-19"}
     )
+
+
+def test_workspace_identity_distinguishes_absent_from_literal_defaults(tmp_path):
+    workspace = str(tmp_path / "workspace")
+    package_url = "https://github.com/org/repo.git"
+
+    absent_key = dbt_module._workspace_cache_key(
+        package_url, workspace, None, None, None
+    )
+    literal_key = dbt_module._workspace_cache_key(
+        package_url, workspace, "default", None, "default"
+    )
+    absent_dir = dbt_module._resolve_managed_clone_dir(workspace, package_url, None)
+    literal_dir = dbt_module._resolve_managed_clone_dir(
+        workspace, package_url, "default", profile_name="default"
+    )
+
+    assert absent_key != literal_key
+    assert absent_dir != literal_dir
+    assert (
+        dbt_module._workspace_cache_key(package_url, workspace, "", "", "")
+        == absent_key
+    )
+
+
+def test_concurrent_literal_default_and_absent_branch_use_distinct_workspaces(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_paths = []
+    clone_lock = threading.Lock()
+
+    def _fake_clone(_url, clone_dir, _branch):
+        with clone_lock:
+            clone_paths.append(clone_dir)
+        clone_dir.mkdir(parents=True)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+
+    def _worker(branch):
+        return dbt_module._get_compiled_project(
+            package_url="https://github.com/org/repo.git",
+            project_dir=str(tmp_path / "workspace"),
+            branch=branch,
+            target="prod",
+            vars=None,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        paths = list(executor.map(_worker, (None, "default")))
+
+    assert len(set(clone_paths)) == 2
+    assert dbt_module._source_clone_dir(paths[0]) != dbt_module._source_clone_dir(
+        paths[1]
+    )
+
+
+def test_managed_compile_dir_is_a_sibling_of_clone_tree(tmp_path):
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(tmp_path / "workspace"),
+        "https://github.com/org/repo.git",
+        "main",
+    )
+    compiled_dir = dbt_module._resolve_managed_compile_dir(
+        clone_dir, "prod", {"country": "US"}
+    )
+
+    assert (
+        compiled_dir.parent.parent == tmp_path / "workspace" / ".slideflow_dbt_targets"
+    )
+    assert dbt_module._source_clone_dir(compiled_dir) == clone_dir
+    assert not compiled_dir.is_relative_to(clone_dir)
+
+
+def test_clone_cleanup_invalidates_sibling_manifest_indexes(tmp_path):
+    _reset_dbt_caches()
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(tmp_path / "workspace"),
+        "https://github.com/org/repo.git",
+        "main",
+    )
+    compiled_dir = dbt_module._resolve_managed_compile_dir(
+        clone_dir, "prod", {"country": "US"}
+    )
+    clone_dir.mkdir(parents=True)
+    compiled_dir.mkdir(parents=True)
+    manifest_key = compiled_dir.resolve()
+    dbt_module._manifest_index_cache[manifest_key] = dbt_module._ManifestIndex({}, {})
+
+    dbt_module._cleanup_managed_clone_dir(clone_dir)
+
+    assert manifest_key not in dbt_module._manifest_index_cache
+    assert not clone_dir.exists()
+    assert not compiled_dir.exists()
+
+
+def test_clone_cleanup_does_not_follow_symlinked_artifact_namespace(tmp_path):
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(tmp_path / "workspace"),
+        "https://github.com/org/repo.git",
+        "main",
+    )
+    clone_dir.mkdir(parents=True)
+    external = tmp_path / "external"
+    external.mkdir()
+    sentinel = external / "sentinel.txt"
+    sentinel.write_text("preserve")
+    target_root = clone_dir.parent.parent / ".slideflow_dbt_targets"
+    target_root.symlink_to(external, target_is_directory=True)
+
+    dbt_module._cleanup_managed_clone_dir(clone_dir)
+
+    assert sentinel.read_text() == "preserve"
+    assert target_root.is_symlink()
+
+
+@pytest.mark.parametrize("symlink_level", ["namespace", "workspace", "variant"])
+def test_get_compiled_project_rejects_symlinked_artifact_paths(
+    monkeypatch, tmp_path, symlink_level
+):
+    _reset_dbt_caches()
+    workspace = tmp_path / "workspace"
+    package_url = "https://github.com/org/repo.git"
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(workspace), package_url, "main"
+    )
+    compiled_dir = dbt_module._resolve_managed_compile_dir(
+        clone_dir, "prod", {"country": "US"}
+    )
+    external = tmp_path / f"external-{symlink_level}"
+    external.mkdir()
+    sentinel = external / "sentinel.txt"
+    sentinel.write_text("preserve")
+
+    if symlink_level == "namespace":
+        compiled_dir.parent.parent.symlink_to(external, target_is_directory=True)
+    elif symlink_level == "workspace":
+        compiled_dir.parent.parent.mkdir()
+        compiled_dir.parent.symlink_to(external, target_is_directory=True)
+    else:
+        compiled_dir.parent.mkdir(parents=True)
+        compiled_dir.symlink_to(external, target_is_directory=True)
+
+    def _fake_clone(_url, path, _branch):
+        path.mkdir(parents=True)
+
+    invocations = []
+
+    class _Runner:
+        def invoke(self, args):
+            invocations.append(args)
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+
+    with pytest.raises(DataSourceError, match="must not be a symlink"):
+        dbt_module._get_compiled_project(
+            package_url=package_url,
+            project_dir=str(workspace),
+            branch="main",
+            target="prod",
+            vars={"country": "US"},
+        )
+
+    assert [args[0] for args in invocations] == ["deps"]
+    assert sentinel.read_text() == "preserve"
+
+
+def test_cached_compile_path_rejects_symlink_replacement(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+
+    def _fake_clone(_url, clone_dir, _branch):
+        clone_dir.mkdir(parents=True)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "vars": {"country": "US"},
+    }
+    compiled_dir = dbt_module._get_compiled_project(**kwargs)
+    external = tmp_path / "external"
+    external.mkdir()
+    sentinel = external / "sentinel.txt"
+    sentinel.write_text("preserve")
+    shutil.rmtree(compiled_dir)
+    compiled_dir.symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(DataSourceError, match="must not be a symlink"):
+        dbt_module._get_compiled_project(**kwargs)
+
+    assert sentinel.read_text() == "preserve"
+
+
+def test_compile_stops_when_existing_variant_cannot_be_removed(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    workspace = str(tmp_path / "workspace")
+    package_url = "https://github.com/org/repo.git"
+    clone_dir = dbt_module._resolve_managed_clone_dir(workspace, package_url, "main")
+    compiled_dir = dbt_module._resolve_managed_compile_dir(clone_dir, "prod", None)
+    compiled_dir.mkdir(parents=True)
+
+    def _fake_clone(_url, path, _branch):
+        path.mkdir(parents=True)
+
+    invocations = []
+
+    class _Runner:
+        def invoke(self, args):
+            invocations.append(args)
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    monkeypatch.setattr(dbt_module.shutil, "rmtree", lambda _path: None)
+
+    with pytest.raises(DataSourceError, match="Failed to safely reset"):
+        dbt_module._get_compiled_project(
+            package_url=package_url,
+            project_dir=workspace,
+            branch="main",
+            target="prod",
+            vars=None,
+        )
+
+    assert [args[0] for args in invocations] == ["deps"]
 
 
 def test_get_compiled_project_reuses_clone_and_deps_across_isolated_vars(

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -732,6 +732,94 @@ def test_cached_compile_path_rejects_symlink_replacement(monkeypatch, tmp_path):
     assert sentinel.read_text() == "preserve"
 
 
+def test_cached_compile_reprepares_externally_deleted_source_clone(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_calls = 0
+    invocations = []
+    project_dir_states = []
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        clone_dir.mkdir(parents=True)
+
+    class _Runner:
+        def invoke(self, args):
+            invocations.append(list(args))
+            if "--project-dir" in args:
+                project_dir = Path(args[args.index("--project-dir") + 1])
+                project_dir_states.append(project_dir.is_dir())
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "vars": {"country": "US"},
+        "parse_only": True,
+    }
+
+    compiled_dir = dbt_module._get_compiled_project(**kwargs)
+    source_dir = dbt_module._source_clone_dir(compiled_dir)
+    dbt_module._ensure_selected_compilation(
+        clone_dir=compiled_dir,
+        package_url=kwargs["package_url"],
+        project_dir=kwargs["project_dir"],
+        branch=kwargs["branch"],
+        target=kwargs["target"],
+        vars=kwargs["vars"],
+        profiles_dir=None,
+        profile_name=None,
+        selectors=("model.project.existing_selector",),
+    )
+    shutil.rmtree(source_dir)
+
+    refreshed_dir = dbt_module._get_compiled_project(**kwargs)
+    cache_key = dbt_module._project_cache_key(
+        kwargs["package_url"],
+        kwargs["project_dir"],
+        kwargs["branch"],
+        kwargs["target"],
+        kwargs["vars"],
+        None,
+        None,
+    )
+    assert dbt_module._compiled_project_coverage[cache_key] == frozenset()
+    dbt_module._ensure_selected_compilation(
+        clone_dir=refreshed_dir,
+        package_url=kwargs["package_url"],
+        project_dir=kwargs["project_dir"],
+        branch=kwargs["branch"],
+        target=kwargs["target"],
+        vars=kwargs["vars"],
+        profiles_dir=None,
+        profile_name=None,
+        selectors=("model.project.new_selector",),
+    )
+
+    assert refreshed_dir == compiled_dir
+    assert source_dir.is_dir()
+    assert clone_calls == 2
+    assert [args[0] for args in invocations] == [
+        "deps",
+        "parse",
+        "compile",
+        "deps",
+        "parse",
+        "compile",
+    ]
+    assert all(project_dir_states)
+    assert str(source_dir) in invocations[-1]
+    assert invocations[-1][invocations[-1].index("--select") + 1] == (
+        "model.project.new_selector"
+    )
+
+
 def test_compile_stops_when_existing_variant_cannot_be_removed(monkeypatch, tmp_path):
     _reset_dbt_caches()
     workspace = str(tmp_path / "workspace")

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -22,6 +22,11 @@ from slideflow.utilities.exceptions import DataSourceError
 
 
 def _reset_dbt_caches() -> None:
+    dbt_module._prepared_workspaces_cache.clear()
+    dbt_module._prepared_workspaces_last_access.clear()
+    dbt_module._workspace_preparation_inflight.clear()
+    dbt_module._prepared_workspaces_in_use.clear()
+    dbt_module._pending_workspace_cleanup_dirs.clear()
     dbt_module._compiled_projects_cache.clear()
     dbt_module._compiled_projects_last_access.clear()
     dbt_module._compilation_inflight.clear()
@@ -32,6 +37,16 @@ def _reset_dbt_caches() -> None:
     dbt_module._manifest_index_inflight.clear()
     dbt_module._compiled_project_coverage.clear()
     dbt_module._selection_locks.clear()
+
+
+def _copy_seeded_target_to_invocation(args: list[str]) -> None:
+    """Make no-op dbt runners materialize fake-clone artifacts per target path."""
+    if "--target-path" not in args or "--project-dir" not in args:
+        return
+    source = Path(args[args.index("--project-dir") + 1]) / "target"
+    destination = Path(args[args.index("--target-path") + 1])
+    if source.exists():
+        shutil.copytree(source, destination, dirs_exist_ok=True)
 
 
 def _write_compiled_dbt_project(
@@ -87,6 +102,7 @@ def test_prepare_models_batches_exact_sorted_selectors(monkeypatch, tmp_path):
     class _Runner:
         def invoke(self, args):
             invocations.append(list(args))
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -135,7 +151,8 @@ def test_scoped_compile_ignores_unrelated_execute_time_failure(tmp_path):
     )
     (repo_dir / "profiles.yml").write_text(
         "analytics:\n  target: dev\n  outputs:\n    dev:\n"
-        "      type: duckdb\n      path: warehouse.duckdb\n      threads: 1\n",
+        f"      type: duckdb\n      path: {tmp_path / 'warehouse.duckdb'}\n"
+        "      threads: 1\n",
         encoding="utf-8",
     )
     (models_dir / "ephemeral_parent.sql").write_text(
@@ -194,6 +211,101 @@ print(connector.get_compiled_query('alias_b'))
     )
     assert "select" in result.stdout.lower()
     assert "select 2" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_multi_source_vars_share_workspace_and_isolate_artifacts(tmp_path):
+    try:
+        version("dbt-core")
+        version("dbt-duckdb")
+        version("gitpython")
+    except PackageNotFoundError:
+        pytest.skip("dbt and GitPython integration extras are not installed")
+
+    repo_dir = tmp_path / "source_repo"
+    models_dir = repo_dir / "models"
+    models_dir.mkdir(parents=True)
+    (repo_dir / "dbt_project.yml").write_text(
+        "name: analytics\nversion: '1.0'\nconfig-version: 2\n"
+        "profile: analytics\nmodel-paths: ['models']\n",
+        encoding="utf-8",
+    )
+    (repo_dir / "profiles.yml").write_text(
+        "analytics:\n  target: dev\n  outputs:\n    dev:\n"
+        f"      type: duckdb\n      path: {tmp_path / 'warehouse.duckdb'}\n"
+        "      threads: 1\n",
+        encoding="utf-8",
+    )
+    for suffix in ("a", "b"):
+        (models_dir / f"model_{suffix}.sql").write_text(
+            "{{ config(alias='alias_" + suffix + "') }} "
+            "select '{{ var(\"region\") }}' as region, '" + suffix + "' as analysis\n",
+            encoding="utf-8",
+        )
+    subprocess.run(["git", "init", str(repo_dir)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "config", "user.name", "Slideflow Tests"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo_dir), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "commit", "-m", "fixture"],
+        check=True,
+        capture_output=True,
+    )
+
+    workspace = tmp_path / "workspace"
+    script = f"""
+import json
+from pathlib import Path
+from slideflow.data.connectors.dbt import DBTManifestConnector
+
+workspace = Path({str(workspace)!r})
+connectors = {{
+    region: DBTManifestConnector(
+        package_url={str(repo_dir)!r},
+        project_dir=str(workspace),
+        target='dev',
+        vars={{'region': region}},
+    )
+    for region in ('US', 'CA')
+}}
+requests = [
+    ('alias_a', None, None, None),
+    ('alias_b', None, None, None),
+    ('alias_a', None, None, None),
+]
+for connector in connectors.values():
+    connector.prepare_models(requests)
+payload = {{
+    region: [
+        connector.get_compiled_query('alias_a'),
+        connector.get_compiled_query('alias_b'),
+    ]
+    for region, connector in connectors.items()
+}}
+clones = list((workspace / '.slideflow_dbt_clones').iterdir())
+payload['clone_count'] = len(clones)
+payload['variant_count'] = len(list((clones[0] / '.slideflow_dbt_targets').iterdir()))
+print(json.dumps(payload))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["clone_count"] == 1
+    assert payload["variant_count"] == 2
+    assert all("'US' as region" in sql for sql in payload["US"])
+    assert all("'CA' as region" in sql for sql in payload["CA"])
+    assert "'a' as analysis" in payload["US"][0]
+    assert "'b' as analysis" in payload["US"][1]
 
 
 def test_sanitize_git_url_redacts_embedded_credentials():
@@ -326,7 +438,32 @@ def test_resolve_managed_clone_dir_uses_managed_workspace(tmp_path):
     assert clone_dir.parent.exists()
 
 
-def test_resolve_managed_clone_dir_includes_compile_inputs_in_identity(tmp_path):
+def test_get_compiled_project_rejects_reserved_target_path_from_repo(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+
+    def _fake_clone(_url, clone_dir, _branch):
+        (clone_dir / ".slideflow_dbt_targets").mkdir(parents=True)
+
+    class _Runner:
+        def invoke(self, _args):
+            raise AssertionError("dbt must not run for a reserved-path collision")
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+
+    with pytest.raises(DataSourceError, match="reserved Slideflow path"):
+        dbt_module._get_compiled_project(
+            package_url="https://github.com/org/repo.git",
+            project_dir=str(tmp_path / "workspace"),
+            branch="main",
+            target="prod",
+            vars={"country": "US"},
+        )
+
+
+def test_resolve_managed_clone_dir_excludes_compile_variant_inputs(tmp_path):
     workspace = str(tmp_path / "workspace")
     package_url = "https://github.com/org/repo.git"
     branch = "main"
@@ -368,19 +505,36 @@ def test_resolve_managed_clone_dir_includes_compile_inputs_in_identity(tmp_path)
         profile_name="analytics",
     )
 
-    assert baseline != different_target
-    assert baseline != different_vars
+    assert baseline == different_target
+    assert baseline == different_vars
     assert baseline != different_profile
+    assert dbt_module._resolve_managed_compile_dir(
+        baseline, "prod", {"as_of_date": "2026-02-18"}
+    ) != dbt_module._resolve_managed_compile_dir(
+        baseline, "dev", {"as_of_date": "2026-02-18"}
+    )
+    assert dbt_module._resolve_managed_compile_dir(
+        baseline, "prod", {"as_of_date": "2026-02-18"}
+    ) != dbt_module._resolve_managed_compile_dir(
+        baseline, "prod", {"as_of_date": "2026-02-19"}
+    )
 
 
-def test_get_compiled_project_keeps_variant_clone_paths_isolated(monkeypatch, tmp_path):
+def test_get_compiled_project_reuses_clone_and_deps_across_isolated_vars(
+    monkeypatch, tmp_path
+):
     _reset_dbt_caches()
+    clone_calls = 0
+    invocations: list[list[str]] = []
 
     def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
         clone_dir.mkdir(parents=True, exist_ok=True)
 
     class _Runner:
-        def invoke(self, _args):
+        def invoke(self, args):
+            invocations.append(list(args))
             return None
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -420,6 +574,12 @@ def test_get_compiled_project_keeps_variant_clone_paths_isolated(monkeypatch, tm
 
     assert path_a != path_b
     assert path_a_again == path_a
+    assert dbt_module._source_clone_dir(path_a) == dbt_module._source_clone_dir(path_b)
+    assert clone_calls == 1
+    assert [args[0] for args in invocations].count("deps") == 1
+    assert [args[0] for args in invocations].count("compile") == 2
+    assert str(path_a / "target") in invocations[1]
+    assert str(path_b / "target") in invocations[2]
 
 
 def test_get_compiled_project_does_not_change_process_cwd(monkeypatch, tmp_path):
@@ -433,6 +593,7 @@ def test_get_compiled_project_does_not_change_process_cwd(monkeypatch, tmp_path)
     class _Runner:
         def invoke(self, args):
             invoke_args.append(args)
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     chdir_calls = []
@@ -471,6 +632,7 @@ def test_get_compiled_project_uses_project_root_profiles_when_present(
     class _Runner:
         def invoke(self, args):
             invoke_args.append(args)
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -490,8 +652,10 @@ def test_get_compiled_project_uses_project_root_profiles_when_present(
     assert invoke_args
     assert "--profiles-dir" in invoke_args[0]
     assert "--profiles-dir" in invoke_args[1]
-    assert str(compiled_path) in invoke_args[0]
-    assert str(compiled_path) in invoke_args[1]
+    source_dir = dbt_module._source_clone_dir(compiled_path)
+    assert str(source_dir) in invoke_args[0]
+    assert str(source_dir) in invoke_args[1]
+    assert str(compiled_path / "target") in invoke_args[1]
 
 
 def test_get_compiled_project_raises_when_dbt_compile_reports_failure(
@@ -566,6 +730,49 @@ def test_get_compiled_project_caches_failure_and_fails_fast_for_same_key(
         dbt_module._get_compiled_project(**kwargs)
 
     assert compile_calls == 1
+
+
+def test_compile_failure_isolated_from_other_vars(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    clone_calls = 0
+    deps_calls = 0
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        clone_dir.mkdir(parents=True, exist_ok=True)
+
+    class _Runner:
+        def invoke(self, args):
+            nonlocal deps_calls
+            if args[0] == "deps":
+                deps_calls += 1
+                return SimpleNamespace(success=True)
+            vars_payload = args[args.index("--vars") + 1]
+            if json.loads(vars_payload)["country"] == "US":
+                return SimpleNamespace(
+                    success=False, exception=RuntimeError("US compile failed")
+                )
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+        "profiles_dir": None,
+        "profile_name": None,
+    }
+
+    with pytest.raises(DataSourceError, match="US compile failed"):
+        dbt_module._get_compiled_project(vars={"country": "US"}, **kwargs)
+    ca_path = dbt_module._get_compiled_project(vars={"country": "CA"}, **kwargs)
+
+    assert ca_path.exists()
+    assert clone_calls == 1
+    assert deps_calls == 1
 
 
 def test_get_compiled_project_retries_after_failure_backoff_expiry(
@@ -713,6 +920,7 @@ def test_get_compiled_project_single_flight_deduplicates_concurrent_compiles(
                 with counter_lock:
                     compile_calls += 1
                 time.sleep(0.05)
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -736,6 +944,60 @@ def test_get_compiled_project_single_flight_deduplicates_concurrent_compiles(
     assert clone_calls == 1
     assert compile_calls == 1
     assert all(result == results[0] for result in results)
+
+
+def test_concurrent_vars_single_flight_shared_workspace_preparation(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_calls = 0
+    deps_calls = 0
+    compile_calls = 0
+    counter_lock = threading.Lock()
+    start_barrier = threading.Barrier(2)
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        with counter_lock:
+            clone_calls += 1
+        time.sleep(0.05)
+        clone_dir.mkdir(parents=True, exist_ok=True)
+
+    class _Runner:
+        def invoke(self, args):
+            nonlocal deps_calls, compile_calls
+            with counter_lock:
+                if args[0] == "deps":
+                    deps_calls += 1
+                elif args[0] == "compile":
+                    compile_calls += 1
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+
+    def _worker(country):
+        start_barrier.wait()
+        return dbt_module._get_compiled_project(
+            package_url="https://github.com/org/repo.git",
+            project_dir=str(tmp_path / "workspace"),
+            branch="main",
+            target="prod",
+            vars={"country": country},
+            profiles_dir=None,
+            profile_name=None,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(_worker, ("US", "CA")))
+
+    assert clone_calls == 1
+    assert deps_calls == 1
+    assert compile_calls == 2
+    assert results[0] != results[1]
+    assert dbt_module._source_clone_dir(results[0]) == dbt_module._source_clone_dir(
+        results[1]
+    )
 
 
 def test_manifest_connector_single_flight_deduplicates_concurrent_manifest_reads(
@@ -772,6 +1034,7 @@ def test_manifest_connector_single_flight_deduplicates_concurrent_manifest_reads
                 with counter_lock:
                     compile_calls += 1
                 time.sleep(0.05)
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -825,7 +1088,8 @@ def test_manifest_lookup_ambiguous_alias_requires_disambiguation(monkeypatch, tm
         (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
 
     class _Runner:
-        def invoke(self, _args):
+        def invoke(self, args):
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -871,7 +1135,8 @@ def test_manifest_lookup_supports_alias_disambiguation_selectors(monkeypatch, tm
         (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
 
     class _Runner:
-        def invoke(self, _args):
+        def invoke(self, args):
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -922,7 +1187,8 @@ def test_manifest_lookup_reuses_manifest_index_for_repeated_queries(
         (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
 
     class _Runner:
-        def invoke(self, _args):
+        def invoke(self, args):
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     original_loader = dbt_module._load_manifest_index
@@ -952,7 +1218,7 @@ def test_manifest_lookup_reuses_manifest_index_for_repeated_queries(
     assert load_calls == 2
 
 
-def test_manifest_index_is_rebuilt_when_cached_clone_dir_is_missing(
+def test_manifest_index_is_rebuilt_without_recloning_when_variant_is_missing(
     monkeypatch, tmp_path
 ):
     _reset_dbt_caches()
@@ -981,7 +1247,8 @@ def test_manifest_index_is_rebuilt_when_cached_clone_dir_is_missing(
         (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
 
     class _Runner:
-        def invoke(self, _args):
+        def invoke(self, args):
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -1003,8 +1270,8 @@ def test_manifest_index_is_rebuilt_when_cached_clone_dir_is_missing(
     shutil.rmtree(cached_clone_dir)
 
     second = connector.get_compiled_query("metrics_model")
-    assert second == "select 'second' as version"
-    assert clone_calls == 2
+    assert second == "select 'first' as version"
+    assert clone_calls == 1
 
 
 def test_manifest_index_single_flight_deduplicates_parallel_reads_on_warm_cache(
@@ -1029,7 +1296,8 @@ def test_manifest_index_single_flight_deduplicates_parallel_reads_on_warm_cache(
         (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
 
     class _Runner:
-        def invoke(self, _args):
+        def invoke(self, args):
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -1140,7 +1408,8 @@ def test_manifest_lookup_returns_none_when_compiled_file_is_missing(
         (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
 
     class _Runner:
-        def invoke(self, _args):
+        def invoke(self, args):
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -1528,6 +1797,9 @@ def test_parallel_model_fetches_with_low_cache_do_not_delete_active_manifest(
         profiles_dir=None,
         profile_name=None,
     )
+    us_compiled_dir = dbt_module._resolve_managed_compile_dir(
+        us_clone_dir, target, {"country": "US"}
+    )
 
     def _write_compiled_artifacts(clone_dir):
         (clone_dir / "target").mkdir(parents=True, exist_ok=True)
@@ -1547,7 +1819,8 @@ def test_parallel_model_fetches_with_low_cache_do_not_delete_active_manifest(
         _write_compiled_artifacts(clone_dir)
 
     class _Runner:
-        def invoke(self, _args):
+        def invoke(self, args):
+            _copy_seeded_target_to_invocation(args)
             return SimpleNamespace(success=True)
 
     monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
@@ -1555,7 +1828,7 @@ def test_parallel_model_fetches_with_low_cache_do_not_delete_active_manifest(
 
     first_about_to_open = threading.Event()
     allow_first_open = threading.Event()
-    us_manifest_path = (us_clone_dir / "target" / "manifest.json").resolve()
+    us_manifest_path = (us_compiled_dir / "target" / "manifest.json").resolve()
     real_open = builtins.open
 
     def _open_proxy(file, *args, **kwargs):
@@ -1662,7 +1935,7 @@ def test_in_use_cache_entry_is_not_evicted_or_recompiled_for_same_key(
         assert us_path in cached_paths
         assert in_use_count > 0
 
-    assert clone_counts[str(us_path)] == 1
+    assert clone_counts[str(dbt_module._source_clone_dir(us_path))] == 1
 
 
 def test_get_compiled_project_prunes_old_entries(monkeypatch, tmp_path):
@@ -1699,6 +1972,37 @@ def test_get_compiled_project_prunes_old_entries(monkeypatch, tmp_path):
     assert not paths[0].exists()
     assert paths[1].exists()
     assert paths[2].exists()
+
+
+def test_cache_prunes_unreferenced_shared_workspaces(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    monkeypatch.setenv("SLIDEFLOW_DBT_CACHE_MAX_ENTRIES", "1")
+
+    def _fake_clone(_url, clone_dir, _branch):
+        clone_dir.mkdir(parents=True, exist_ok=True)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    paths = []
+    for package in ("repo-a", "repo-b"):
+        paths.append(
+            dbt_module._get_compiled_project(
+                package_url=f"https://github.com/org/{package}.git",
+                project_dir=str(tmp_path / "workspace"),
+                branch="main",
+                target="prod",
+                vars={"country": "US"},
+            )
+        )
+
+    assert len(dbt_module._compiled_projects_cache) == 1
+    assert len(dbt_module._prepared_workspaces_cache) == 1
+    assert not dbt_module._source_clone_dir(paths[0]).exists()
+    assert dbt_module._source_clone_dir(paths[1]).exists()
 
 
 def test_clone_repo_refuses_to_delete_unmanaged_existing_path(tmp_path):

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -1184,7 +1184,7 @@ def test_pending_workspace_cleanup_restarts_after_releasing_prepared_lease(
     monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
     monkeypatch.setattr(dbt_module, "_get_prepared_workspace", _inject_pending_cleanup)
     result: list[Path] = []
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def _worker():
         try:
@@ -1197,7 +1197,7 @@ def test_pending_workspace_cleanup_restarts_after_releasing_prepared_lease(
                     vars=None,
                 )
             )
-        except BaseException as error:  # pragma: no cover - assertion helper
+        except Exception as error:  # pragma: no cover - assertion helper
             errors.append(error)
 
     worker = threading.Thread(target=_worker)
@@ -1209,6 +1209,9 @@ def test_pending_workspace_cleanup_restarts_after_releasing_prepared_lease(
     assert len(result) == 1
     assert result[0].is_dir()
     assert dbt_module._prepared_workspaces_in_use == {}
+    assert dbt_module._compilation_inflight == {}
+    assert dbt_module._pending_workspace_cleanup_dirs == set()
+    assert dbt_module._pending_cleanup_dirs == set()
 
 
 @pytest.mark.parametrize("marker_payload", [[], "invalid", 7, None])
@@ -1441,13 +1444,13 @@ def test_workspace_failure_cleanup_finishes_before_retry_waiter_recreates_path(
         "target": "prod",
         "vars": None,
     }
-    first_errors: list[BaseException] = []
+    first_errors: list[Exception] = []
     retry_results: list[Path] = []
 
     def _first():
         try:
             dbt_module._get_compiled_project(**kwargs)
-        except BaseException as error:  # pragma: no cover - assertion helper
+        except Exception as error:  # pragma: no cover - assertion helper
             first_errors.append(error)
 
     def _retry():
@@ -1472,6 +1475,10 @@ def test_workspace_failure_cleanup_finishes_before_retry_waiter_recreates_path(
     assert clone_calls == 2
     assert len(retry_results) == 1
     assert retry_results[0].is_dir()
+    assert dbt_module._workspace_preparation_inflight == {}
+    assert dbt_module._compilation_inflight == {}
+    assert dbt_module._prepared_workspaces_in_use == {}
+    assert dbt_module._pending_workspace_cleanup_dirs == set()
 
 
 def test_compile_failure_cleanup_finishes_before_retry_waiter_reuses_variant(
@@ -1515,13 +1522,13 @@ def test_compile_failure_cleanup_finishes_before_retry_waiter_reuses_variant(
         "target": "prod",
         "vars": None,
     }
-    first_errors: list[BaseException] = []
+    first_errors: list[Exception] = []
     retry_results: list[Path] = []
 
     def _first():
         try:
             dbt_module._get_compiled_project(**kwargs)
-        except BaseException as error:  # pragma: no cover - assertion helper
+        except Exception as error:  # pragma: no cover - assertion helper
             first_errors.append(error)
 
     def _retry():
@@ -1546,6 +1553,9 @@ def test_compile_failure_cleanup_finishes_before_retry_waiter_reuses_variant(
     assert compile_calls == 2
     assert len(retry_results) == 1
     assert retry_results[0].is_dir()
+    assert dbt_module._compilation_inflight == {}
+    assert dbt_module._prepared_workspaces_in_use == {}
+    assert dbt_module._pending_cleanup_dirs == set()
 
 
 def test_compile_stops_when_existing_variant_cannot_be_removed(monkeypatch, tmp_path):

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -2496,6 +2496,13 @@ def test_manifest_lookup_prefers_target_invariant_name_over_compiled_alias(
     assert model.alias == "dev_cesar_metrics"
     assert model.sql_text == "select 1 as answer"
 
+    fallback = connector.get_compiled_model_info(
+        "prod_cesar_metrics", model_selector_name="metrics"
+    )
+
+    assert fallback is not None
+    assert fallback.unique_id == "model.analytics.metrics"
+
 
 def test_manifest_lookup_supports_alias_disambiguation_selectors(monkeypatch, tmp_path):
     _reset_dbt_caches()
@@ -2518,6 +2525,13 @@ def test_manifest_lookup_supports_alias_disambiguation_selectors(monkeypatch, tm
                     "resource_type": "model",
                     "alias": "metrics_model",
                     "package_name": "pkg_b",
+                    "name": "metrics_eu",
+                    "compiled_path": "target/eu.sql",
+                },
+                "model.dep.metrics_eu": {
+                    "resource_type": "model",
+                    "alias": "dependency_metrics",
+                    "package_name": "dep",
                     "name": "metrics_eu",
                     "compiled_path": "target/eu.sql",
                 },
@@ -2555,6 +2569,13 @@ def test_manifest_lookup_supports_alias_disambiguation_selectors(monkeypatch, tm
         "metrics_model", model_selector_name="metrics_eu"
     )
     assert by_model_name == "select 'EU' as country"
+
+    by_package_and_model_name = connector.get_compiled_query(
+        "metrics_model",
+        model_package_name="pkg_b",
+        model_selector_name="metrics_eu",
+    )
+    assert by_package_and_model_name == "select 'EU' as country"
 
 
 def test_manifest_lookup_reuses_manifest_index_for_repeated_queries(

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -178,7 +178,9 @@ def test_prepare_models_batches_exact_sorted_selectors(monkeypatch, tmp_path):
     assert [args[0] for args in invocations] == ["deps", "parse", "compile"]
     compile_args = invocations[-1]
     assert compile_args[compile_args.index("--select") + 1] == (
-        "fqn:analytics.analysis.reporting.model_b fqn:analytics.staging.model_a"
+        "package:analytics,resource_type:analysis,"
+        "fqn:analytics.analysis.reporting.model_b "
+        "package:analytics,resource_type:model,fqn:analytics.staging.model_a"
     )
 
     assert connector.get_compiled_query("alias_model_a") == "select 'model_a'"
@@ -196,6 +198,82 @@ def test_exact_selector_falls_back_when_manifest_fqn_is_missing():
     )
 
     assert dbt_module._exact_selector(node) == "analytics.metrics"
+
+
+def test_exact_selector_intersects_package_for_versioned_nodes():
+    node = dbt_module._ManifestNodeIndexEntry(
+        unique_id="model.analytics.orders.v1",
+        alias="orders_v1",
+        package_name="analytics",
+        model_name="orders",
+        compiled_path=None,
+        fqn=("analytics", "orders", "v1"),
+        resource_type="model",
+    )
+
+    assert dbt_module._exact_selector(node) == (
+        "package:analytics,resource_type:model,fqn:analytics.orders.v1"
+    )
+
+
+@pytest.mark.parametrize(
+    "unsafe_component",
+    ["orders+", "orders*", "orders,other", "orders other", "orders?"],
+)
+def test_exact_selector_falls_back_for_selector_metacharacters(unsafe_component):
+    node = dbt_module._ManifestNodeIndexEntry(
+        unique_id=f"model.analytics.{unsafe_component}",
+        alias="orders",
+        package_name="analytics",
+        model_name=unsafe_component,
+        compiled_path=None,
+        fqn=("analytics", unsafe_component),
+        resource_type="model",
+    )
+
+    assert dbt_module._exact_selector(node) is None
+
+
+def test_unsafe_manifest_fqn_uses_full_compile_without_select(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    invocations = []
+
+    def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
+        (clone_dir / "target").mkdir(parents=True, exist_ok=True)
+        (clone_dir / "target" / "orders.sql").write_text("select 1")
+        manifest = {
+            "nodes": {
+                "model.analytics.orders": {
+                    "resource_type": "model",
+                    "alias": "orders",
+                    "package_name": "analytics",
+                    "name": "orders",
+                    "fqn": ["analytics", "orders+"],
+                    "compiled_path": "target/orders.sql",
+                }
+            }
+        }
+        (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    class _Runner:
+        def invoke(self, args):
+            invocations.append(list(args))
+            _copy_seeded_target_to_invocation(args)
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    connector = dbt_module.DBTManifestConnector(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(tmp_path / "workspace"),
+        target="prod",
+    )
+
+    connector.prepare_models([("orders", None, None, None)])
+
+    compile_args = next(args for args in invocations if args[0] == "compile")
+    assert "--select" not in compile_args
 
 
 @pytest.mark.integration
@@ -836,7 +914,7 @@ def test_get_compiled_project_rejects_symlinked_artifact_paths(
             vars={"country": "US"},
         )
 
-    assert [args[0] for args in invocations] == ["deps"]
+    assert invocations == []
     assert sentinel.read_text() == "preserve"
 
 
@@ -1499,6 +1577,108 @@ def test_cleanup_failure_keeps_reservation_until_retry_succeeds(monkeypatch, tmp
     assert compiled_dir not in dbt_module._pending_cleanup_dirs
     assert compiled_dir not in dbt_module._cleanup_failures
     assert not compiled_dir.exists()
+
+
+def test_cleanup_lock_failure_releases_in_progress_reservation(monkeypatch, tmp_path):
+    _reset_dbt_caches()
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(tmp_path / "workspace"), "https://github.com/org/repo.git", "main"
+    )
+    compiled_dir = dbt_module._resolve_managed_compile_dir(clone_dir, "prod", None)
+    compiled_dir.mkdir(parents=True)
+
+    @dbt_module.contextmanager
+    def _failing_lock(_clone_dir):
+        raise DataSourceError("lock acquisition failed")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(dbt_module, "_workspace_process_lock", _failing_lock)
+    with dbt_module._cache_lock:
+        dbt_module._pending_cleanup_dirs.add(compiled_dir)
+
+    with pytest.raises(DataSourceError, match="lock acquisition failed"):
+        dbt_module._cleanup_ready_managed_dirs()
+
+    assert compiled_dir in dbt_module._pending_cleanup_dirs
+    assert compiled_dir not in dbt_module._cleanup_in_progress_dirs
+    assert compiled_dir in dbt_module._cleanup_failures
+
+
+def test_variant_waiter_propagates_parent_workspace_cleanup_failure(tmp_path):
+    _reset_dbt_caches()
+    clone_dir = dbt_module._resolve_managed_clone_dir(
+        str(tmp_path / "workspace"), "https://github.com/org/repo.git", "main"
+    )
+    compiled_dir = dbt_module._resolve_managed_compile_dir(clone_dir, "prod", None)
+    with dbt_module._cache_lock:
+        dbt_module._pending_cleanup_dirs.add(compiled_dir)
+        dbt_module._pending_workspace_cleanup_dirs.add(clone_dir)
+        dbt_module._cleanup_failures[clone_dir] = "parent cleanup failed"
+
+    with pytest.raises(DataSourceError, match="parent cleanup failed"):
+        dbt_module._wait_for_managed_cleanup(compiled_dir, workspace=False)
+
+
+def test_pre_owner_cleanup_wait_failure_releases_compilation_owner(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    real_wait = dbt_module._wait_for_managed_cleanup
+
+    def _failing_variant_wait(directory, *, workspace):
+        if not workspace:
+            raise DataSourceError("cleanup wait failed before owner body")
+        return real_wait(directory, workspace=workspace)
+
+    monkeypatch.setattr(dbt_module, "_wait_for_managed_cleanup", _failing_variant_wait)
+
+    with pytest.raises(DataSourceError, match="cleanup wait failed"):
+        dbt_module._get_compiled_project(
+            package_url="https://github.com/org/repo.git",
+            project_dir=str(tmp_path / "workspace"),
+            branch="main",
+            target="prod",
+            vars=None,
+        )
+
+    assert dbt_module._compilation_inflight == {}
+
+
+def test_cold_process_workspace_refresh_removes_all_old_variant_siblings(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+    clone_calls = 0
+
+    def _fake_clone(_url, clone_dir, _branch):
+        nonlocal clone_calls
+        clone_calls += 1
+        _write_fake_dbt_project(clone_dir)
+
+    class _Runner:
+        def invoke(self, _args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    kwargs = {
+        "package_url": "https://github.com/org/repo.git",
+        "project_dir": str(tmp_path / "workspace"),
+        "branch": "main",
+        "target": "prod",
+    }
+
+    us_dir = dbt_module._get_compiled_project(**kwargs, vars={"country": "US"})
+    ca_dir = dbt_module._get_compiled_project(**kwargs, vars={"country": "CA"})
+    assert us_dir.exists() and ca_dir.exists()
+
+    _reset_dbt_caches()
+    uk_dir = dbt_module._get_compiled_project(**kwargs, vars={"country": "UK"})
+
+    assert clone_calls == 2
+    assert uk_dir.exists()
+    assert not us_dir.exists()
+    assert not ca_dir.exists()
 
 
 def test_workspace_failure_cleanup_finishes_before_retry_waiter_recreates_path(
@@ -2270,8 +2450,51 @@ def test_manifest_lookup_ambiguous_alias_requires_disambiguation(monkeypatch, tm
         vars={"country": "US"},
     )
 
-    with pytest.raises(DataSourceError, match="Ambiguous dbt model alias"):
+    with pytest.raises(DataSourceError, match="Ambiguous dbt model identifier"):
         connector.get_compiled_query("metrics_model")
+
+
+def test_manifest_lookup_prefers_target_invariant_name_over_compiled_alias(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+
+    def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
+        (clone_dir / "target").mkdir(parents=True, exist_ok=True)
+        (clone_dir / "target" / "metrics.sql").write_text("select 1 as answer")
+        manifest = {
+            "nodes": {
+                "model.analytics.metrics": {
+                    "resource_type": "model",
+                    "alias": "dev_cesar_metrics",
+                    "package_name": "analytics",
+                    "name": "metrics",
+                    "compiled_path": "target/metrics.sql",
+                }
+            }
+        }
+        (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    class _Runner:
+        def invoke(self, args):
+            _copy_seeded_target_to_invocation(args)
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    connector = dbt_module.DBTManifestConnector(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(tmp_path / "workspace"),
+        target="dev",
+    )
+
+    model = connector.get_compiled_model_info("metrics")
+
+    assert model is not None
+    assert model.unique_id == "model.analytics.metrics"
+    assert model.alias == "dev_cesar_metrics"
+    assert model.sql_text == "select 1 as answer"
 
 
 def test_manifest_lookup_supports_alias_disambiguation_selectors(monkeypatch, tmp_path):

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -1,0 +1,236 @@
+import datetime as dt
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT_SCRIPT = ROOT / "scripts" / "ci" / "run_dependency_audit.py"
+
+
+def _load_audit_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "slideflow_dependency_audit", AUDIT_SCRIPT
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_policy(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        ["not-an-object"],
+        [{"package": "sqlparse", "vulnerability": "CVE-1", "expires": "2027-01-01"}],
+        [
+            {
+                "package": "sqlparse",
+                "vulnerability": "CVE-1",
+                "reason": "temporary exception",
+                "expires": "not-a-date",
+            }
+        ],
+    ],
+)
+def test_dependency_audit_rejects_malformed_policy(tmp_path, payload):
+    module = _load_audit_module()
+    policy_path = tmp_path / "policy.json"
+    _write_policy(policy_path, payload)
+
+    with pytest.raises(SystemExit, match="dependency audit exception"):
+        module._load_policy(policy_path, today=dt.date(2026, 8, 19))
+
+
+def test_dependency_audit_rejects_expired_policy(tmp_path):
+    module = _load_audit_module()
+    policy_path = tmp_path / "policy.json"
+    _write_policy(
+        policy_path,
+        [
+            {
+                "package": "sqlparse",
+                "vulnerability": "CVE-1",
+                "reason": "temporary exception",
+                "expires": "2026-08-18",
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="expired for sqlparse CVE-1"):
+        module._load_policy(policy_path, today=dt.date(2026, 8, 19))
+
+
+def test_dependency_audit_scopes_suppression_to_package_and_keeps_findings_visible(
+    tmp_path, monkeypatch
+):
+    module = _load_audit_module()
+    policy_path = tmp_path / "policy.json"
+    output_path = tmp_path / "audit.json"
+    _write_policy(
+        policy_path,
+        [
+            {
+                "package": "SQLParse",
+                "vulnerability": "CVE-1",
+                "reason": "blocked by dbt-core",
+                "expires": "2026-11-18",
+            }
+        ],
+    )
+    raw_audit = {
+        "dependencies": [
+            {
+                "name": "sqlparse",
+                "version": "0.5.4",
+                "vulns": [
+                    {
+                        "id": "PYSEC-1",
+                        "aliases": ["CVE-1"],
+                        "fix_versions": ["0.6.0"],
+                    }
+                ],
+            },
+            {
+                "name": "unrelated-package",
+                "version": "1.0",
+                "vulns": [
+                    {
+                        "id": "CVE-1",
+                        "aliases": [],
+                        "fix_versions": ["2.0"],
+                    }
+                ],
+            },
+        ],
+        "fixes": [],
+    }
+    captured_command = []
+
+    def _fake_run(command, check):
+        assert check is False
+        captured_command.extend(command)
+        raw_output = Path(command[command.index("--output") + 1])
+        raw_output.write_text(json.dumps(raw_audit), encoding="utf-8")
+        return SimpleNamespace(returncode=1)
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    returncode = module.main(
+        ["--format=json", "--output", str(output_path), "--progress-spinner", "off"],
+        policy_path=policy_path,
+        today=dt.date(2026, 8, 19),
+    )
+
+    artifact = json.loads(output_path.read_text(encoding="utf-8"))
+    suppressed = artifact["dependencies"][0]["vulns"][0]
+    active = artifact["dependencies"][1]["vulns"][0]
+    assert returncode == 1
+    assert "--ignore-vuln" not in captured_command
+    assert suppressed["status"] == "suppressed"
+    assert suppressed["suppression"] == {
+        "package": "SQLParse",
+        "vulnerability": "CVE-1",
+        "reason": "blocked by dbt-core",
+        "expires": "2026-11-18",
+    }
+    assert active["status"] == "active"
+    assert "suppression" not in active
+    assert artifact["summary"] == {
+        "active_vulnerabilities": 1,
+        "suppressed_vulnerabilities": 1,
+    }
+
+
+def test_dependency_audit_succeeds_when_every_finding_is_suppressed(
+    tmp_path, monkeypatch
+):
+    module = _load_audit_module()
+    policy_path = tmp_path / "policy.json"
+    _write_policy(
+        policy_path,
+        [
+            {
+                "package": "sqlparse",
+                "vulnerability": "CVE-1",
+                "reason": "blocked by dbt-core",
+                "expires": "2026-11-18",
+            }
+        ],
+    )
+
+    def _fake_run(command, check):
+        assert check is False
+        raw_output = Path(command[command.index("--output") + 1])
+        raw_output.write_text(
+            json.dumps(
+                {
+                    "dependencies": [
+                        {
+                            "name": "sqlparse",
+                            "version": "0.5.4",
+                            "vulns": [
+                                {"id": "CVE-1", "aliases": [], "fix_versions": []}
+                            ],
+                        }
+                    ],
+                    "fixes": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=1)
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    returncode = module.main(
+        ["--progress-spinner", "off"],
+        policy_path=policy_path,
+        today=dt.date(2026, 8, 19),
+    )
+
+    assert returncode == 0
+
+
+def test_dependency_audit_propagates_operational_failure_without_output(
+    tmp_path, monkeypatch
+):
+    module = _load_audit_module()
+    policy_path = tmp_path / "policy.json"
+    _write_policy(policy_path, [])
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda _command, check: SimpleNamespace(returncode=2),
+    )
+
+    returncode = module.main([], policy_path=policy_path, today=dt.date(2026, 8, 19))
+
+    assert returncode == 2
+
+
+def test_dependency_audit_rejects_invalid_audit_json(tmp_path, monkeypatch):
+    module = _load_audit_module()
+    policy_path = tmp_path / "policy.json"
+    _write_policy(policy_path, [])
+
+    def _fake_run(command, check):
+        assert check is False
+        raw_output = Path(command[command.index("--output") + 1])
+        raw_output.write_text("not-json", encoding="utf-8")
+        return SimpleNamespace(returncode=1)
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    with pytest.raises(SystemExit, match="pip-audit produced invalid JSON"):
+        module.main([], policy_path=policy_path, today=dt.date(2026, 8, 19))

--- a/uv.lock
+++ b/uv.lock
@@ -2626,15 +2626,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -3208,7 +3208,7 @@ requires-dist = [
     { name = "dbt-duckdb", marker = "extra == 'duckdb'", specifier = ">=1.9,<1.12" },
     { name = "dbt-redshift", marker = "extra == 'redshift'", specifier = ">=1.10,<1.12" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1.5.3,<2.0" },
-    { name = "filelock", marker = "extra == 'dbt'", specifier = ">=3.20,<4.0" },
+    { name = "filelock", marker = "extra == 'dbt'", specifier = ">=3.20.1,<4.0" },
     { name = "gitpython", marker = "extra == 'dbt'", specifier = ">=3.1.58,<4.0" },
     { name = "google-api-python-client", specifier = ">=2.198.0,<3.0" },
     { name = "google-auth", specifier = ">=2.0,<3.0" },
@@ -3233,7 +3233,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.0,<3.0" },
-    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0.1" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "python-pptx", marker = "extra == 'powerpoint'", specifier = ">=1.0.0,<2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3162,6 +3162,7 @@ databricks = [
 dbt = [
     { name = "dbt-core" },
     { name = "dbt-databricks" },
+    { name = "filelock" },
     { name = "gitpython" },
 ]
 dev = [
@@ -3207,6 +3208,7 @@ requires-dist = [
     { name = "dbt-duckdb", marker = "extra == 'duckdb'", specifier = ">=1.9,<1.12" },
     { name = "dbt-redshift", marker = "extra == 'redshift'", specifier = ">=1.10,<1.12" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1.5.3,<2.0" },
+    { name = "filelock", marker = "extra == 'dbt'", specifier = ">=3.20,<4.0" },
     { name = "gitpython", marker = "extra == 'dbt'", specifier = ">=3.1.58,<4.0" },
     { name = "google-api-python-client", specifier = ">=2.198.0,<3.0" },
     { name = "google-auth", specifier = ">=2.0,<3.0" },


### PR DESCRIPTION
## Summary

- split dbt caching into a shared clone/dependency workspace and isolated compile variants
- reuse one clone and `dbt deps` run across sources that differ only by `target` or `vars`
- preserve the batched exact-selector workflow from #300 so each unique variant parses once and compiles one sorted, deduplicated model batch
- select nodes with dbt's manifest-provided `fqn`, including analyses and models in nested directories
- store manifests, compiled SQL, and compile logs outside the cloned dbt project under `project_dir/.slideflow_dbt_targets/<workspace-key>/<variant-key>`
- harden single-flight concurrency, lease-safe LRU cleanup, manifest invalidation, failure isolation, and managed-path handling
- document the cache identity, filesystem layout, tuning, and troubleshooting behavior

## Why

The previous cache key included `vars`, so each variable combination cloned the same repository again, reran `dbt deps`, and compiled into a separate full clone. Reusing a clone without isolating dbt output is unsafe because later compiles overwrite the same `target/` artifacts.

The first implementation isolated variants beneath the cloned project. Projects with broad paths such as `model-paths: ['.']` could then parse generated `target/compiled/**/*.sql` from a prior variant as source models. It also normalized optional branch/profile values differently between the in-memory cache and physical clone key, and could accept a deterministic variant path redirected through a symlink.

This revision moves generated artifacts to a sibling workspace tree, uses one tagged normalized identity for both cache and disk keys, and validates managed paths before creation, after creation, on cache hits, and immediately before dbt invocation. Symlinks, non-directory collisions, escaped paths, and failed cleanup now stop compilation without following or deleting external targets.

Scoped compilation now uses each node's manifest `fqn` instead of assuming every node is selectable as `package.name`. This covers dbt analyses, whose FQN includes an `analysis` segment, and models stored in nested directories.

## Review follow-up

- variant target and log roots are outside the parsed dbt project
- absent optional identity values cannot collide with literal values such as `"default"`
- variant paths fail closed when a namespace, workspace, or child is a symlink
- clone eviction invalidates and removes sibling artifact state without following redirected paths
- the dbt-duckdb regression fixture now compiles two vars variants with `model-paths: ['.']`
- exact selectors retain dbt's manifest FQN, with a backward-compatible package/name fallback for synthetic or older manifests

## Base

#300 has merged. This branch is based on the current `master` line and contains the follow-on optimization plus review-hardening commits.

## Validation

- focused dbt suite: 82 passed
- full suite: 609 passed, 3 live Google tests skipped
- real dbt-duckdb regression covers a nested model and an analysis in one scoped compile batch
- Ruff check and format check, mypy, and `git diff --check` passed

Closes #299
Closes #304

## Consolidated stable-identity fix

PR #303's target-invariant dbt model resolution is consolidated into commit 017ecb1. Manifest node names are preferred, compiled aliases remain supported for compatibility, and ambiguous name/alias collisions fail closed with explicit disambiguation.

Closes #302