### PR TITLE
Fix dbt model resolution for target-dependent aliases

### DIFF
--- a/.github/skills/slideflow-yaml-authoring/assets/snippets/connectors.yml
+++ b/.github/skills/slideflow-yaml-authoring/assets/snippets/connectors.yml
@@ -26,7 +26,8 @@ redshift_sql:
 dbt_preferred:
   type: "dbt"
   name: "dbt_model"
-  model_alias: "slide__revenue_model"
+  # Historical field name; prefer the stable dbt node.name here.
+  model_alias: "revenue_model"
   dbt:
     package_url: "https://$DBT_GIT_TOKEN@github.com/org/dbt-project.git"
     project_dir: "/tmp/dbt_project"
@@ -40,7 +41,7 @@ dbt_preferred:
 dbt_redshift:
   type: "dbt"
   name: "dbt_model_redshift"
-  model_alias: "slide__revenue_model"
+  model_alias: "revenue_model"
   dbt:
     package_url: "https://$DBT_GIT_TOKEN@github.com/org/dbt-project.git"
     project_dir: "/tmp/dbt_project"
@@ -55,7 +56,7 @@ dbt_redshift:
 databricks_dbt_legacy:
   type: "databricks_dbt"
   name: "dbt_model_legacy"
-  model_alias: "slide__revenue_model"
+  model_alias: "revenue_model"
   package_url: "https://$DBT_GIT_TOKEN@github.com/org/dbt-project.git"
   project_dir: "/tmp/dbt_project"
   branch: "main"

--- a/.github/skills/slideflow-yaml-authoring/references/config-schema-cheatsheet.md
+++ b/.github/skills/slideflow-yaml-authoring/references/config-schema-cheatsheet.md
@@ -113,7 +113,8 @@ registry: []
 data_source:
   type: dbt
   name: dbt_model
-  model_alias: slide__example_model
+  # Historical field name; prefer the stable dbt node.name here.
+  model_alias: example_model
   dbt:
     package_url: https://$DBT_GIT_TOKEN@github.com/org/repo.git
     project_dir: /tmp/dbt_project
@@ -131,7 +132,8 @@ Preferred Redshift warehouse variant:
 data_source:
   type: dbt
   name: dbt_model_redshift
-  model_alias: slide__example_model
+  # Exact compiled aliases are also accepted for legacy configs.
+  model_alias: example_model
   dbt:
     package_url: https://$DBT_GIT_TOKEN@github.com/org/repo.git
     project_dir: /tmp/dbt_project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- dbt-backed slide and workbook configs now resolve models by stable manifest
