### PR TITLE
docs: sweep changelog and operational guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Restricted Google Slides/Docs chart-image cleanup is strict by default through
   `strict_restricted_chart_cleanup`, making temporary public-access revoke or
   cleanup failures fail the render unless explicitly opted out.
+- Google Slides/Docs chart-image uploads now default to restricted access, with
+  explicit public opt-in; cleanup summaries expose failed counts and file IDs.
 - Google Slides/Docs API rate limiters are keyed by configured rate instead of
   first writer winning process-wide, and CLI `--rps` overrides now install a
   provider-neutral limiter on the active provider.
@@ -78,6 +80,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `provider_args.timeout` overrides.
 - CI, audit, live-validation, and release workflows now use locked build/security
   environments for build, `twine`, Bandit, and live Google test dependencies.
+- Post-release dependency maintenance refreshed runtime, optional-connector,
+  documentation, build-tool, and GitHub Actions dependencies through the
+  tracked lockfile.
 - PyPI metadata now includes license, classifiers, keywords, project URLs, and a
   tested Python range of `>=3.12,<3.14`.
 
@@ -100,6 +105,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Documentation and the Slideflow YAML authoring skill now cover PowerPoint,
   Redshift env fallbacks, BigQuery timeouts, partial-render semantics, and the
   current reusable workflow defaults.
+- Dependabot lockfile refreshes now validate same-repository PR metadata and
+  push with an explicit authenticated header, so successful lockfile updates
+  are not lost to token-auth failures.
+
+### Security
+
+- Updated `cryptography` to `50.0.0` and GitPython to `3.1.61`, raised the
+  `dbt` extra's GitPython minimum to `3.1.59`, and resolved the stale `sqlparse`
+  advisories with `sqlparse 0.6.0`.
+- The audit policy currently contains one time-bounded exception for
+  transitive `google-cloud-aiplatform` `CVE-2026-2473`. No patched release is
+  currently compatible with the required `google-genai` 2.x line and supported
+  `dbt-bigquery` releases; the exception expires on `2026-12-31` and must be
+  re-evaluated before then.
 
 ## [0.0.7] - 2026-05-25
 
@@ -130,8 +149,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - `provider.config.transfer_ownership_to`
   - `provider.config.transfer_ownership_strict`
 - Chart image sharing-mode controls for Google Slides/Docs:
-  - `provider.config.chart_image_sharing_mode` (`restricted` by default, explicit `public` opt-in)
-  - cleanup failure counts and file IDs in build results/output JSON
+  - `provider.config.chart_image_sharing_mode` (`public` | `restricted`)
 - Shared Google API utility layer for provider internals:
   - shared credential construction
   - shared rate-limited request execution helper
@@ -239,10 +257,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Security
 
 - Resolved open dependency security advisories by refreshing locked versions for:
-  - `cryptography` to `50.0.0`
+  - `cryptography`
   - `dbt-common`
