### PR TITLE
security: harden dbt managed clone cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
     rebase-strategy: "auto"
     labels:
       - "dependencies"
-      - "python"
     commit-message:
       prefix: "deps"
       include: "scope"

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,90 @@
+name: Dependabot lockfile
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Dependabot pull request number to update"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update-lockfile:
+    # This job only handles same-repository Dependabot branches. It checks out
+    # PR metadata to resolve dependencies, but never executes project code.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve Dependabot branch
+        id: pull-request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          author="$(jq -r '.user.login' <<<"${pr_json}")"
+          head_repo="$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")"
+          base_ref="$(jq -r '.base.ref' <<<"${pr_json}")"
+          head_ref="$(jq -r '.head.ref' <<<"${pr_json}")"
+          if [ "${author}" != "dependabot[bot]" ] || \
+            [ "${head_repo}" != "${GITHUB_REPOSITORY}" ] || \
+            [ "${base_ref}" != "master" ]; then
+            echo "Refusing non-Dependabot or cross-repository PR #${PR_NUMBER}."
+            exit 1
+          fi
+          echo "checkout_ref=refs/pull/${PR_NUMBER}/head" >> "${GITHUB_OUTPUT}"
+          echo "head_ref=${head_ref}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout Dependabot branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.pull-request.outputs.checkout_ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Refresh lockfile
+        run: |
+          uv lock
+          uv lock --check
+
+      - name: Commit lockfile update
+        id: commit
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- uv.lock; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: refresh uv lockfile for Dependabot update"
+          echo "changed=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Push lockfile update
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          HEAD_REF: ${{ steps.pull-request.outputs.head_ref }}
+        run: git push origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -39,10 +39,12 @@ jobs:
           head_repo="$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")"
           base_ref="$(jq -r '.base.ref' <<<"${pr_json}")"
           head_ref="$(jq -r '.head.ref' <<<"${pr_json}")"
+          state="$(jq -r '.state' <<<"${pr_json}")"
           if [ "${author}" != "dependabot[bot]" ] || \
             [ "${head_repo}" != "${GITHUB_REPOSITORY}" ] || \
-            [ "${base_ref}" != "master" ]; then
-            echo "Refusing non-Dependabot or cross-repository PR #${PR_NUMBER}."
+            [ "${base_ref}" != "master" ] || \
+            [ "${state}" != "open" ]; then
+            echo "Refusing non-open Dependabot or cross-repository PR #${PR_NUMBER}."
             exit 1
           fi
           echo "checkout_ref=refs/pull/${PR_NUMBER}/head" >> "${GITHUB_OUTPUT}"