+  node name before falling back to legacy compiled aliases, so target-dependent
+  alias macros no longer break model lookup. Name/alias collisions fail closed
+  with explicit selector guidance instead of silently changing the selected SQL.
 - Data-source cache reads now return isolated `DataFrame` copies, table
   formatting avoids mutating shared source frames, and cache `clear()`/`disable()`
   wake in-flight waiters without allowing stale loads to refill the cache.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -491,7 +491,7 @@ warehouse:
 ```
 
 `dbt.compile: true` clones the repository, runs `dbt deps`, parses the project,
-resolves requested aliases to exact dbt nodes, and compiles the required nodes
+resolves requested identifiers to exact dbt nodes, and compiles the required nodes
 with one bounded `dbt compile --select` invocation per project batch. dbt still
 parses the full project; scoped compilation does not build or refresh upstream
 relations and does not add ancestor `+` selectors. Set `dbt.compile: false` only
@@ -500,7 +500,13 @@ points at a compiled dbt project with `target/manifest.json` and the compiled
 SQL files referenced by that manifest; SlideFlow will not clone or invoke dbt in
 that mode.
 
-Optional alias disambiguation fields for `dbt`:
+`model_alias` keeps its historical field name for configuration compatibility.
+Prefer setting it to the target-invariant dbt `node.name`; exact compiled aliases
+remain supported for existing configs. If the identifier matches one node by name
+and another by alias, SlideFlow fails closed instead of silently executing a
+different model.
+
+Optional model disambiguation fields for `dbt`:
 
 - `model_unique_id` (most specific)
 - `model_package_name`

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -261,11 +261,17 @@ Behavior highlights:
 - Clone/dependency/parse work for identical project identities is deduplicated.
   Compiled selector coverage expands as a sorted union, so cached supersets
   satisfy later subset requests without recompiling.
-- If multiple dbt nodes share `model_alias`, set one of:
+- `model_alias` retains its legacy field name, but a stable dbt `node.name` is
+  preferred so the same slide config works across targets whose
+  `generate_alias_name` macro produces different physical aliases. Existing
+  exact-alias configs remain supported.
+- If an identifier is ambiguous, including when it matches one node by stable
+  name and another by compiled alias, set one of:
   - `model_unique_id`
   - `model_package_name`
   - `model_selector_name`
-  to avoid ambiguity errors.
+  SlideFlow fails closed in this case rather than silently changing the model
+  used by an existing slide config.
 
 ## dbt on BigQuery (`dbt`)
 
@@ -422,7 +428,8 @@ Cache/compile tuning env vars:
 - Redshift auth/config errors: verify database, host/cluster/serverless endpoint,
   and either password auth or IAM region/identity settings.
 - dbt model not found: check `model_alias`, `branch`, and `target`.
-- dbt alias ambiguity: add `model_unique_id`, `model_package_name`, or `model_selector_name`.
+- dbt model identifier ambiguity: add `model_unique_id`,
+  `model_package_name`, or `model_selector_name`.
 - dbt Git clone fails: verify token variable in `package_url` and repo access.
 - dbt `compile:false` fails: ensure `project_dir/target/manifest.json` exists
   and every selected manifest node has a compiled SQL file on disk.

--- a/docs/dbt-migration.md
+++ b/docs/dbt-migration.md
@@ -128,7 +128,7 @@ Redshift execution (`warehouse.type: redshift`):
 
 ## Common Migration Errors
 
-- `Ambiguous dbt model alias ...`
+- `Ambiguous dbt model identifier ...`
   - Add `model_unique_id`, `model_package_name`, or `model_selector_name`.
 - `dbt compile failed: Path '/home/runner/.dbt' does not exist`
   - Set `dbt.profiles_dir` or ensure `profiles.yml` exists in dbt project root.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -106,8 +106,8 @@ Frequent CI symptom:
 
 Frequent dbt model-resolution symptom:
 
-- `Ambiguous dbt model alias '...'`
-- `No dbt model found for alias '...'` or a missing compiled artifact after a
+- `Ambiguous dbt model identifier '...'`
+- `No dbt model found for identifier '...'` or a missing compiled artifact after a
   selected compile
 
 Fixes:
@@ -117,13 +117,18 @@ Fixes:
 - if using `compile: false`, run `dbt deps` and `dbt compile` before SlideFlow,
   point `project_dir` at that compiled project, and ensure
   `target/manifest.json` references an existing compiled SQL file.
+- set `model_alias` to the stable dbt node name when target-specific macros
+  transform the compiled alias; the field name is retained for config
+  compatibility and legacy exact aliases remain supported.
 - use `model_unique_id`, `model_package_name`, or `model_selector_name` when an
-  alias is ambiguous; SlideFlow converts the resolved node to an exact selector.
+  identifier is ambiguous; SlideFlow converts the resolved node to an exact
+  selector. This also resolves the fail-closed case where the same identifier
+  matches one node by name and a different node by alias.
 
 For private dbt deps/repo access, ensure token env vars referenced by
 `package_url` or `env_var(...)` are present at runtime.
 
-If alias ambiguity occurs, add one of these selectors in your source config:
+If model identifier ambiguity occurs, add one of these selectors in your source config:
 
 - `model_unique_id` (most specific)
 - `model_package_name`

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -56,7 +56,7 @@ import shutil
 import threading
 import time
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Iterator, Literal, Optional, Sequence, Type
 
@@ -131,6 +131,7 @@ class _ManifestIndex:
 
     by_alias: dict[str, list[_ManifestNodeIndexEntry]]
     by_unique_id: dict[str, _ManifestNodeIndexEntry]
+    by_name: dict[str, list[_ManifestNodeIndexEntry]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -212,6 +213,7 @@ def _load_manifest_index(clone_dir: Path) -> _ManifestIndex:
         manifest = json.load(f)
 
     by_alias: dict[str, list[_ManifestNodeIndexEntry]] = {}
+    by_name: dict[str, list[_ManifestNodeIndexEntry]] = {}
     by_unique_id: dict[str, _ManifestNodeIndexEntry] = {}
 
     for unique_id, node in manifest.get("nodes", {}).items():
@@ -237,9 +239,15 @@ def _load_manifest_index(clone_dir: Path) -> _ManifestIndex:
         )
 
         by_alias.setdefault(entry.alias, []).append(entry)
+        if entry.model_name:
+            by_name.setdefault(entry.model_name, []).append(entry)
         by_unique_id[entry.unique_id] = entry
 
-    return _ManifestIndex(by_alias=by_alias, by_unique_id=by_unique_id)
+    return _ManifestIndex(
+        by_alias=by_alias,
+        by_unique_id=by_unique_id,
+        by_name=by_name,
+    )
 
 
 def _get_manifest_index(clone_dir: Path) -> _ManifestIndex:
@@ -295,7 +303,7 @@ def _format_manifest_candidate(entry: _ManifestNodeIndexEntry) -> str:
 def _format_selector_context(
     model_unique_id: Optional[str],
     model_package_name: Optional[str],
-    model_name: Optional[str],
+    model_selector_name: Optional[str],
 ) -> str:
     """Format optional selector fields for user-facing error messages."""
     selectors = []
@@ -303,8 +311,8 @@ def _format_selector_context(
         selectors.append(f"model_unique_id='{model_unique_id}'")
     if model_package_name:
         selectors.append(f"model_package_name='{model_package_name}'")
-    if model_name:
-        selectors.append(f"model_name='{model_name}'")
+    if model_selector_name:
+        selectors.append(f"model_selector_name='{model_selector_name}'")
     if not selectors:
         return ""
     return " with selectors " + ", ".join(selectors)
@@ -1087,27 +1095,58 @@ def _resolve_model_from_index(
     model_package_name: Optional[str] = None,
     model_selector_name: Optional[str] = None,
 ) -> Optional[_ManifestNodeIndexEntry]:
-    candidates = list(manifest_index.by_alias.get(model_name, []))
-    if not candidates:
-        return None
     selector_context = _format_selector_context(
         model_unique_id=model_unique_id,
         model_package_name=model_package_name,
-        model_name=model_selector_name,
+        model_selector_name=model_selector_name,
     )
+
     if model_unique_id:
         unique_candidate = manifest_index.by_unique_id.get(model_unique_id)
         if unique_candidate is None:
             raise DataSourceError(
-                f"No dbt node with unique_id '{model_unique_id}' for alias "
-                f"'{model_name}'."
-            )
-        if unique_candidate.alias != model_name:
-            raise DataSourceError(
-                f"unique_id '{model_unique_id}' resolved to alias "
-                f"'{unique_candidate.alias}', expected '{model_name}'."
+                f"No dbt node with unique_id '{model_unique_id}' for model "
+                f"identifier '{model_name}'."
             )
         candidates = [unique_candidate]
+    elif model_selector_name:
+        candidates = list(manifest_index.by_name.get(model_selector_name, []))
+    else:
+        name_candidates = list(manifest_index.by_name.get(model_name, []))
+        alias_candidates = list(manifest_index.by_alias.get(model_name, []))
+
+        if model_package_name:
+            name_candidates = [
+                candidate
+                for candidate in name_candidates
+                if candidate.package_name == model_package_name
+            ]
+            alias_candidates = [
+                candidate
+                for candidate in alias_candidates
+                if candidate.package_name == model_package_name
+            ]
+
+        name_ids = {candidate.unique_id for candidate in name_candidates}
+        alias_ids = {candidate.unique_id for candidate in alias_candidates}
+        if name_ids and alias_ids and name_ids != alias_ids:
+            combined = {
+                candidate.unique_id: candidate
+                for candidate in name_candidates + alias_candidates
+            }
+            rendered_candidates = ", ".join(
+                _format_manifest_candidate(candidate) for candidate in combined.values()
+            )
+            raise DataSourceError(
+                f"dbt model identifier '{model_name}' matches different nodes by "
+                "stable name and compiled alias. Provide one of "
+                "`model_unique_id`, `model_package_name`, or "
+                "`model_selector_name` to select the intended node. "
+                f"Candidates: {rendered_candidates}"
+            )
+
+        candidates = name_candidates or alias_candidates
+
     if model_package_name:
         candidates = [
             candidate
@@ -1121,15 +1160,17 @@ def _resolve_model_from_index(
             if candidate.model_name == model_selector_name
         ]
     if not candidates:
+        if not selector_context:
+            return None
         raise DataSourceError(
-            f"No dbt model found for alias '{model_name}'{selector_context}."
+            f"No dbt model found for identifier '{model_name}'{selector_context}."
         )
     if len(candidates) > 1:
         rendered_candidates = ", ".join(
             _format_manifest_candidate(candidate) for candidate in candidates
         )
         raise DataSourceError(
-            f"Ambiguous dbt model alias '{model_name}'. Provide one of "
+            f"Ambiguous dbt model identifier '{model_name}'. Provide one of "
             "`model_unique_id`, `model_package_name`, or `model_selector_name` "
             f"to disambiguate. Candidates: {rendered_candidates}"
         )
@@ -1229,7 +1270,9 @@ class DBTManifestConnector(BaseModel, DataConnector):
                     model_selector_name=selector_name,
                 )
                 if selection is None:
-                    raise DataSourceError(f"No dbt model found for alias '{alias}'.")
+                    raise DataSourceError(
+                        f"No dbt model found for identifier '{alias}'."
+                    )
                 selections.append(selection)
             selectors = tuple(_exact_selector(selection) for selection in selections)
             _ensure_selected_compilation(
@@ -1266,7 +1309,7 @@ class DBTManifestConnector(BaseModel, DataConnector):
         model_package_name: Optional[str] = None,
         model_selector_name: Optional[str] = None,
     ) -> Optional[str]:
-        """Extract compiled SQL query for a specific DBT model alias."""
+        """Extract compiled SQL for a dbt node name or legacy compiled alias."""
         model_info = self.get_compiled_model_info(
             model_name,
             model_unique_id=model_unique_id,
@@ -1462,7 +1505,7 @@ class DBTDatabricksConnector(_DBTWarehouseConnectorBase):
     3. Return results as a pandas DataFrame
 
     Attributes:
-        model_alias: The alias of the DBT model to execute.
+        model_alias: Stable dbt node name or legacy compiled alias to execute.
         package_url: Git URL of the DBT project repository.
         project_dir: Local directory path for cloning the project.
         profile_name: Optional dbt profile name to override project default.
@@ -1662,7 +1705,7 @@ class DBTDatabricksSourceConfig(BaseSourceConfig):
 
     Attributes:
         type: Always "databricks_dbt" for DBT-Databricks data sources.
-        model_alias: The alias of the DBT model to execute.
+        model_alias: Stable dbt node name or legacy compiled alias to execute.
         package_url: Git URL of the DBT project repository.
         project_dir: Local directory path for cloning the project.
         profile_name: Optional dbt profile name to override project default.
@@ -1715,7 +1758,10 @@ class DBTDatabricksSourceConfig(BaseSourceConfig):
     type: Literal["databricks_dbt"] = Field(
         "databricks_dbt", description="dbt + Databricks data source"
     )
-    model_alias: str = Field(..., description="dbt model alias")
+    model_alias: str = Field(
+        ...,
+        description="dbt node name (preferred) or legacy compiled alias",
+    )
     model_unique_id: Optional[str] = Field(
         None, description="Optional dbt unique_id selector for alias disambiguation"
     )
@@ -1933,7 +1979,10 @@ class DBTSourceConfig(BaseSourceConfig):
     """
 
     type: Literal["dbt"] = Field("dbt", description="Composable dbt data source")
-    model_alias: str = Field(..., description="dbt model alias")
+    model_alias: str = Field(
+        ...,
+        description="dbt node name (preferred) or legacy compiled alias",
+    )
     model_unique_id: Optional[str] = Field(
         None, description="Optional dbt unique_id selector for alias disambiguation"
     )

--- a/tests/test_compatibility_matrix.py
+++ b/tests/test_compatibility_matrix.py
@@ -22,6 +22,7 @@ from slideflow.data.connectors import (
     JSONSourceConfig,
     RedshiftSourceConfig,
 )
+from slideflow.presentations.builder import PresentationBuilder
 from slideflow.presentations.charts import (
     ChartUnion,
     CustomChart,
@@ -34,6 +35,7 @@ from slideflow.replacements import (
     TableReplacement,
     TextReplacement,
 )
+from slideflow.workbooks.config import WorkbookTabSpec
 
 
 def test_public_identity_contracts_remain_stable():
@@ -121,6 +123,45 @@ def test_data_connector_matrix_remains_supported(payload, expected_type):
     parsed = adapter.validate_python(payload)
 
     assert isinstance(parsed, expected_type)
+
+
+def test_dbt_identity_selectors_survive_slide_and_workbook_config_building():
+    dbt_source = {
+        "type": "dbt",
+        "name": "source_dbt_composable",
+        "model_alias": "monthly_revenue",
+        "model_unique_id": "model.analytics.monthly_revenue",
+        "model_package_name": "analytics",
+        "model_selector_name": "monthly_revenue",
+        "dbt": {
+            "package_url": "https://github.com/example/dbt-project.git",
+            "project_dir": "/tmp/dbt_project",
+            "target": "dev",
+        },
+        "warehouse": {"type": "databricks"},
+    }
+
+    table = TypeAdapter(ReplacementUnion).validate_python(
+        {"type": "table", "prefix": "TABLE_", "data_source": dbt_source}
+    )
+    chart_source = PresentationBuilder._build_data_source(dbt_source)
+    chart = TypeAdapter(ChartUnion).validate_python(
+        {
+            "type": "plotly_go",
+            "traces": [{"type": "bar", "x": [1], "y": [2]}],
+            "data_source": chart_source,
+        }
+    )
+    workbook_tab = WorkbookTabSpec.model_validate(
+        {"name": "Metrics", "data_source": dbt_source}
+    )
+
+    for parsed in (table.data_source, chart.data_source, workbook_tab.data_source):
+        assert isinstance(parsed, DBTSourceConfig)
+        assert parsed.model_alias == "monthly_revenue"
+        assert parsed.model_unique_id == "model.analytics.monthly_revenue"
+        assert parsed.model_package_name == "analytics"
+        assert parsed.model_selector_name == "monthly_revenue"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -34,6 +34,11 @@ def _reset_dbt_caches() -> None:
     dbt_module._selection_locks.clear()
 
 
+def _write_fake_dbt_project(project_dir: Path) -> None:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "dbt_project.yml").write_text("name: test_project\nversion: '1.0'\n")
+
+
 def _write_compiled_dbt_project(
     project_dir: Path,
     *,
@@ -194,6 +199,84 @@ print(connector.get_compiled_query('alias_b'))
     )
     assert "select" in result.stdout.lower()
     assert "select 2" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_target_dependent_alias_macro_resolves_stable_model_name(tmp_path):
+    try:
+        version("dbt-core")
+        version("dbt-duckdb")
+        version("gitpython")
+    except PackageNotFoundError:
+        pytest.skip("dbt and GitPython integration extras are not installed")
+
+    repo_dir = tmp_path / "source_repo"
+    models_dir = repo_dir / "models"
+    macros_dir = repo_dir / "macros"
+    models_dir.mkdir(parents=True)
+    macros_dir.mkdir()
+    (repo_dir / "dbt_project.yml").write_text(
+        "name: analytics\nversion: '1.0'\nconfig-version: 2\n"
+        "profile: analytics\nmodel-paths: ['models']\nmacro-paths: ['macros']\n",
+        encoding="utf-8",
+    )
+    (repo_dir / "profiles.yml").write_text(
+        "analytics:\n  target: dev\n  outputs:\n    dev:\n"
+        f"      type: duckdb\n      path: {tmp_path / 'warehouse.duckdb'}\n"
+        "      threads: 1\n",
+        encoding="utf-8",
+    )
+    (macros_dir / "generate_alias_name.sql").write_text(
+        "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n"
+        "  {%- set base_name = custom_alias_name | trim "
+        "if custom_alias_name is not none else node.name -%}\n"
+        "  {%- if target.name == 'dev' -%}\n"
+        "    dev_cesar_{{ base_name }}\n"
+        "  {%- else -%}\n"
+        "    {{ base_name }}\n"
+        "  {%- endif -%}\n"
+        "{%- endmacro %}\n",
+        encoding="utf-8",
+    )
+    (models_dir / "monthly_revenue.sql").write_text(
+        "select 1 as revenue\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "init", str(repo_dir)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "config", "user.name", "Slideflow Tests"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo_dir), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "commit", "-m", "fixture"],
+        check=True,
+        capture_output=True,
+    )
+
+    script = f"""
+from slideflow.data.connectors.dbt import DBTManifestConnector
+connector = DBTManifestConnector(
+    package_url={str(repo_dir)!r},
+    project_dir={str(tmp_path / 'workspace')!r},
+    target='dev',
+)
+model = connector.get_compiled_model_info('monthly_revenue')
+print(model.alias)
+print(model.sql_text)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "dev_cesar_monthly_revenue" in result.stdout
+    assert "select 1 as revenue" in result.stdout.lower()
 
 
 def test_sanitize_git_url_redacts_embedded_credentials():
@@ -839,8 +922,160 @@ def test_manifest_lookup_ambiguous_alias_requires_disambiguation(monkeypatch, tm
         vars={"country": "US"},
     )
 
-    with pytest.raises(DataSourceError, match="Ambiguous dbt model alias"):
+    with pytest.raises(DataSourceError, match="Ambiguous dbt model identifier"):
         connector.get_compiled_query("metrics_model")
+
+
+@pytest.mark.parametrize("resource_type", ["model", "analysis"])
+def test_manifest_lookup_prefers_stable_name_over_target_dependent_alias(
+    monkeypatch, tmp_path, resource_type
+):
+    _reset_dbt_caches()
+
+    def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
+        (clone_dir / "target").mkdir(parents=True, exist_ok=True)
+        (clone_dir / "target" / "metrics.sql").write_text("select 1 as answer")
+        manifest = {
+            "nodes": {
+                f"{resource_type}.analytics.metrics": {
+                    "resource_type": resource_type,
+                    "alias": "dev_cesar_metrics",
+                    "package_name": "analytics",
+                    "name": "metrics",
+                    "compiled_path": "target/metrics.sql",
+                }
+            }
+        }
+        (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    class _Runner:
+        def invoke(self, args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    connector = dbt_module.DBTManifestConnector(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(tmp_path / "workspace"),
+        target="dev",
+    )
+
+    model_info = connector.get_compiled_model_info("metrics")
+
+    assert model_info is not None
+    assert model_info.sql_text == "select 1 as answer"
+    assert model_info.unique_id == f"{resource_type}.analytics.metrics"
+    assert model_info.model_name == "metrics"
+    assert model_info.alias == "dev_cesar_metrics"
+
+
+@pytest.mark.parametrize(
+    ("selector_kwargs", "expected_sql"),
+    [
+        ({"model_unique_id": "model.pkg_b.metrics_eu"}, "select 'EU'"),
+        ({"model_selector_name": "metrics_eu"}, "select 'EU'"),
+    ],
+)
+def test_manifest_stable_selectors_do_not_depend_on_configured_alias(
+    monkeypatch, tmp_path, selector_kwargs, expected_sql
+):
+    _reset_dbt_caches()
+
+    def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
+        (clone_dir / "target").mkdir(parents=True, exist_ok=True)
+        (clone_dir / "target" / "eu.sql").write_text("select 'EU'")
+        manifest = {
+            "nodes": {
+                "model.pkg_b.metrics_eu": {
+                    "resource_type": "model",
+                    "alias": "dev_cesar_metrics",
+                    "package_name": "pkg_b",
+                    "name": "metrics_eu",
+                    "compiled_path": "target/eu.sql",
+                }
+            }
+        }
+        (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    class _Runner:
+        def invoke(self, args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    connector = dbt_module.DBTManifestConnector(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(tmp_path / "workspace"),
+        target="dev",
+    )
+
+    assert (
+        connector.get_compiled_query("prod_metrics_alias", **selector_kwargs)
+        == expected_sql
+    )
+
+
+def test_manifest_name_alias_collision_fails_closed_and_can_be_disambiguated(
+    monkeypatch, tmp_path
+):
+    _reset_dbt_caches()
+
+    def _fake_clone(_url, clone_dir, _branch):
+        _write_fake_dbt_project(clone_dir)
+        (clone_dir / "target").mkdir(parents=True, exist_ok=True)
+        (clone_dir / "target" / "stable.sql").write_text("select 'stable'")
+        (clone_dir / "target" / "legacy.sql").write_text("select 'legacy'")
+        manifest = {
+            "nodes": {
+                "model.stable.metrics": {
+                    "resource_type": "model",
+                    "alias": "dev_cesar_metrics",
+                    "package_name": "stable",
+                    "name": "metrics",
+                    "compiled_path": "target/stable.sql",
+                },
+                "model.legacy.other_model": {
+                    "resource_type": "model",
+                    "alias": "metrics",
+                    "package_name": "legacy",
+                    "name": "other_model",
+                    "compiled_path": "target/legacy.sql",
+                },
+            }
+        }
+        (clone_dir / "target" / "manifest.json").write_text(json.dumps(manifest))
+
+    class _Runner:
+        def invoke(self, args):
+            return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(dbt_module, "_clone_repo", _fake_clone)
+    monkeypatch.setattr(dbt_module, "dbtRunner", _Runner)
+    connector = dbt_module.DBTManifestConnector(
+        package_url="https://github.com/org/repo.git",
+        project_dir=str(tmp_path / "workspace"),
+        target="dev",
+    )
+
+    with pytest.raises(DataSourceError, match="matches different nodes"):
+        connector.get_compiled_query("metrics")
+
+    assert (
+        connector.get_compiled_query("metrics", model_package_name="stable")
+        == "select 'stable'"
+    )
+    assert (
+        connector.get_compiled_query(
+            "metrics", model_unique_id="model.legacy.other_model"
+        )
+        == "select 'legacy'"
+    )
+    assert (
+        connector.get_compiled_query("metrics", model_selector_name="other_model")
+        == "select 'legacy'"
+    )
 
 
 def test_manifest_lookup_supports_alias_disambiguation_selectors(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- resolve dbt models and analyses by target-invariant manifest `name` before falling back to legacy compiled `alias`
- make explicit `model_unique_id` and `model_selector_name` selectors independent of target-generated aliases
- fail closed when one identifier matches different nodes by name and alias, with actionable disambiguation guidance
- preserve the existing slide/workbook YAML schema and document the compatibility behavior in user docs and the YAML-authoring skill

## Root cause

The connector treated a compiled node alias as a stable identifier, but dbt projects may customize `generate_alias_name` by target. The same logical node could therefore compile to different aliases in development and production, causing valid slide configs to fail model lookup.

## Compatibility

No config fields were renamed, removed, or made optional. `model_alias` keeps its historical name and continues accepting exact aliases, while stable dbt node names are now preferred. If a value matches one node by stable name and another by compiled alias, SlideFlow raises an explicit ambiguity error rather than silently executing different SQL; `model_unique_id`, `model_package_name`, or `model_selector_name` resolves that edge case.

The compatibility suite verifies selector propagation through slide table sources, the chart builder path, and workbook tabs. Legacy and composable dbt source shapes remain supported.

## Validation

- 573 non-integration tests passed; 3 live tests skipped as expected
- 4 integration tests passed, including a real dbt/DuckDB project with a target-dependent `generate_alias_name` macro
- 1 e2e test passed
- repository-wide Black, Ruff, mypy, and pre-commit checks passed
- NumPy/Pandas ABI and version-consistency checks passed
- YAML-authoring skill asset validation passed

Fixes #302