-  - `GitPython` to `3.1.61` and raised the `dbt` extra's minimum accordingly
-  - `sqlparse` advisories resolved by `sqlparse 0.6.0` (waiver entries removed from the dependency-audit exception policy(; the audit exception policy is now empty.
+  - `GitPython`
   - `idna`
   - `pyasn1`
   - `pymdown-extensions`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing to SlideFlow.
 
 ## Development setup
 
-1. Use Python 3.12+.
+1. Use Python 3.12 or 3.13 (`>=3.12,<3.14`, matching the package metadata).
 2. Create and activate a virtual environment.
 3. Install project dependencies from the tracked lockfile.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/release/python-3120/)
+[![Python 3.12–3.13](https://img.shields.io/badge/python-3.12--3.13-blue.svg)](https://www.python.org/downloads/release/python-3120/)
 [![Docs](https://img.shields.io/badge/docs-mkdocs%20material-blue.svg?logo=materialformkdocs&logoColor=white)](https://joe-broadhead.github.io/slideflow/)
 [![Release](https://img.shields.io/github/v/release/joe-broadhead/slideflow?label=release&logo=github)](https://github.com/joe-broadhead/slideflow/releases/latest)
 [![CI](https://img.shields.io/github/actions/workflow/status/joe-broadhead/slideflow/ci.yml?branch=master&label=CI)](https://github.com/joe-broadhead/slideflow/actions/workflows/ci.yml)
@@ -102,6 +102,9 @@ Connector extras (install only what you need):
 ```bash
 # Databricks SQL sources
 pip install "slideflow-presentations[databricks]"
+
+# AI text providers
+pip install "slideflow-presentations[ai]"
 
 # dbt sources (includes dbt-core adapter stack + Git clone support)
 pip install "slideflow-presentations[dbt]"

--- a/docs/ci-quality.md
+++ b/docs/ci-quality.md
@@ -17,8 +17,8 @@
   - builds wheel/sdist artifacts and verifies distribution identity (`slideflow-presentations`)
   - installs built wheel and runs quickstart smoke validation (`validate` + `build --dry-run`)
 - `Docs` (`.github/workflows/docs.yml`)
-  - builds docs on pull requests that touch docs, README, changelog, package
-    metadata, or docs dependencies
+  - builds docs on pull requests that touch docs, README, CONTRIBUTING, changelog,
+    package metadata, or docs dependencies
   - installs locked docs dependencies with `uv sync --extra docs --locked`
   - runs `uv run mkdocs build --strict`
   - deploys to GitHub Pages on `master`/`main`
@@ -33,7 +33,8 @@
     then creates the GitHub release
 - `Audit` (`.github/workflows/audit.yml`)
   - installs the locked project environment with `dev`, `ai`, `databricks`, `dbt`, `bigquery`, `duckdb`, `redshift`, and `powerpoint` extras
-  - runs blocking `pip-audit` from that locked environment
+  - runs the policy-aware `scripts/ci/run_dependency_audit.py` wrapper, which
+    applies only documented, expiring exceptions around `pip-audit`
   - runs blocking `bandit` medium/high severity scan from the locked dev environment
   - uploads audit reports as artifacts
 - `Live Google Slides` (`.github/workflows/live-google-slides.yml`)
@@ -72,7 +73,12 @@
   - groups patch/minor updates to reduce PR noise
   - leaves major updates ungrouped for explicit review
   - refreshes `uv.lock` automatically for same-repository Python update PRs
-  - supports manual dispatch to backfill an existing Dependabot PR
+  - supports manual dispatch to backfill an existing Dependabot PR; provide
+    the open PR number explicitly:
+
+    ```bash
+    gh workflow run dependabot-lockfile.yml -f pr_number=<number>
+    ```
 - `CodeQL` (`.github/workflows/codeql.yml`)
   - runs static security analysis for Python on:
     - pull requests to `master`/`main`/`release/**`
@@ -90,7 +96,7 @@ source .venv/bin/activate
 uv lock --check
 uv pip check
 uv run python scripts/ci/check_secret_hygiene.py
-uv run pip-audit
+uv run python scripts/ci/run_dependency_audit.py --progress-spinner off
 actionlint
 uv run python scripts/ci/check_numpy_binary_compatibility.py
 uvx --from black==26.3.1 black --check slideflow tests scripts

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -10,7 +10,7 @@ This guide covers production execution patterns for SlideFlow in:
 
 For all orchestrated environments, ensure:
 
-- Python 3.12+
+- Python 3.12 or 3.13 (supported range: `>=3.12,<3.14`)
 - SlideFlow package installed (plus connector/provider extras used by your config)
 - Access to required data systems (Drive/Slides/Docs/Databricks/Git)
 - Correct environment variables and secrets

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Python `3.12+`
+- Python `3.12` or `3.13` (supported range: `>=3.12,<3.14`)
 - Google Cloud project with:
   - Google Slides API enabled
   - Google Docs API enabled (if using `google_docs` provider)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -86,6 +86,10 @@ PyPI package identity:
 2. Update docs + changelog in the same release prep PR:
    - update user-facing docs for new behavior/flags/workflows
    - update `CHANGELOG.md` with release notes and known issues
+   - compare the latest release tag with `HEAD` so every user-visible change is
+     covered, and keep post-release changes under `[Unreleased]`
+   - review `.github/dependency-audit-exceptions.json`; every active exception
+     must have a current expiry, rationale, and a documented follow-up
 
 3. Ensure docs build cleanly:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -44,7 +44,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - id: auth
         uses: google-github-actions/auth@v2
@@ -223,6 +223,13 @@ Audit enforcement policy:
 - Static Bandit medium/high severity findings are blocking. Low-signal findings
   should be converted into explicit suppressions or code changes before merge.
 
+The exception policy is intentionally time-bounded and reviewed with each
+release. It currently contains one transitive `google-cloud-aiplatform`
+exception for `CVE-2026-2473`, expiring `2026-12-31`, because the available
+patched releases are incompatible with the required `google-genai` 2.x line
+and supported `dbt-bigquery` releases. This is not a clean audit result; it is
+an explicit compatibility exception that must be re-evaluated before expiry.
+
 Default-branch dependency alert closure:
 
 - Treat the locked all-extras `pip-audit` result as the branch-side proof that a
@@ -240,7 +247,7 @@ Default-branch dependency alert closure:
 Useful checks:
 
 ```bash
-uv run pip-audit --progress-spinner off
+uv run python scripts/ci/run_dependency_audit.py --progress-spinner off
 gh api '/repos/OWNER/REPO/dependabot/alerts?state=open' --paginate
 gh pr list --author app/dependabot --state open
 ```


### PR DESCRIPTION
## Summary\n\n- Reconcile the post-v0.0.7 Unreleased notes with current dependency and security state.\n- Document the active, expiring google-cloud-aiplatform audit exception and policy-aware audit command.\n- Document manual Dependabot lockfile backfill and align Python/action-version guidance.\n- Add the AI installation extra to the README and tighten release-prep sweep guidance.\n\n## Validation\n\n- git diff --check\n- python scripts/ci/check_secret_hygiene.py\n- strict MkDocs build will run in CI\n\n## Notes\n\n- The current open high-severity Dependabot alert is CVE-2026-2473 for transitive google-cloud-aiplatform; the repository exception expires 2026-12-31 and is documented in this sweep.