@@ -53,6 +55,7 @@ jobs:
         with:
           ref: ${{ steps.pull-request.outputs.checkout_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -87,4 +90,6 @@ jobs:
         if: steps.commit.outputs.changed == 'true'
         env:
           HEAD_REF: ${{ steps.pull-request.outputs.head_ref }}
-        run: git push origin "HEAD:${HEAD_REF}"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git -c "http.extraheader=AUTHORIZATION: bearer ${GH_TOKEN}" push origin "HEAD:${HEAD_REF}"

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -71,6 +71,8 @@
     - GitHub Actions versions (`github-actions`)
   - groups patch/minor updates to reduce PR noise
   - leaves major updates ungrouped for explicit review
+  - refreshes `uv.lock` automatically for same-repository Python update PRs
+  - supports manual dispatch to backfill an existing Dependabot PR
 - `CodeQL` (`.github/workflows/codeql.yml`)
   - runs static security analysis for Python on:
     - pull requests to `master`/`main`/`release/**`

--- a/slideflow/data/connectors/dbt.py
+++ b/slideflow/data/connectors/dbt.py
@@ -458,16 +458,22 @@ def _clone_repo(git_url: str, clone_dir: Path, branch: Optional[str]) -> None:
         git_url = git_url.replace(f"${token_name}", token)
     safe_git_url = _sanitize_git_url(git_url)
 
+    clone_exists = clone_dir.exists() or clone_dir.is_symlink()
+    managed_clone_path = clone_exists or clone_dir.parent.name == ".slideflow_dbt_clones"
+    if managed_clone_path:
+        try:
+            _validate_managed_clone_path(clone_dir)
+        except DataSourceError as error:
+            if clone_exists:
+                message = "Refusing to delete unmanaged DBT clone directory."
+            else:
+                message = "Refusing to use unsafe DBT clone directory."
+            raise DataSourceError(
+                f"{message} clone_dir={clone_dir}"
+            ) from error
+
     if clone_dir.exists():
         _drop_manifest_index(clone_dir)
-        managed_root = clone_dir.parent
-        if managed_root.name != ".slideflow_dbt_clones" or not _is_path_within(
-            clone_dir, managed_root
-        ):
-            raise DataSourceError(
-                "Refusing to delete unmanaged DBT clone directory. "
-                f"clone_dir={clone_dir}"
-            )
         shutil.rmtree(clone_dir)
     try:
         if branch:
@@ -576,38 +582,29 @@ def _cleanup_managed_clone_dir(clone_dir: Path) -> bool:
     """Remove a managed clone and sibling artifacts without following links."""
     workspace_root = clone_dir.parent.parent
     workspace_artifact_dir = workspace_root / ".slideflow_dbt_targets" / clone_dir.name
-    with _cache_lock:
-        _drop_manifest_indexes_under_locked(clone_dir)
-        _drop_manifest_indexes_under_locked(workspace_artifact_dir)
-    managed_root = clone_dir.parent
-    if managed_root.name != ".slideflow_dbt_clones" or not _is_path_within(
-        clone_dir, managed_root
-    ):
+    sibling_dirs = (
+        workspace_artifact_dir,
+        workspace_root / ".slideflow_dbt_logs" / clone_dir.name,
+    )
+    try:
+        _validate_managed_clone_path(clone_dir)
+        for sibling_dir in sibling_dirs:
+            _validate_real_directory_chain(
+                sibling_dir, workspace_root, require_exists=False
+            )
+    except DataSourceError:
         logger.warning(
-            "Refusing to delete unmanaged DBT clone directory: %s", clone_dir
+            "Refusing to delete unsafe managed DBT workspace: %s", clone_dir
         )
         return False
 
     try:
+        with _cache_lock:
+            _drop_manifest_indexes_under_locked(clone_dir)
+            _drop_manifest_indexes_under_locked(workspace_artifact_dir)
         if clone_dir.exists():
             shutil.rmtree(clone_dir)
-        sibling_dirs = (
-            workspace_artifact_dir,
-            workspace_root / ".slideflow_dbt_logs" / clone_dir.name,
-        )
         for sibling_dir in sibling_dirs:
-            managed_root = sibling_dir.parent
-            if (
-                managed_root.is_symlink()
-                or (managed_root.exists() and not managed_root.is_dir())
-                or sibling_dir.is_symlink()
-                or not _is_path_within(sibling_dir, managed_root)
-            ):
-                logger.warning(
-                    "Refusing to delete unsafe managed DBT directory: %s",
-                    sibling_dir,
-                )
-                return False
             if sibling_dir.exists():
                 shutil.rmtree(sibling_dir)
         return True
@@ -1128,7 +1125,9 @@ def _resolve_managed_clone_dir(
         )
 
     managed_root = workspace_root / ".slideflow_dbt_clones"
+    _validate_real_directory_chain(managed_root, workspace_root, require_exists=False)
     managed_root.mkdir(parents=True, exist_ok=True)
+    _validate_real_directory_chain(managed_root, workspace_root, require_exists=True)
     key = _build_clone_identity_key(
         package_url=package_url,
         branch=branch,
@@ -1216,6 +1215,15 @@ def _validate_real_directory_chain(
         )
     if require_exists and not directory.is_dir():
         raise DataSourceError(f"Reserved DBT directory does not exist: {directory}")
+
+
+def _validate_managed_clone_path(clone_dir: Path) -> None:
+    """Validate a clone path and every parent before filesystem mutation."""
+    managed_root = clone_dir.parent
+    workspace_root = managed_root.parent
+    if managed_root.name != ".slideflow_dbt_clones":
+        raise DataSourceError(f"Invalid managed DBT clone path: {clone_dir}")
+    _validate_real_directory_chain(clone_dir, workspace_root, require_exists=False)
 
 
 def _resolve_workspace_lock_path(clone_dir: Path) -> Path:

--- a/tests/test_dbt_sanitization.py
+++ b/tests/test_dbt_sanitization.py
@@ -865,6 +865,43 @@ def test_clone_cleanup_does_not_follow_symlinked_artifact_namespace(tmp_path):
     assert target_root.is_symlink()
 
 
+def test_clone_cleanup_refuses_symlinked_clone_namespace(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    sentinel = external / "sentinel.txt"
+    sentinel.write_text("preserve")
+    clone_namespace = workspace / ".slideflow_dbt_clones"
+    clone_namespace.symlink_to(external, target_is_directory=True)
+    clone_dir = clone_namespace / "clone"
+    (external / "clone").mkdir()
+
+    assert dbt_module._cleanup_managed_clone_dir(clone_dir) is False
+
+    assert sentinel.read_text() == "preserve"
+    assert (external / "clone").exists()
+    assert clone_namespace.is_symlink()
+
+
+def test_resolve_managed_clone_dir_refuses_symlinked_namespace(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    clone_namespace = workspace / ".slideflow_dbt_clones"
+    clone_namespace.symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(DataSourceError, match="must not be a symlink"):
+        dbt_module._resolve_managed_clone_dir(
+            str(workspace),
+            "https://github.com/org/repo.git",
+            "main",
+        )
+
+    assert clone_namespace.is_symlink()
+
+
 @pytest.mark.parametrize("symlink_level", ["namespace", "workspace", "variant"])
 def test_get_compiled_project_rejects_symlinked_artifact_paths(
     monkeypatch, tmp_path, symlink_level
@@ -3479,6 +3516,36 @@ def test_clone_repo_refuses_to_delete_unmanaged_existing_path(tmp_path):
             unmanaged_clone_dir,
             branch=None,
         )
+
+
+def test_clone_repo_refuses_symlinked_clone_namespace(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    sentinel = external / "sentinel.txt"
+    sentinel.write_text("preserve")
+    clone_namespace = workspace / ".slideflow_dbt_clones"
+    clone_namespace.symlink_to(external, target_is_directory=True)
+    clone_dir = clone_namespace / "new-clone"
+    called = False
+
+    def _clone(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(dbt_module.Repo, "clone_from", staticmethod(_clone))
+
+    with pytest.raises(DataSourceError, match="unsafe DBT clone directory"):
+        dbt_module._clone_repo(
+            "https://github.com/org/repo.git",
+            clone_dir,
+            branch=None,
+        )
+
+    assert not called
+    assert sentinel.read_text() == "preserve"
+    assert clone_namespace.is_symlink()
 
 
 def test_clone_repo_allows_managed_clone_directory_cleanup(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary\n- validate managed clone paths before cleanup and clone operations\n- add regression coverage for unsafe and valid clone paths\n- update Dependabot configuration and add guarded lockfile maintenance workflow\n\n## Validation\n- 627 passed, 3 skipped, 6 deselected\n- integration and e2e tests passed\n- Ruff, mypy, MkDocs strict, actionlint, and git diff --check passed\n\n## Review notes\nThe cleanup guard validates the full real directory chain and rejects unsafe targets before any recursive deletion.